### PR TITLE
Backend: Auto Approval - Use Application

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.0.1"
+version = "0.0.2"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -94,6 +94,7 @@ class Application(BaseModel):
         backref=backref("reviewer", uselist=False),
         foreign_keys=[reviewer_id],
     )
+    # Currently this relects a one-to-one, although the RFC depicted a many-to-one relationship
     registration = db.relationship(
         "Registration",
         backref=backref("registration", uselist=False),
@@ -123,6 +124,11 @@ class Application(BaseModel):
 
         paginated_result = query.paginate(per_page=filter_criteria.limit, page=filter_criteria.page)
         return paginated_result
+
+    @classmethod
+    def get_by_registration_id(cls, registration_id: int) -> Application | None:
+        """Return the application associated with a given registration_id."""
+        return cls.query.filter_by(registration_id=registration_id).one_or_none()
 
 
 class ApplicationSerializer:

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -54,7 +54,7 @@ from strr_api.exceptions import (
     error_response,
     exception_response,
 )
-from strr_api.models import User, Application
+from strr_api.models import Application, User
 from strr_api.requests import RegistrationRequest
 from strr_api.responses import AutoApprovalRecord, Document, EventRecord, Invoice, LTSARecord, Pagination, Registration
 from strr_api.schemas.utils import validate

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -54,7 +54,7 @@ from strr_api.exceptions import (
     error_response,
     exception_response,
 )
-from strr_api.models import User
+from strr_api.models import User, Application
 from strr_api.requests import RegistrationRequest
 from strr_api.responses import AutoApprovalRecord, Document, EventRecord, Invoice, LTSARecord, Pagination, Registration
 from strr_api.schemas.utils import validate
@@ -577,8 +577,11 @@ def mark_registration_invoice_paid(registration_id, invoice_id):
 
         invoice = strr_pay.update_invoice_payment_status(jwt, registration, invoice)
         if invoice.payment_status_code == PaymentStatus.COMPLETED:
-            approval = ApprovalService.process_auto_approval(token, registration)
-            ApprovalService.save_approval_record(registration.id, approval)
+            # Redundant code, this is a breaking change as currently data
+            # is not being inserted into application table
+            application = Application.get_by_registration_id(registration.id)
+            approval = ApprovalService.process_auto_approval(token, application)
+            ApprovalService.save_approval_record_by_registration(registration.id, approval)
 
         return jsonify(Invoice.from_db(invoice).model_dump(mode="json")), HTTPStatus.OK
     except ValidationException as auth_exception:

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -576,12 +576,6 @@ def mark_registration_invoice_paid(registration_id, invoice_id):
             return error_response(HTTPStatus.NOT_FOUND, "Invoice not found")
 
         invoice = strr_pay.update_invoice_payment_status(jwt, registration, invoice)
-        if invoice.payment_status_code == PaymentStatus.COMPLETED:
-            # Redundant code, this is a breaking change as currently data
-            # is not being inserted into application table
-            application = Application.get_by_registration_id(registration.id)
-            approval = ApprovalService.process_auto_approval(token, application)
-            ApprovalService.save_approval_record_by_registration(registration.id, approval)
 
         return jsonify(Invoice.from_db(invoice).model_dump(mode="json")), HTTPStatus.OK
     except ValidationException as auth_exception:

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -566,7 +566,6 @@ def mark_registration_invoice_paid(registration_id, invoice_id):
     """
 
     try:
-        token = jwt.get_token_auth_header()
         registration = RegistrationService.get_registration(g.jwt_oidc_token_info, registration_id)
         if not registration:
             raise AuthException()

--- a/strr-api/src/strr_api/responses/AutoApprovalRecordResponse.py
+++ b/strr-api/src/strr_api/responses/AutoApprovalRecordResponse.py
@@ -2,7 +2,7 @@
 AutoApprovalRecord response object.
 """
 from datetime import datetime
-
+from typing import Optional
 from pydantic import BaseModel
 
 from strr_api import models
@@ -13,7 +13,8 @@ class AutoApprovalRecord(BaseModel):
     """AutoApprovalRecord response object."""
 
     id: int
-    registration_id: int
+    application_id: Optional[int]
+    registration_id: Optional[int]
     record: AutoApproval
     creation_date: datetime
 
@@ -22,6 +23,7 @@ class AutoApprovalRecord(BaseModel):
         """Return an AutoApprovalRecord object from a database model."""
         return cls(
             id=source.id,
+            application_id=source.application_id,
             registration_id=source.registration_id,
             record=AutoApproval(**source.record),
             creation_date=source.creation_date,

--- a/strr-api/src/strr_api/responses/AutoApprovalRecordResponse.py
+++ b/strr-api/src/strr_api/responses/AutoApprovalRecordResponse.py
@@ -3,6 +3,7 @@ AutoApprovalRecord response object.
 """
 from datetime import datetime
 from typing import Optional
+
 from pydantic import BaseModel
 
 from strr_api import models

--- a/strr-api/tests/unit/common/test_run_version.py
+++ b/strr-api/tests/unit/common/test_run_version.py
@@ -4,7 +4,7 @@ from unittest import mock
 from strr_api.common.run_version import _get_commit_hash, get_run_version
 
 ref = "de9d3e669f9ef35a7031d9cea7013984b8a87000"
-version = "0.0.1"
+version = "0.0.2"
 
 
 def test_get_commit_hash():

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -314,6 +314,7 @@ def test_get_registration_ltsa_403(client):
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration_pending)
 @patch("strr_api.models.Application.get_by_registration_id", new=fake_application)
+@patch("strr_api.models.Application.save", new=no_op)
 @patch("strr_api.models.rental.Registration.save", new=no_op)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_examiner_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
@@ -338,6 +339,7 @@ def test_post_registration_approve_403(client):
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
 @patch("strr_api.models.Application.get_by_registration_id", new=fake_application)
+@patch("strr_api.models.Application.save", new=no_op)
 @patch("strr_api.models.rental.Registration.save", new=no_op)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_examiner_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from flask import g
 
 from tests.unit.utils.mocks import (
+    fake_application,
     fake_document,
     fake_examiner_from_token,
     fake_get_token_auth_header,
@@ -312,6 +313,7 @@ def test_get_registration_ltsa_403(client):
 
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration_pending)
+@patch("strr_api.models.Application.get_by_registration_id", new=fake_application)
 @patch("strr_api.models.rental.Registration.save", new=no_op)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_examiner_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
@@ -335,6 +337,7 @@ def test_post_registration_approve_403(client):
 
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
+@patch("strr_api.models.Application.get_by_registration_id", new=fake_application)
 @patch("strr_api.models.rental.Registration.save", new=no_op)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_examiner_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -313,13 +313,14 @@ def test_get_registration_ltsa_403(client):
 
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration_pending)
-@patch("strr_api.models.Application.get_by_registration_id", new=fake_application)
+@patch("strr_api.models.Application.get_by_registration_id")
 @patch("strr_api.models.Application.save", new=no_op)
 @patch("strr_api.models.rental.Registration.save", new=no_op)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_examiner_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_post_registration_approve_200(client):
+def test_post_registration_approve_200(mock_get_by_registration_id, client):
+    mock_get_by_registration_id.return_value = fake_application()
     rv = client.post("/registrations/1/approve")
     assert rv.status_code == HTTPStatus.OK
 
@@ -338,13 +339,14 @@ def test_post_registration_approve_403(client):
 
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
-@patch("strr_api.models.Application.get_by_registration_id", new=fake_application)
+@patch("strr_api.models.Application.get_by_registration_id")
 @patch("strr_api.models.Application.save", new=no_op)
 @patch("strr_api.models.rental.Registration.save", new=no_op)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_examiner_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_post_registration_deny_200(client):
+def test_post_registration_deny_200(mock_get_by_registration_id, client):
+    mock_get_by_registration_id.return_value = fake_application()
     rv = client.post("/registrations/1/deny")
     assert rv.status_code == HTTPStatus.OK
 

--- a/strr-api/tests/unit/utils/mocks.py
+++ b/strr-api/tests/unit/utils/mocks.py
@@ -112,7 +112,7 @@ def fake_registration_pending(*args, **kwargs):
     )
 
 
-def fake_application(ownership_type, is_principal_residence, specified_service_provider):
+def fake_application(ownership_type="rent", is_principal_residence=True, specified_service_provider=None):
     json_data = {
         "selectedAccount": {"sbc_account_id": 3299},
         "registration": {

--- a/strr-api/tests/unit/utils/mocks.py
+++ b/strr-api/tests/unit/utils/mocks.py
@@ -16,7 +16,9 @@ from strr_api.models import (
     User,
 )
 
-from ..resources.test_registration_applications import CREATE_REGISTRATION_REQUEST
+CREATE_REGISTRATION_REQUEST = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "../../mocks/json/registration_use_sbc_account.json"
+)
 
 
 def mock_json_file(filename):
@@ -110,14 +112,78 @@ def fake_registration_pending(*args, **kwargs):
     )
 
 
-def fake_application(*args, **kwargs):
-    with open(CREATE_REGISTRATION_REQUEST) as f:
-        json_data = json.load(f)
-        return Application(
-            id=1,
-            application_json=json_data,
-            type="registration",
-        )
+def fake_application(ownership_type, is_principal_residence, specified_service_provider):
+    json_data = {
+        "selectedAccount": {"sbc_account_id": 3299},
+        "registration": {
+            "primaryContact": {
+                "name": {"firstName": "The", "middleName": "First", "lastName": "Guy"},
+                "dateOfBirth": "1986-10-23",
+                "details": {
+                    "preferredName": "Mickey",
+                    "phoneNumber": "604-999-9999",
+                    "extension": "x64",
+                    "faxNumber": "604-777-7777",
+                    "emailAddress": "test@test.test",
+                },
+                "mailingAddress": {
+                    "country": "CA",
+                    "address": "12766 227st",
+                    "addressLineTwo": "",
+                    "city": "MAPLE RIDGE",
+                    "province": "BC",
+                    "postalCode": "V2X 6K6",
+                },
+            },
+            "secondaryContact": {
+                "name": {"firstName": "The", "middleName": "Other", "lastName": "Guy"},
+                "dateOfBirth": "1986-10-23",
+                "details": {
+                    "preferredName": "Mouse",
+                    "phoneNumber": "604-888-8888",
+                    "extension": "",
+                    "faxNumber": "",
+                    "emailAddress": "test2@test.test",
+                },
+                "mailingAddress": {
+                    "country": "CA",
+                    "address": "12766 227st",
+                    "addressLineTwo": "",
+                    "city": "MAPLE RIDGE",
+                    "province": "BC",
+                    "postalCode": "V2X 6K6",
+                },
+            },
+            "unitDetails": {
+                "parcelIdentifier": "000-460-991",
+                "businessLicense": "",
+                "propertyType": "PRIMARY",
+                "ownershipType": ownership_type,
+            },
+            "unitAddress": {
+                "nickname": "My Rental Property",
+                "country": "CA",
+                "address": "12166 GREENWELL ST MAPLE RIDGE",
+                "addressLineTwo": "",
+                "city": "MAPLE RIDGE",
+                "province": "BC",
+                "postalCode": "V2X 7N1",
+            },
+            "listingDetails": [{"url": "https://www.airbnb.ca/rooms/26359027"}],
+            "principalResidence": {
+                "isPrincipalResidence": is_principal_residence,
+                "agreedToRentalAct": True,
+                "nonPrincipalOption": "n/a" if is_principal_residence else "OTHER",
+                "specifiedServiceProvider": specified_service_provider,
+                "agreedToSubmit": True,
+            },
+        },
+    }
+
+    return Application(
+        application_json=json_data,
+        type="registration",
+    )
 
 
 def fake_registration(*args, **kwargs):

--- a/strr-api/tests/unit/utils/mocks.py
+++ b/strr-api/tests/unit/utils/mocks.py
@@ -1,9 +1,11 @@
+import json
 import os
 
 from strr_api.enums.enum import OwnershipType, PaymentStatus, PropertyType, RegistrationStatus
 from strr_api.exceptions import ExternalServiceException
 from strr_api.models import (
     Address,
+    Application,
     Contact,
     Document,
     Eligibility,
@@ -13,6 +15,8 @@ from strr_api.models import (
     RentalProperty,
     User,
 )
+
+from ..resources.test_registration_applications import CREATE_REGISTRATION_REQUEST
 
 
 def mock_json_file(filename):
@@ -104,6 +108,16 @@ def fake_registration_pending(*args, **kwargs):
             ),
         ),
     )
+
+
+def fake_application(*args, **kwargs):
+    with open(CREATE_REGISTRATION_REQUEST) as f:
+        json_data = json.load(f)
+        return Application(
+            id=1,
+            application_json=json_data,
+            type="registration",
+        )
 
 
 def fake_registration(*args, **kwargs):


### PR DESCRIPTION
*Issue:* https://github.com/bcgov/entity/issues/22348

*Description of changes:*
- Auto-approve use application instead of registrations
- Update application status along with registration when applicable
- Currently relationship between `Application` and `Registrations` in the code is one-to-one. Whereas the RFC depicts this as many-to-one. Outlined in comments where and what changes will be needed to accommodate this.
![image](https://github.com/user-attachments/assets/e55dbfe3-ea7d-4109-b2a6-b1b1772ed1e6)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
