### PR TITLE
Remove Renewal button in Status Cards

### DIFF
--- a/strr-web/components/bcros/status-card/StatusCard.vue
+++ b/strr-web/components/bcros/status-card/StatusCard.vue
@@ -38,9 +38,6 @@
       >
         {{ tRegistrationStatus('download') }}
       </p>
-      <p class="cursor-pointer">
-        {{ tRegistrationStatus('renewal') }}
-      </p>
     </div>
   </div>
 </template>

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
*Issue:*
- https://github.com/bcgov/entity/issues/22485

*Description of changes:*
- Remove `Renewal` button in Status Cards as the button functionality will be implemented later

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
