### PR TITLE
Bugfix: Adding redirect on account creation with no documents

### DIFF
--- a/strr-web/components/bcros/form-section/contact-information/Form.vue
+++ b/strr-web/components/bcros/form-section/contact-information/Form.vue
@@ -126,15 +126,13 @@ const {
   addSecondaryContact,
   toggleAddSecondary,
   isComplete,
-  secondFormIsComplete,
-  id
+  secondFormIsComplete
 } = defineProps<{
   fullName: string,
   addSecondaryContact: boolean,
   toggleAddSecondary:() => void,
   isComplete: boolean,
   secondFormIsComplete: boolean
-  id?: string
 }>()
 
 const {
@@ -190,17 +188,6 @@ if (currentAccount && me) {
 
 onMounted(() => {
   if (isComplete) { validateMonths() }
-
-  if (me?.profile.contacts && me?.profile.contacts.length > 0 && !id) {
-    formState.primaryContact.phoneNumber = me?.profile.contacts[0].phone
-    formState.primaryContact.emailAddress = me?.profile.contacts[0].email
-    formState.primaryContact.extension = me?.profile.contacts[0].phoneExtension
-  } else {
-    const profile = me?.orgs.find((pro: any) => pro.id.toString() === id)
-    formState.primaryContact.phoneNumber = profile?.mailingAddress[0].phone
-    formState.primaryContact.emailAddress = profile?.mailingAddress[0].email
-    formState.primaryContact.extension = profile?.mailingAddress[0].phoneExtension
-  }
 })
 
 const form = ref()

--- a/strr-web/components/bcros/form-section/contact-information/Form.vue
+++ b/strr-web/components/bcros/form-section/contact-information/Form.vue
@@ -171,23 +171,33 @@ const validateMonths = () => {
 
 const { me, currentAccount } = useBcrosAccount()
 
-if (currentAccount && me) {
-  const mailingAddress = me?.orgs.find(({ id }) => id === currentAccount.id)?.mailingAddress
-  if (mailingAddress) {
-    // Check if field already has content before populating so as not to overwrite user changes
-    if (!formState.primaryContact.country) { formState.primaryContact.country = mailingAddress[0].country }
-    if (!formState.primaryContact.city) { formState.primaryContact.city = mailingAddress[0].city }
-    if (!formState.primaryContact.postalCode) { formState.primaryContact.postalCode = mailingAddress[0].postalCode }
-    if (!formState.primaryContact.province) { formState.primaryContact.province = mailingAddress[0].region }
-    if (!formState.primaryContact.address) { formState.primaryContact.address = mailingAddress[0].street }
-    if (!formState.primaryContact.addressLineTwo) {
-      formState.primaryContact.addressLineTwo = mailingAddress[0].streetAdditional
-    }
-  }
-}
-
 onMounted(() => {
   if (isComplete) { validateMonths() }
+  if (currentAccount && me) {
+    const currentAccountInfo = me?.orgs.find(({ id }) => id === currentAccount.id)?.mailingAddress
+    if (currentAccountInfo) {
+      if (!formState.primaryContact.emailAddress) {
+        formState.primaryContact.emailAddress = currentAccountInfo[0].email
+      }
+      if (!formState.primaryContact.phoneNumber) {
+        formState.primaryContact.phoneNumber = currentAccountInfo[0].phone
+      }
+      if (!formState.primaryContact.extension) {
+        formState.primaryContact.extension = currentAccountInfo[0].phoneExtension
+      }
+      // Check if field already has content before populating so as not to overwrite user changes
+      if (!formState.primaryContact.country) { formState.primaryContact.country = currentAccountInfo[0].country }
+      if (!formState.primaryContact.city) { formState.primaryContact.city = currentAccountInfo[0].city }
+      if (!formState.primaryContact.postalCode) {
+        formState.primaryContact.postalCode = currentAccountInfo[0].postalCode
+      }
+      if (!formState.primaryContact.province) { formState.primaryContact.province = currentAccountInfo[0].region }
+      if (!formState.primaryContact.address) { formState.primaryContact.address = currentAccountInfo[0].street }
+      if (!formState.primaryContact.addressLineTwo) {
+        formState.primaryContact.addressLineTwo = currentAccountInfo[0].streetAdditional
+      }
+    }
+  }
 })
 
 const form = ref()

--- a/strr-web/composables/useRegistrations.ts
+++ b/strr-web/composables/useRegistrations.ts
@@ -17,6 +17,10 @@ export const useRegistrations = () => {
       return res.data
         .sort(
           (registrationA, registrationB) =>
+            getStatusPriority(registrationA.status) - getStatusPriority(registrationB.status)
+        )
+        .sort(
+          (registrationA, registrationB) =>
             registrationA.unitAddress.city.localeCompare(registrationB.unitAddress.city)
         )
     })
@@ -46,6 +50,19 @@ export const useRegistrations = () => {
   const getRegistrationHistory = (id: string): Promise<RegistrationHistoryEventI[]> =>
     axiosInstance.get(`${apiURL}/registrations/${id}/history`)
       .then(res => res.data)
+
+  const getStatusPriority = (status: string) => {
+    switch (status) {
+      case 'DENIED':
+        return 4
+      case 'APPROVED':
+        return 3
+      case 'PENDING':
+        return 2
+      default:
+        return 1
+    }
+  }
 
   const createSbcRegistration = (registration:
     {

--- a/strr-web/composables/useRegistrations.ts
+++ b/strr-web/composables/useRegistrations.ts
@@ -19,10 +19,6 @@ export const useRegistrations = () => {
           (registrationA, registrationB) =>
             registrationA.unitAddress.city.localeCompare(registrationB.unitAddress.city)
         )
-        .sort(
-          (registrationA, registrationB) =>
-            getStatusPriority(registrationA.status) - getStatusPriority(registrationB.status)
-        )
     })
 
   const getPaginatedRegistrations = (paginationObject: PaginationI): Promise<PaginatedRegistrationsI | void> => {
@@ -50,19 +46,6 @@ export const useRegistrations = () => {
   const getRegistrationHistory = (id: string): Promise<RegistrationHistoryEventI[]> =>
     axiosInstance.get(`${apiURL}/registrations/${id}/history`)
       .then(res => res.data)
-
-  const getStatusPriority = (status: string) => {
-    switch (status) {
-      case 'DENIED':
-        return 4
-      case 'APPROVED':
-        return 3
-      case 'PENDING':
-        return 2
-      default:
-        return 1
-    }
-  }
 
   const createSbcRegistration = (registration:
     {

--- a/strr-web/stores/account.ts
+++ b/strr-web/stores/account.ts
@@ -81,7 +81,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       .then(() => {
         setAccountInfo()
           .then(() => {
-            navigateTo('/account-select')
+            navigateTo('/create-account')
           })
       })
   }

--- a/strr-web/stores/account.ts
+++ b/strr-web/stores/account.ts
@@ -36,7 +36,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   const strrApiURL = useRuntimeConfig().public.strrApiURL
 
   /** Get user information from AUTH */
-  async function getAuthUserProfile(identifier: string) {
+  async function getAuthUserProfile (identifier: string) {
     return await axiosInstance.get<KCUserI | void>(`${apiURL}/users/${identifier}`)
       .then((response) => {
         const data = response?.data
@@ -54,7 +54,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Update user information in AUTH with current token info */
-  async function updateAuthUserInfo() {
+  async function updateAuthUserInfo () {
     return await axiosInstance.post<KCUserI | void>(`${apiURL}/users`, { isLogin: true })
       .then(response => response.data)
       .catch((error) => {
@@ -63,7 +63,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       })
   }
 
-  async function updateTosAcceptance(): Promise<TermsOfServiceI | void> {
+  async function updateTosAcceptance (): Promise<TermsOfServiceI | void> {
     return await axiosInstance.get<TermsOfServiceI>(`${apiURL}/documents/termsofuse`)
       .then((response) => {
         tos.value = response.data
@@ -71,7 +71,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       })
   }
 
-  async function acceptTos(acceptance: boolean, versionId?: string): Promise<TermsOfServiceI | void> {
+  async function acceptTos (acceptance: boolean, versionId?: string): Promise<TermsOfServiceI | void> {
     return await axiosInstance.patch<TermsOfServiceI>(`${strrApiURL}/account`,
       {
         acceptTermsAndConditions: acceptance,
@@ -87,7 +87,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Set user name information */
-  async function setUserName() {
+  async function setUserName () {
     if (user.value?.loginSource === LoginSourceE.BCEID) {
       // get from auth
       const authUserInfo = await getAuthUserProfile('@me')
@@ -103,7 +103,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
 
   /** Get me object for this user from STRR api */
   // TODO: TC - move this to an STRR store
-  async function getMe() {
+  async function getMe () {
     const apiURL = useRuntimeConfig().public.strrApiURL
     return await axiosInstance.get(`${apiURL}/account/me`)
       .then((response) => {
@@ -123,7 +123,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Get the user's account list */
-  async function getUserAccounts(keycloakGuid: string) {
+  async function getUserAccounts (keycloakGuid: string) {
     const apiURL = useRuntimeConfig().public.authApiURL
     return await axiosInstance.get<UserSettingsI[]>(`${apiURL}/users/${keycloakGuid}/settings`)
       .then((response) => {
@@ -142,7 +142,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Set the user account list and current account */
-  async function setAccountInfo(currentAccountId?: string) {
+  async function setAccountInfo (currentAccountId?: string) {
     if (!currentAccountId) {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
@@ -168,7 +168,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Switch the current account to the given account ID if it exists in the user's account list */
-  function switchCurrentAccount(accountId: string) {
+  function switchCurrentAccount (accountId: string) {
     for (const i in userAccounts.value) {
       if (userAccounts.value[i].id === accountId) {
         currentAccount.value = userAccounts.value[i]

--- a/strr-web/stores/account.ts
+++ b/strr-web/stores/account.ts
@@ -36,7 +36,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   const strrApiURL = useRuntimeConfig().public.strrApiURL
 
   /** Get user information from AUTH */
-  async function getAuthUserProfile (identifier: string) {
+  async function getAuthUserProfile(identifier: string) {
     return await axiosInstance.get<KCUserI | void>(`${apiURL}/users/${identifier}`)
       .then((response) => {
         const data = response?.data
@@ -54,7 +54,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Update user information in AUTH with current token info */
-  async function updateAuthUserInfo () {
+  async function updateAuthUserInfo() {
     return await axiosInstance.post<KCUserI | void>(`${apiURL}/users`, { isLogin: true })
       .then(response => response.data)
       .catch((error) => {
@@ -63,7 +63,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       })
   }
 
-  async function updateTosAcceptance (): Promise<TermsOfServiceI | void> {
+  async function updateTosAcceptance(): Promise<TermsOfServiceI | void> {
     return await axiosInstance.get<TermsOfServiceI>(`${apiURL}/documents/termsofuse`)
       .then((response) => {
         tos.value = response.data
@@ -71,22 +71,23 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
       })
   }
 
-  async function acceptTos (acceptance: boolean, versionId?: string): Promise<TermsOfServiceI | void> {
+  async function acceptTos(acceptance: boolean, versionId?: string): Promise<TermsOfServiceI | void> {
     return await axiosInstance.patch<TermsOfServiceI>(`${strrApiURL}/account`,
       {
         acceptTermsAndConditions: acceptance,
         termsVersion: versionId
       }
     )
-      .then((response) => {
-        tos.value = response.data
-        navigateTo('/account-select')
-        return response.data
+      .then(() => {
+        setAccountInfo()
+          .then(() => {
+            navigateTo('/account-select')
+          })
       })
   }
 
   /** Set user name information */
-  async function setUserName () {
+  async function setUserName() {
     if (user.value?.loginSource === LoginSourceE.BCEID) {
       // get from auth
       const authUserInfo = await getAuthUserProfile('@me')
@@ -102,7 +103,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
 
   /** Get me object for this user from STRR api */
   // TODO: TC - move this to an STRR store
-  async function getMe () {
+  async function getMe() {
     const apiURL = useRuntimeConfig().public.strrApiURL
     return await axiosInstance.get(`${apiURL}/account/me`)
       .then((response) => {
@@ -122,7 +123,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Get the user's account list */
-  async function getUserAccounts (keycloakGuid: string) {
+  async function getUserAccounts(keycloakGuid: string) {
     const apiURL = useRuntimeConfig().public.authApiURL
     return await axiosInstance.get<UserSettingsI[]>(`${apiURL}/users/${keycloakGuid}/settings`)
       .then((response) => {
@@ -141,7 +142,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Set the user account list and current account */
-  async function setAccountInfo (currentAccountId?: string) {
+  async function setAccountInfo(currentAccountId?: string) {
     if (!currentAccountId) {
       // try getting id from existing session storage
       currentAccountId = JSON.parse(sessionStorage.getItem(SessionStorageKeyE.CURRENT_ACCOUNT) || '{}').id
@@ -167,7 +168,7 @@ export const useBcrosAccount = defineStore('bcros/account', () => {
   }
 
   /** Switch the current account to the given account ID if it exists in the user's account list */
-  function switchCurrentAccount (accountId: string) {
+  function switchCurrentAccount(accountId: string) {
     for (const i in userAccounts.value) {
       if (userAccounts.value[i].id === accountId) {
         currentAccount.value = userAccounts.value[i]

--- a/strr-web/stores/strr.ts
+++ b/strr-web/stores/strr.ts
@@ -49,6 +49,9 @@ export const submitCreateAccountForm = (
               handlePaymentRedirect(invoices[0].invoice_id, data.id)
             }
           })
+          .catch(() => {
+            handlePaymentRedirect(invoices[0].invoice_id, data.id)
+          })
       })
       return data
     })

--- a/strr-web/stores/strr.ts
+++ b/strr-web/stores/strr.ts
@@ -39,7 +39,7 @@ export const submitCreateAccountForm = (
     })
     .then((data) => {
       const { invoices } = data
-      if (!formState.supportingDocuments) {
+      if (formState.supportingDocuments.length === 0) {
         handlePaymentRedirect(invoices[0].invoice_id, data.id)
       }
       formState.supportingDocuments.forEach((file: File, fileIndex: number) => {

--- a/strr-web/stores/strr.ts
+++ b/strr-web/stores/strr.ts
@@ -38,10 +38,13 @@ export const submitCreateAccountForm = (
       return data
     })
     .then((data) => {
+      const { invoices } = data
+      if (!formState.supportingDocuments) {
+        handlePaymentRedirect(invoices[0].invoice_id, data.id)
+      }
       formState.supportingDocuments.forEach((file: File, fileIndex: number) => {
         fileAxiosInstance.post<File>(`${apiURL}/registrations/${data.id}/documents`, { file })
           .then(() => {
-            const { invoices } = data
             if (fileIndex === formState.supportingDocuments.length - 1) {
               handlePaymentRedirect(invoices[0].invoice_id, data.id)
             }


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*

Adding redirect logic to allow redirect to pay after account creation when:
 - no files uploaded
 - file upload fails
 - all files uploaded

Fixing ToS acceptance loop issue

Fixing logic for prepopulating information after account select



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
