### PR TITLE
Backend - Update Registrations Document Endpoints

### DIFF
--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -532,7 +532,7 @@ def get_document(application_id, file_key):
         if not application_documents:
             return error_response(ErrorMessage.DOCUMENT_NOT_FOUND.value, HTTPStatus.BAD_REQUEST)
         document = application_documents[0]
-        file_content = DocumentService.get_document_by_key(file_key)
+        file_content = DocumentService.get_file_by_key(file_key)
         return send_file(
             BytesIO(file_content),
             as_attachment=True,

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -48,8 +48,8 @@ from strr_api.common.auth import jwt
 from strr_api.enums.enum import RegistrationSortBy, RegistrationStatus, Role
 from strr_api.exceptions import AuthException, ExternalServiceException, error_response, exception_response
 from strr_api.models import User
-from strr_api.responses import Document, Events, Pagination, Registration
-from strr_api.services import DocumentService, EventsService, GCPStorageService, RegistrationService
+from strr_api.responses import Events, Pagination, Registration
+from strr_api.services import DocumentService, EventsService, RegistrationService
 
 logger = logging.getLogger("api")
 bp = Blueprint("registrations", __name__)
@@ -182,98 +182,99 @@ def get_registration(registration_id):
         return exception_response(auth_exception)
 
 
-@bp.route("/<registration_id>/documents", methods=("GET",))
+# TODO Delete this
+# @bp.route("/<registration_id>/documents", methods=("GET",))
+# @swag_from({"security": [{"Bearer": []}]})
+# @cross_origin(origin="*")
+# @jwt.requires_auth
+# def get_registration_documents(registration_id):
+#     """
+#     Get registration supporting documents for given registration id.
+#     ---
+#     tags:
+#       - registration
+#     parameters:
+#       - in: path
+#         name: registration_id
+#         type: integer
+#         required: true
+#         description: ID of the registration
+#     responses:
+#       200:
+#         description:
+#       401:
+#         description:
+#       403:
+#         description:
+#     """
+
+#     try:
+#         # only allow upload for registrations that belong to the user
+#         registration = RegistrationService.get_registration(g.jwt_oidc_token_info, registration_id)
+#         if not registration:
+#             raise AuthException()
+
+#         documents = DocumentService.get_registration_documents(registration_id)
+#         return (
+#             jsonify([Document.from_db(document).model_dump(mode="json") for document in documents]),
+#             HTTPStatus.OK,
+#         )
+#     except AuthException as auth_exception:
+#         return exception_response(auth_exception)
+
+# TODO Delete this
+# @bp.route("/<registration_id>/documents/<document_id>", methods=("GET",))
+# @swag_from({"security": [{"Bearer": []}]})
+# @cross_origin(origin="*")
+# @jwt.requires_auth
+# def get_registration_supporting_document_by_id(registration_id, document_id):
+#     """
+#     Get registration supporting document metadata for given registration id and document id.
+#     ---
+#     tags:
+#       - registration
+#     parameters:
+#       - in: path
+#         name: registration_id
+#         type: integer
+#         required: true
+#         description: ID of the registration
+#       - in: path
+#         name: document_id
+#         type: integer
+#         required: true
+#         description: ID of the document
+#     responses:
+#       200:
+#         description:
+#       401:
+#         description:
+#       403:
+#         description:
+#       404:
+#         description:
+#     """
+
+#     try:
+#         # only allow upload for registrations that belong to the user
+#         registration = RegistrationService.get_registration(g.jwt_oidc_token_info, registration_id)
+#         if not registration:
+#             raise AuthException()
+
+#         document = DocumentService.get_registration_document(registration_id, document_id)
+#         if not document:
+#             return error_response(HTTPStatus.NOT_FOUND, "Document not found")
+
+#         return jsonify(Document.from_db(document).model_dump(mode="json")), HTTPStatus.OK
+#     except AuthException as auth_exception:
+#         return exception_response(auth_exception)
+
+
+@bp.route("/<registration_id>/documents/<file_key>", methods=("GET",))
 @swag_from({"security": [{"Bearer": []}]})
 @cross_origin(origin="*")
 @jwt.requires_auth
-def get_registration_documents(registration_id):
-    """
-    Get registration supporting documents for given registration id.
-    ---
-    tags:
-      - registration
-    parameters:
-      - in: path
-        name: registration_id
-        type: integer
-        required: true
-        description: ID of the registration
-    responses:
-      200:
-        description:
-      401:
-        description:
-      403:
-        description:
-    """
-
-    try:
-        # only allow upload for registrations that belong to the user
-        registration = RegistrationService.get_registration(g.jwt_oidc_token_info, registration_id)
-        if not registration:
-            raise AuthException()
-
-        documents = DocumentService.get_registration_documents(registration_id)
-        return (
-            jsonify([Document.from_db(document).model_dump(mode="json") for document in documents]),
-            HTTPStatus.OK,
-        )
-    except AuthException as auth_exception:
-        return exception_response(auth_exception)
-
-
-@bp.route("/<registration_id>/documents/<document_id>", methods=("GET",))
-@swag_from({"security": [{"Bearer": []}]})
-@cross_origin(origin="*")
-@jwt.requires_auth
-def get_registration_supporting_document_by_id(registration_id, document_id):
-    """
-    Get registration supporting document metadata for given registration id and document id.
-    ---
-    tags:
-      - registration
-    parameters:
-      - in: path
-        name: registration_id
-        type: integer
-        required: true
-        description: ID of the registration
-      - in: path
-        name: document_id
-        type: integer
-        required: true
-        description: ID of the document
-    responses:
-      200:
-        description:
-      401:
-        description:
-      403:
-        description:
-      404:
-        description:
-    """
-
-    try:
-        # only allow upload for registrations that belong to the user
-        registration = RegistrationService.get_registration(g.jwt_oidc_token_info, registration_id)
-        if not registration:
-            raise AuthException()
-
-        document = DocumentService.get_registration_document(registration_id, document_id)
-        if not document:
-            return error_response(HTTPStatus.NOT_FOUND, "Document not found")
-
-        return jsonify(Document.from_db(document).model_dump(mode="json")), HTTPStatus.OK
-    except AuthException as auth_exception:
-        return exception_response(auth_exception)
-
-
-@bp.route("/<registration_id>/documents/<document_id>/file", methods=("GET",))
-@swag_from({"security": [{"Bearer": []}]})
-@cross_origin(origin="*")
-@jwt.requires_auth
-def get_registration_file_by_id(registration_id, document_id):
+def get_registration_file_by_id(registration_id, file_key):
     """
     Get registration file contents for given registration id and document id.
     ---
@@ -286,10 +287,10 @@ def get_registration_file_by_id(registration_id, document_id):
         required: true
         description: ID of the registration
       - in: path
-        name: document_id
-        type: integer
+        name: file_key
+        type: string
         required: true
-        description: ID of the document
+        description: File key from the upload document response
     responses:
       200:
         description:
@@ -309,13 +310,12 @@ def get_registration_file_by_id(registration_id, document_id):
         if not registration:
             raise AuthException()
 
-        document = DocumentService.get_registration_document(registration_id, document_id)
+        document = DocumentService.get_registration_document_by_key(registration_id, file_key)
         if not document:
             return error_response(HTTPStatus.NOT_FOUND, "Document not found")
-
-        file_bytes = GCPStorageService.fetch_registration_document(document.path)
+        file_content = DocumentService.get_file_by_key(file_key)
         return send_file(
-            BytesIO(file_bytes), as_attachment=True, download_name=document.file_name, mimetype=document.file_type
+            BytesIO(file_content), as_attachment=True, download_name=document.file_name, mimetype=document.file_type
         )
     except AuthException as auth_exception:
         return exception_response(auth_exception)

--- a/strr-api/src/strr_api/services/document_service.py
+++ b/strr-api/src/strr_api/services/document_service.py
@@ -80,6 +80,16 @@ class DocumentService:
         )
 
     @classmethod
-    def get_document_by_key(cls, file_key: str):
-        """Get registration document by file_key."""
+    def get_registration_document_by_key(cls, registration_id, file_key):
+        """Get registration document by key."""
+        return (
+            Document.query.join(Eligibility, Eligibility.id == Document.eligibility_id)
+            .filter(Eligibility.registration_id == registration_id)
+            .filter(Document.path == file_key)
+            .one_or_none()
+        )
+
+    @classmethod
+    def get_file_by_key(cls, file_key: str):
+        """Get registration supporting document by file_key."""
         return GCPStorageService.fetch_registration_document(blob_name=file_key)

--- a/strr-api/tests/postman/strr-api.postman_collection.json
+++ b/strr-api/tests/postman/strr-api.postman_collection.json
@@ -760,6 +760,36 @@
 					"response": []
 				},
 				{
+					"name": "Download registration document",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/registrations/{{registration_id}}/documents/{{file_key}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"registrations",
+								"{{registration_id}}",
+								"documents",
+								"{{file_key}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get Registrations",
 					"request": {
 						"auth": {

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -5,15 +5,14 @@ from unittest.mock import patch
 import pytest
 from flask import g
 
+from strr_api.exceptions import ExternalServiceException
 from tests.unit.utils.mocks import (
     fake_document,
     fake_examiner_from_token,
     fake_get_token_auth_header,
     fake_registration,
-    fake_registration_pending,
     fake_user_from_token,
     no_op,
-    throw_external_service_exception,
 )
 
 REGISTRATION = "registration_use_sbc_account"
@@ -40,41 +39,56 @@ def test_get_registrations_401(client):
     assert rv.status_code == HTTPStatus.UNAUTHORIZED
 
 
-@patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_documents_200(client):
-    rv = client.get("/registrations/1/documents")
+def test_get_registration_document_200(client, mock_registration_service, mock_document_service):
+    mock_registration_service.get_registration.return_value = fake_registration()
+    mock_document = fake_document
+    mock_document.file_name = "test.pdf"
+    mock_document.file_type = "application/pdf"
+    mock_document_service.get_registration_document_by_key.return_value = mock_document
+    mock_document_service.get_file_by_key.return_value = b"file content"
+    rv = client.get("/registrations/1/documents/test_key")
     assert rv.status_code == HTTPStatus.OK
-
-
-def test_get_registration_documents_401(client):
-    rv = client.get("/registrations/1/documents")
-    assert rv.status_code == HTTPStatus.UNAUTHORIZED
-
-
-@patch("strr_api.services.DocumentService.get_registration_document", new=fake_document)
-@patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
-@patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
-@patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
-@patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_document_200(client):
-    rv = client.get("/registrations/1/documents/1")
-    assert rv.status_code == HTTPStatus.OK
+    assert rv.data == b"file content"
+    assert rv.headers["Content-Disposition"] == "attachment; filename=test.pdf"
+    assert rv.headers["Content-Type"] == "application/pdf"
 
 
 def test_get_registration_document_401(client):
-    rv = client.get("/registrations/1/documents/1")
+    rv = client.get("/registrations/1/documents/test_key")
     assert rv.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_document_403(client):
-    rv = client.get("/registrations/1/documents/1")
+def test_get_registration_document_403(client, mock_registration_service):
+    mock_registration_service.get_registration.return_value = None
+    rv = client.get("/registrations/1/documents/test_key")
     assert rv.status_code == HTTPStatus.FORBIDDEN
+
+
+@patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
+@patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
+@patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
+def test_get_registration_document_404(client, mock_registration_service, mock_document_service):
+    mock_registration_service.get_registration.return_value = fake_registration()
+    mock_document_service.get_registration_document_by_key.return_value = None
+    rv = client.get("/registrations/1/documents/test_key")
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+    assert b"Document not found" in rv.data
+
+
+@patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
+@patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
+@patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
+def test_get_registration_document_502(client, mock_registration_service, mock_document_service):
+    mock_registration_service.get_registration.return_value = fake_registration()
+    mock_document_service.get_registration_document_by_key.side_effect = ExternalServiceException()
+    rv = client.get("/registrations/1/documents/test_key")
+    assert rv.status_code == HTTPStatus.BAD_GATEWAY
 
 
 @patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 from flask import g
 
-from strr_api.exceptions import ExternalServiceException
 from tests.unit.utils.mocks import (
     fake_document,
     fake_examiner_from_token,
@@ -42,52 +41,61 @@ def test_get_registrations_401(client):
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_document_200(client, mock_registration_service, mock_document_service):
-    mock_registration_service.get_registration.return_value = fake_registration()
-    mock_document = fake_document
+@patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
+@patch("strr_api.services.document_service.DocumentService.get_registration_document_by_key")
+@patch("strr_api.services.document_service.DocumentService.get_file_by_key")
+def test_get_registration_file_by_id_200(mock_get_file, mock_get_document, client):
+    mock_document = fake_document()
     mock_document.file_name = "test.pdf"
     mock_document.file_type = "application/pdf"
-    mock_document_service.get_registration_document_by_key.return_value = mock_document
-    mock_document_service.get_file_by_key.return_value = b"file content"
-    rv = client.get("/registrations/1/documents/test_key")
+    mock_get_document.return_value = mock_document
+    mock_file_content = b"test file content"
+    mock_get_file.return_value = mock_file_content
+
+    rv = client.get("/registrations/1/documents/test-key")
     assert rv.status_code == HTTPStatus.OK
-    assert rv.data == b"file content"
+    assert rv.data == mock_file_content
     assert rv.headers["Content-Disposition"] == "attachment; filename=test.pdf"
     assert rv.headers["Content-Type"] == "application/pdf"
 
 
-def test_get_registration_document_401(client):
-    rv = client.get("/registrations/1/documents/test_key")
+def test_get_registration_file_by_id_401(client):
+    rv = client.get("/registrations/1/documents/test-key")
     assert rv.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_document_403(client, mock_registration_service):
-    mock_registration_service.get_registration.return_value = None
-    rv = client.get("/registrations/1/documents/test_key")
+@patch("strr_api.services.registration_service.RegistrationService.get_registration", return_value=None)
+def test_get_registration_file_by_id_403(mock_get_registration, client):
+    rv = client.get("/registrations/1/documents/test-key")
     assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_document_404(client, mock_registration_service, mock_document_service):
-    mock_registration_service.get_registration.return_value = fake_registration()
-    mock_document_service.get_registration_document_by_key.return_value = None
-    rv = client.get("/registrations/1/documents/test_key")
+@patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
+@patch("strr_api.services.document_service.DocumentService.get_registration_document_by_key", return_value=None)
+def test_get_registration_file_by_id_404(mock_get_document, client):
+    rv = client.get("/registrations/1/documents/test-key")
     assert rv.status_code == HTTPStatus.NOT_FOUND
-    assert b"Document not found" in rv.data
 
 
 @patch("strr_api.models.user.User.find_by_jwt_token", new=fake_user_from_token)
 @patch("flask_jwt_oidc.JwtManager.get_token_auth_header", new=fake_get_token_auth_header)
 @patch("flask_jwt_oidc.JwtManager._validate_token", new=no_op)
-def test_get_registration_document_502(client, mock_registration_service, mock_document_service):
-    mock_registration_service.get_registration.return_value = fake_registration()
-    mock_document_service.get_registration_document_by_key.side_effect = ExternalServiceException()
-    rv = client.get("/registrations/1/documents/test_key")
+@patch("strr_api.services.registration_service.RegistrationService.get_registration", new=fake_registration)
+@patch("strr_api.services.document_service.DocumentService.get_registration_document_by_key")
+@patch(
+    "strr_api.services.document_service.DocumentService.get_file_by_key",
+    side_effect=Exception("External service error"),
+)
+def test_get_registration_file_by_id_502(mock_get_file, mock_get_document, client):
+    mock_document = fake_document()
+    mock_get_document.return_value = mock_document
+    rv = client.get("/registrations/1/documents/test-key")
     assert rv.status_code == HTTPStatus.BAD_GATEWAY
 
 

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from flask import g
 
+from strr_api.exceptions import ExternalServiceException
 from tests.unit.utils.mocks import (
     fake_document,
     fake_examiner_from_token,
@@ -90,7 +91,7 @@ def test_get_registration_file_by_id_404(mock_get_document, client):
 @patch("strr_api.services.document_service.DocumentService.get_registration_document_by_key")
 @patch(
     "strr_api.services.document_service.DocumentService.get_file_by_key",
-    side_effect=Exception("External service error"),
+    side_effect=ExternalServiceException("External service error"),
 )
 def test_get_registration_file_by_id_502(mock_get_file, mock_get_document, client):
     mock_document = fake_document()

--- a/strr-web/composables/useRegistrations.ts
+++ b/strr-web/composables/useRegistrations.ts
@@ -36,9 +36,10 @@ export const useRegistrations = () => {
     axiosInstance.get(`${apiURL}/registrations/${id}`)
       .then(res => res.data)
 
-  const getDocumentsForRegistration = (id: string): Promise<DocumentI[]> =>
-    axiosInstance.get(`${apiURL}/registrations/${id}/documents`)
-      .then(res => res.data)
+  // TODO Remove this
+  const getDocumentsForRegistration = (id: string): Promise<DocumentI[]> => {
+    return Promise.resolve([])
+  }
 
   const getRegistrationHistory = (id: string): Promise<FilingHistoryEventI[]> =>
     axiosInstance.get(`${apiURL}/registrations/${id}/events`)

--- a/strr-web/composables/useRegistrations.ts
+++ b/strr-web/composables/useRegistrations.ts
@@ -37,6 +37,7 @@ export const useRegistrations = () => {
       .then(res => res.data)
 
   // TODO Remove this
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   const getDocumentsForRegistration = (id: string): Promise<DocumentI[]> => {
     return Promise.resolve([])
   }


### PR DESCRIPTION
*Issue:*
- https://github.com/bcgov/entity/issues/22961

*Description of changes:*
- Commented out the registration document endpoints as they will not be used:
    - `GET registrations/<registration_id>/documents`
    - `GET registrations/<registration_id>/documents/<document_id>`
    Needs to be cleanup in future
- Updated `registrations/<registration_id>/documents/<document_id>/file` to `registrations/<registration_id>/documents/<file_key>`
- Added postman test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
