### PR TITLE
Fixing Secondary Birthday & BC Lock

### DIFF
--- a/strr-web/components/bcros/form-section/property/Address.vue
+++ b/strr-web/components/bcros/form-section/property/Address.vue
@@ -51,7 +51,11 @@
         <UFormGroup name="city" class="pr-[16px] flex-grow mobile:mb-[16px]">
           <UInput v-model="city" aria-label="city" :placeholder="t('create-account.contact-form.city')" />
         </UFormGroup>
-        <UFormGroup name="province" class="pr-[16px] flex-grow mobile:mb-[16px]">
+        <UFormGroup
+          name="province"
+          class="pr-[16px] flex-grow mobile:mb-[16px]"
+          :error="addressNotInBC ? 'Address must be in BC' :''"
+        >
           <UInput
             v-model="province"
             aria-label="province"
@@ -95,11 +99,13 @@ const addressComplete = () => {
 const {
   id,
   defaultCountryIso2,
-  enableAddressComplete
+  enableAddressComplete,
+  addressNotInBC
 } = defineProps<{
   id: string,
   defaultCountryIso2: string,
-  enableAddressComplete:(id: string, countryIso2: string, countrySelect: boolean) => void
+  enableAddressComplete:(id: string, countryIso2: string, countrySelect: boolean) => void,
+  addressNotInBC?: boolean
 }>()
 
 country.value = defaultCountryIso2

--- a/strr-web/components/bcros/form-section/property/Form.vue
+++ b/strr-web/components/bcros/form-section/property/Form.vue
@@ -18,6 +18,7 @@
           v-model:postal-code="formState.propertyDetails.postalCode"
           :enable-address-complete="enableAddressComplete"
           default-country-iso2="CA"
+          :address-not-in-b-c="addressNotInBC"
         />
         <BcrosFormSectionPropertyDetails
           v-model:property-type="formState.propertyDetails.propertyType"
@@ -49,6 +50,8 @@ const { isComplete } = defineProps<{
   isComplete: boolean
 }>()
 
+const addressNotInBC = ref(false)
+
 const {
   address: canadaPostAddress,
   enableAddressComplete
@@ -57,6 +60,7 @@ const {
 watch(canadaPostAddress, (newAddress) => {
   if (newAddress) {
     if (newAddress.region === 'BC') {
+      addressNotInBC.value = false
       formState.propertyDetails.address = newAddress.street
       formState.propertyDetails.addressLineTwo = newAddress.streetAdditional
       formState.propertyDetails.country = newAddress.country
@@ -64,8 +68,7 @@ watch(canadaPostAddress, (newAddress) => {
       formState.propertyDetails.province = newAddress.region
       formState.propertyDetails.postalCode = newAddress.postalCode
     } else {
-      // replace with validation error?
-      alert('Please choose an address in BC')
+      addressNotInBC.value = true
     }
   }
 })

--- a/strr-web/stores/strr.ts
+++ b/strr-web/stores/strr.ts
@@ -151,7 +151,8 @@ export const propertyDetailsSchema = z.object({
   parcelIdentifier: optionalOrEmptyString,
   postalCode: requiredNonEmptyString,
   propertyType: requiredNonEmptyString,
-  province: requiredNonEmptyString,
+  province: requiredNonEmptyString
+    .refine(province => province === 'BC', { message: 'Province must be set to BC' }),
   useMailing: z.boolean()
 })
 

--- a/strr-web/stores/strr.ts
+++ b/strr-web/stores/strr.ts
@@ -49,6 +49,7 @@ const httpRegex = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+\.?(:\d+)?(\/.*)?)$/i
 const phoneError = { message: 'Valid characters are "()- 123457890" ' }
 const requiredPhone = z.string().regex(phoneRegex, phoneError)
 const requiredNumber = z.string().regex(numbersRegex, { message: 'Must be a number' })
+const optionalNumber = z.string().regex(numbersRegex, { message: 'Must be a number' }).optional()
 const optionalOrEmptyString = z.string().optional().transform(e => e === '' ? undefined : e)
 const requiredNonEmptyString = z.string().refine(e => e !== '', 'Field cannot be empty')
 
@@ -87,7 +88,16 @@ export const secondaryContactSchema = z.object({
   addressLineTwo: optionalOrEmptyString,
   city: requiredNonEmptyString,
   province: requiredNonEmptyString,
-  postalCode: requiredNonEmptyString
+  postalCode: requiredNonEmptyString,
+  birthDay: optionalNumber
+    .refine(day => day?.length === 2, 'Day must be two digits')
+    .refine(day => Number(day) <= 31, 'Must be less than or equal to 31')
+    .optional(),
+  birthMonth: optionalOrEmptyString,
+  birthYear: optionalNumber
+    .refine(year => Number(year) <= new Date().getFullYear(), 'Year must be in the past')
+    .refine(year => year?.length === 4, 'Year must be four digits')
+    .optional()
 })
 
 const primaryContact: ContactInformationI = {


### PR DESCRIPTION
*Issue:* [20659](https://app.zenhub.com/workspaces/strr-65b2a7146835aa0cdf315b79/issues/gh/bcgov/entity/20659) 

*Description of changes:*

Fixes ability to add day past 31 for secondary birthday
Shows validation error when region outside of BC chosen for rental property address


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
