### PR TITLE
Add Fee Summary to Platform Application page

### DIFF
--- a/strr-web/components/FeeWidget.vue
+++ b/strr-web/components/FeeWidget.vue
@@ -57,7 +57,7 @@ const folded = ref(false)
 const isMobile = ref(false)
 
 const { fee } = defineProps<{
-  fee: FeeI
+  fee: FeeI | undefined
 }>()
 
 const toggleFolded = () => {

--- a/strr-web/components/FeeWidget.vue
+++ b/strr-web/components/FeeWidget.vue
@@ -1,17 +1,16 @@
 <template>
-  <div
+  <aside
     data-test-id="fee-widget"
-    role="complementary"
     class="
       desktop:w-[280px]
-      mobile:w-[calc(100%-8px)] mobile:fixed mobile:bottom-[4px] mobile:mx-[4px] mobile:left-[0px]
-      rounded-[4px] font-bold text-black bg-white z-10
+      mobile:w-[calc(100%-8px)] mobile:fixed mobile:bottom-1 mobile:mx-[4px] mobile:left-[0px]
+      rounded-1 font-bold text-black bg-white z-10
       shadow-md
     "
   >
     <div
       :class="`
-        ${isMobile && folded ? 'rounded-[4px]' : 'rounded-t-[4px]'}
+        ${isMobile && folded ? 'rounded-1' : 'rounded-t-1'}
         px-[15px] py-[10px] pt-[10px] text-white bg-blue-550 rounded-t-[4px] flex flex-row justify-between
         mobile:cursor-pointer
         `
@@ -36,22 +35,22 @@
         <p>{{ t("feeWidget.serviceFee") }}</p>
         <p>{{ fee?.serviceFees ? `$${fee.serviceFees.toFixed(2)}`: '-' }}</p>
       </div>
-      <div class="py-[10px] text-[14px] font-bold flex-row flex justify-between items-end" aria-label="null">
+      <div class="py-[10px] text-sm font-bold flex-row flex justify-between items-end" aria-label="null">
         <p>{{ t("feeWidget.total") }}</p>
-        <p class="font-normal text-[14px] text-bcGovGray-700 flex items-end">
+        <p class="font-normal text-sm text-bcGovGray-700 flex items-end">
           {{ t("feeWidget.cad") }}
-          <b class="text-black text-[24px] ml-[5px] mb-[-4px] flex items-end">
+          <b class="text-black text-2xl ml-[5px] mb-[-4px] flex items-end">
             {{ fee?.total ? `$${fee.total.toFixed(2)}` : '-' }}
           </b>
         </p>
       </div>
     </div>
-  </div>
+  </aside>
 </template>
 
 <script setup lang="ts">
 
-import useScreenSize from '../../../composables/useScreenSize'
+import useScreenSize from '../composables/useScreenSize'
 
 const { t } = useTranslation()
 const folded = ref(false)

--- a/strr-web/components/bcros/stepper/StepperFooter.vue
+++ b/strr-web/components/bcros/stepper/StepperFooter.vue
@@ -2,13 +2,13 @@
   <div
     class="
       bg-white h-[120px] flex items-center w-full
-      d:w-screen d:absolute d:left-[-55px] d:bottom-[0px]
+      d:absolute d:bottom-[0px]
       m:relative m:px-[8px]
       justify-center
     "
     data-test-id="stepper-footer"
   >
-    <div class="w-full max-w-[1360px] flex">
+    <div class="w-full max-w-[1360px] flex px-4">
       <BcrosButtonsPrimary
         :label="t('general.back')"
         :action="setPreviousStep"

--- a/strr-web/composables/useFees.ts
+++ b/strr-web/composables/useFees.ts
@@ -4,16 +4,43 @@ export const useFees = () => {
   const apiURL = useRuntimeConfig().public.strrApiURL
   const axiosInstance = addAxiosInterceptors(axios.create())
   const config = useRuntimeConfig()
+  const payApiURL = useRuntimeConfig().public.payApiURL
 
-  const getFeeAmount =
-    (): Promise<FeeI> =>
-      axiosInstance.get<FeeI>(`${config.public.payApiURL}/fees/STRR/RENTAL_FEE`)
-        .then((res) => {
-          return res.data
-        })
-        .finally(() => {
-          return '-'
-        })
+  /**
+   * Fetches the Host Rental Application fee.
+   *
+   * @returns {Promise<FeeI | undefined>} Fee data or undefined if an error occurs.
+   */
+  const getHostApplicationFee = async (): Promise<FeeI | undefined> => {
+    try {
+      const { data } = await axiosInstance.get<FeeI>(`${payApiURL}/fees/STRR/RENTAL_FEE`)
+      return data
+    } catch (error) {
+      console.error('Error fetching Host Application Fee: ', error)
+    }
+  }
+
+  /**
+   * Fetches the Platform Application fee based on Platform size (SM or LG).
+   *
+   * @param {('SM' | 'LG')} type - The size of platform application fee to fetch:
+   *  small - 'SM', large - 'LG' .
+   * @returns {Promise<FeeI | undefined>} Fee data or undefined if an error occurs.
+   */
+  const getPlatformApplicationFee = async (type: 'SM' | 'LG'): Promise<FeeI | undefined> => {
+    try {
+      const { data } = await axiosInstance.get<FeeI>(`${payApiURL}/fees/STRR/PLATREG_${type}`)
+      return data
+    } catch (error) {
+      console.error(`Error fetching Platform Application Fee (${type}): `, error)
+    }
+  }
+
+  // Wrapper function to get Application fee for Small Platform (<1000 listings)
+  const getSmallPlatformApplicationFee = () => getPlatformApplicationFee('SM')
+
+  // Wrapper function to get Application fee for Large Platform (>1000 listings)
+  const getLargePlatformApplicationFee = () => getPlatformApplicationFee('LG')
 
   const createInvoiceRecord = (invoiceId: string, applicationId: string) => {
     axiosInstance.post(`${apiURL}/registrations/${applicationId}/invoice/${invoiceId}/paid`)
@@ -21,18 +48,18 @@ export const useFees = () => {
 
   const handlePaymentRedirect = async (invoiceId: number, applicationId: number) => {
     const paymentUrl = config.public.authWebURL + 'makepayment'
-    const returnUrl =
-      encodeURIComponent(`${window.location.href.replace(
-        'create-account',
-        `success/${applicationId}/invoice/${invoiceId}`
-      )}`)
+    const returnUrl = encodeURIComponent(
+      `${window.location.href.replace('create-account', `success/${applicationId}/invoice/${invoiceId}`)}`
+    )
     const payUrl = `${paymentUrl}/${invoiceId}/${returnUrl}`
     await navigateTo(payUrl, { external: true })
   }
 
   return {
     createInvoiceRecord,
-    getFeeAmount,
+    getHostApplicationFee,
+    getSmallPlatformApplicationFee,
+    getLargePlatformApplicationFee,
     handlePaymentRedirect
   }
 }

--- a/strr-web/layouts/wide.vue
+++ b/strr-web/layouts/wide.vue
@@ -3,8 +3,8 @@
     <div class="flex justify-between flex-col min-h-screen">
       <BcrosHeader />
       <div class="flex grow justify-center">
-        <div class="grow desktop:px-[56px] pt-[75px] mobile:pt-[20px] max-w-[1360px]">
-          <NuxtPage class="px-4" />
+        <div class="grow pt-[75px] mobile:pt-[20px]">
+          <NuxtPage />
         </div>
       </div>
       <BcrosFooter :extra-space="true" />

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/strr-web/pages/create-account-pre/[id].vue
+++ b/strr-web/pages/create-account-pre/[id].vue
@@ -49,7 +49,7 @@
           </div>
         </div>
         <div class="shrink mobile:grow">
-          <BcrosFeeWidget :fee="fee" />
+          <FeeWidget :fee="fee" />
         </div>
       </div>
       <BcrosStepperFooter

--- a/strr-web/pages/create-account-pre/[id].vue
+++ b/strr-web/pages/create-account-pre/[id].vue
@@ -79,10 +79,10 @@ const route = useRoute()
 
 const id = route.params.id
 
-const { getFeeAmount } = useFees()
+const { getHostApplicationFee } = useFees()
 
 const updateFees = async () => {
-  fee.value = await getFeeAmount()
+  fee.value = await getHostApplicationFee()
 }
 
 onMounted(() => {

--- a/strr-web/pages/create-account.vue
+++ b/strr-web/pages/create-account.vue
@@ -2,7 +2,7 @@
   <div data-test-id="create-account-page" class="relative h-full">
     <div class="w-full flex flex-col justify-between desktop:justify-center items-center">
       <div
-        class="shrink w-full flex flex-row mobile:flex-col mobile:justify-between justify-center"
+        class="shrink w-full flex flex-row mobile:flex-col mobile:justify-between justify-center max-w-[1360px] px-4"
       >
         <div class="grow pr-[24px] mobile:pr-[0px]">
           <div class="mobile:px-[8px]">
@@ -50,7 +50,7 @@
           </div>
         </div>
         <div class="shrink mobile:grow">
-          <BcrosFeeWidget :fee="fee" />
+          <FeeWidget :fee="fee" />
         </div>
       </div>
       <BcrosStepperFooter

--- a/strr-web/pages/create-account.vue
+++ b/strr-web/pages/create-account.vue
@@ -4,7 +4,7 @@
       <div
         class="shrink w-full flex flex-row mobile:flex-col mobile:justify-between justify-center max-w-[1360px] px-4"
       >
-        <div class="grow pr-[24px] mobile:pr-[0px]">
+        <div class="grow mr-6 mobile:mr-0">
           <div class="mobile:px-[8px]">
             <BcrosTypographyH1
               :text="t('createAccount.title')"
@@ -77,10 +77,10 @@ const contactForm = ref()
 const fee = ref<FeeI>()
 const headerUpdateKey = ref(0)
 
-const { getFeeAmount } = useFees()
+const { getHostApplicationFee } = useFees()
 
 const updateFees = async () => {
-  fee.value = await getFeeAmount()
+  fee.value = await getHostApplicationFee()
 }
 
 const { t } = useTranslation()

--- a/strr-web/pages/platform-application.vue
+++ b/strr-web/pages/platform-application.vue
@@ -14,28 +14,50 @@ const setActiveStep = (newStep: number) => {
   activeStepIndex.value = newStep
 }
 
+const fee = ref<FeeI>()
+
+const { getSmallPlatformApplicationFee } = useFees()
+
+// TODO: by default load the Small Platform fee for now
+fee.value = await getSmallPlatformApplicationFee()
+
 definePageMeta({
   layout: 'wide'
 })
 </script>
 
 <template>
-  <div data-test-id="platform-application">
-    <BcrosTypographyH1 :text="t('platformApplication.header')" class-name="mobile:pb-[20px]" />
+  <div
+    data-test-id="platform-application"
+    class="w-full flex flex-col justify-between desktop:justify-center items-center relative"
+  >
+    <div class="w-full max-w-[1360px] px-4 flex">
+      <div class="grow mr-6 mobile:mr-0">
+        <BcrosTypographyH1 :text="t('platformApplication.header')" class-name="mobile:pb-[20px]" />
 
-    <BcrosStepper :key="headerUpdateKey" :active-step="activeStepIndex" :steps="steps" @change-step="setActiveStep" />
-    <div class="mt-8">
-      <div v-if="activeStepIndex === 0" :key="activeStepIndex">
-        [Step 1]
+        <BcrosStepper
+          :key="headerUpdateKey"
+          :active-step="activeStepIndex"
+          :steps="steps"
+          @change-step="setActiveStep"
+        />
+        <div class="mt-8">
+          <div v-if="activeStepIndex === 0" :key="activeStepIndex">
+            [Step 1]
+          </div>
+          <div v-if="activeStepIndex === 1" :key="activeStepIndex">
+            [Step 2]
+          </div>
+          <div v-if="activeStepIndex === 2" :key="activeStepIndex">
+            [Step 3]
+          </div>
+          <div v-if="activeStepIndex === 3" :key="activeStepIndex">
+            [Step 4]
+          </div>
+        </div>
       </div>
-      <div v-if="activeStepIndex === 1" :key="activeStepIndex">
-        [Step 2]
-      </div>
-      <div v-if="activeStepIndex === 2" :key="activeStepIndex">
-        [Step 3]
-      </div>
-      <div v-if="activeStepIndex === 3" :key="activeStepIndex">
-        [Step 4]
+      <div class="shrink mobile:grow">
+        <FeeWidget :fee="fee" />
       </div>
     </div>
   </div>

--- a/strr-web/tests/unit/components/fee-widget/FeeWidget.spec.ts
+++ b/strr-web/tests/unit/components/fee-widget/FeeWidget.spec.ts
@@ -1,9 +1,9 @@
 // @vitest-environment nuxt
 import { it, expect } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { BcrosFeeWidget } from '#components'
+import { FeeWidget } from '#components'
 
 it('can mount Fee Widget component', async () => {
-  const container = await mountSuspended(BcrosFeeWidget)
+  const container = await mountSuspended(FeeWidget)
   expect(container.find('[data-test-id="fee-widget"]').exists()).toBe(true)
 })

--- a/strr-web/tests/unit/pages/platform-application.spec.ts
+++ b/strr-web/tests/unit/pages/platform-application.spec.ts
@@ -1,10 +1,12 @@
-import { mount } from '@vue/test-utils'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
 import PlatformApplication from '@/pages/platform-application.vue'
 import { BcrosStepper } from '#components'
+import FeeWidget from '~/components/FeeWidget.vue'
 
 describe('Platform Application tests', () => {
-  it('renders page and components correctly', () => {
-    const wrapper = mount(PlatformApplication)
+  it('renders page and components correctly', async () => {
+    const wrapper = await mountSuspended(PlatformApplication)
+
     expect(wrapper.exists()).toBe(true)
 
     expect(wrapper.find('h1').exists()).toBe(true)
@@ -12,5 +14,8 @@ describe('Platform Application tests', () => {
     const stepper = wrapper.findComponent(BcrosStepper)
     expect(stepper.exists()).toBe(true)
     expect(stepper.vm.steps.length).toBe(4)
+
+    const feeSummary = wrapper.findComponent(FeeWidget)
+    expect(feeSummary.exists()).toBe(true)
   })
 })


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/22764

*Description of changes:*
- Add Fee Summary widget
- Integrate API calls for fees (small and large Platform fees) 
- Default is the Small Platform fee
- Update unit test

![Screenshot 2024-08-28 at 06 38 27](https://github.com/user-attachments/assets/391c8d24-b83c-4c5e-9eea-bca8ea94c48a)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
