### PR TITLE
Fix: Updated the poetry lock resolved reference of strr-api to the la…

### DIFF
--- a/jobs/auto-approval/poetry.lock
+++ b/jobs/auto-approval/poetry.lock
@@ -2777,7 +2777,7 @@ weasyprint = "^62.3"
 type = "git"
 url = "https://github.com/bcgov/STRR.git"
 reference = "main"
-resolved_reference = "6f96071e03f074b5496ab86f39097453728cc089"
+resolved_reference = "373c60276f3c9c3897ea89863ecf9a91f9504053"
 subdirectory = "strr-api"
 
 [[package]]


### PR DESCRIPTION
…test sha

*Issue:*

- bcgov/entity/issues/

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
