### PR TITLE
UI - Document Upload - Align with Design

### DIFF
--- a/strr-web/components/bcros/form-section/principal-residence/Form.vue
+++ b/strr-web/components/bcros/form-section/principal-residence/Form.vue
@@ -254,12 +254,26 @@ const otherExemptionReasons: string[] = [
 ]
 
 const formatFileName = (fileName: string) => {
-  if (fileName.length <= 25) {
-    return fileName
-  }
-  const extension = fileName.split('.').pop()
+  const extension = fileName.split('.').pop() || ''
   const nameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'))
-  return `${nameWithoutExtension.substring(0, 21)}....${extension}`
+  const isSingleWord = !nameWithoutExtension.includes(' ')
+  if (isSingleWord && fileName.length <= 25) {
+    return fileName
+  } else if (isSingleWord && fileName.length > 25) {
+    return nameWithoutExtension.substring(0, 22) + '...'
+  } else {
+    let truncatedName = ''
+    const words = nameWithoutExtension.split(' ')
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i]
+      if (word.length > 24) {
+        truncatedName += (truncatedName ? ' ' : '') + word.substring(0, 21) + '...'
+      } else {
+        truncatedName += (truncatedName ? ' ' : '') + word
+      }
+    }
+    return truncatedName + (extension ? '.' + extension : '')
+  }
 }
 
 </script>

--- a/strr-web/components/bcros/form-section/principal-residence/Form.vue
+++ b/strr-web/components/bcros/form-section/principal-residence/Form.vue
@@ -119,7 +119,7 @@
             <div
               v-for="(supportingDocument, index) in formState.supportingDocuments"
               :key="supportingDocument.name"
-              class="flex items-center justify-between p-3 bg-gray-100 rounded"
+              class="flex items-center justify-between p-3 mb-1 bg-gray-100 rounded"
             >
               <div class="flex flex-row items-center">
                 <img
@@ -127,12 +127,16 @@
                   src="/icons/create-account/attach_dark.svg"
                   alt="Attach icon"
                 >
-                <p class="desktop:hidden">
-                  {{ formatFileName(supportingDocument.name) }}
-                </p>
-                <p class="mobile:hidden">
-                  {{ supportingDocument.name }}
-                </p>
+                <div class="mobile:max-w-[210px] desktop:max-w-[700px] max-h-auto">
+                  <p
+                    :class="[
+                      'text-ellipsis overflow-hidden desktop:break-words',
+                      hasSpaces(supportingDocument.name) ? 'mobile:break-words' : 'mobile:whitespace-nowrap'
+                    ]"
+                  >
+                    {{ supportingDocument.name }}
+                  </p>
+                </div>
               </div>
               <button
                 class="text-blue-500 hover:text-blue-700 flex items-center"
@@ -253,41 +257,7 @@ const otherExemptionReasons: string[] = [
   tPrincipalResidence('strataGuest')
 ]
 
-const truncateName = (name: string, maxLength: number): string => {
-  return name.substring(0, maxLength) + '...'
-}
-
-const processFileNameWithSingleWord = (name: string) => {
-  if (name.length <= 25) {
-    return name
-  } else {
-    return truncateName(name, 22)
-  }
-}
-
-const processFileNameWithMultipleWords = (name: string, extension: string) => {
-  let truncatedName = ''
-  const words = name.split(' ')
-  for (const word of words) {
-    if (word.length > 24) {
-      truncatedName += (truncatedName ? ' ' : '') + truncateName(word, 21)
-    } else {
-      truncatedName += (truncatedName ? ' ' : '') + word
-    }
-  }
-  return truncatedName + (extension ? '.' + extension : '')
-}
-
-const formatFileName = (fileName: string) => {
-  const extension = fileName.split('.').pop() || ''
-  const nameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'))
-  const isSingleWord = !nameWithoutExtension.includes(' ')
-  if (isSingleWord) {
-    return processFileNameWithSingleWord(nameWithoutExtension)
-  } else {
-    return processFileNameWithMultipleWords(nameWithoutExtension, extension)
-  }
-}
+const hasSpaces = (str: string) => /\s/.test(str)
 
 </script>
 
@@ -324,4 +294,4 @@ const formatFileName = (fileName: string) => {
   input[type="file"]:focus::before {
     content: attr(placeholder);
   }
-</style>
+  </style>

--- a/strr-web/components/bcros/form-section/principal-residence/Form.vue
+++ b/strr-web/components/bcros/form-section/principal-residence/Form.vue
@@ -95,15 +95,20 @@
             <p class="mb-[16px]">
               {{ tPrincipalResidence('uploadMultiple') }}
             </p>
-            <div class="flex flex-row items-center">
-              <img class="mr-[4px]" src="/icons/create-account/attach.svg" alt="Paperclip icon">
+            <div class="flex flex-row items-center relative">
+              <img
+                class="mr-[4px] absolute left-3 top-1/2 transform -translate-y-1/2 z-10"
+                src="/icons/create-account/attach.svg"
+                alt="Paperclip icon"
+              >
               <UFormGroup :error="fileError">
                 <UInput
+                  :key="fileInputKey"
                   aria-label="Supporting document file upload"
                   accept=".pdf,.jpg,.png,.doc"
                   type="file"
-                  class="w-full"
-                  :placeholder="tPrincipalResidence('supporting')"
+                  class="w-full pl-10 cursor-pointer"
+                  :placeholder="tPrincipalResidence('chooseSupportDocs')"
                   @change="uploadFile"
                 />
               </UFormGroup>
@@ -111,12 +116,32 @@
             <p class="text-[12px] ml-[58px] mt-[4px] mb-[12px] text-bcGovColor-midGray">
               {{ tPrincipalResidence('fileRequirements') }}
             </p>
-            <div v-for="(supportingDocument, index) in formState.supportingDocuments" :key="supportingDocument.name">
+            <div
+              v-for="(supportingDocument, index) in formState.supportingDocuments"
+              :key="supportingDocument.name"
+              class="flex items-center justify-between p-3 bg-gray-100 rounded"
+            >
               <div class="flex flex-row items-center">
-                <img class="mr-[4px] h-[18px] w-[18px]" src="/icons/create-account/attach_dark.svg" alt="Attach icon">
-                <p>{{ supportingDocument.name }}</p>
-                <UIcon name="i-mdi-delete" class="h-[18px] w-[18px] ml-[4px]" @click="() => removeFile(index)" />
+                <img
+                  class="mr-[4px] h-[18px] w-[18px]"
+                  src="/icons/create-account/attach_dark.svg"
+                  alt="Attach icon"
+                >
+                <p class="desktop:hidden">
+                  {{ formatFileName(supportingDocument.name) }}
+                </p>
+                <p class="mobile:hidden">
+                  {{ supportingDocument.name }}
+                </p>
               </div>
+              <button
+                class="text-blue-500 hover:text-blue-700 flex items-center"
+                aria-label="Remove file"
+                @click="() => removeFile(index)"
+              >
+                <span class="mr-1">{{ tPrincipalResidence('removeSupportDoc') }}</span>
+                <UIcon name="i-mdi-close" class="h-[18px] w-[18px]" />
+              </button>
             </div>
           </BcrosFormSection>
         </div>
@@ -159,6 +184,7 @@ const tPrincipalResidence = (translationKey: string) => t(`createAccount.princip
 const reasonError = ref()
 const otherReasonError = ref()
 const fileError = ref()
+const fileInputKey = ref(0)
 
 const { isComplete } = defineProps<{ isComplete: boolean }>()
 
@@ -195,6 +221,7 @@ const uploadFile = (file: FileList) => {
   } else {
     fileError.value = null
     formState.supportingDocuments.push(file[0])
+    fileInputKey.value++
   }
 }
 
@@ -226,10 +253,48 @@ const otherExemptionReasons: string[] = [
   tPrincipalResidence('strataGuest')
 ]
 
+const formatFileName = (fileName: string) => {
+  if (fileName.length <= 25) {
+    return fileName
+  }
+  const extension = fileName.split('.').pop()
+  const nameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'))
+  return `${nameWithoutExtension.substring(0, 21)}....${extension}`
+}
+
 </script>
 
 <style>
   #primary-residence-radio legend {
     font-weight: bold;
+  }
+  input[type="file"]::-webkit-file-upload-button {
+    display: none;
+  }
+  input[type="file"]::file-selector-button {
+    display: none;
+  }
+  input[type="file"] {
+    color: transparent;
+    position: relative;
+  }
+  input[type="file"]:hover {
+    cursor: pointer;
+  }
+  input[type="file"]::before {
+    content: attr(placeholder);
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+    color: #6B7280;
+    pointer-events: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  input[type="file"]:focus::before {
+    content: attr(placeholder);
   }
 </style>

--- a/strr-web/components/bcros/form-section/principal-residence/Form.vue
+++ b/strr-web/components/bcros/form-section/principal-residence/Form.vue
@@ -253,26 +253,39 @@ const otherExemptionReasons: string[] = [
   tPrincipalResidence('strataGuest')
 ]
 
+const truncateName = (name: string, maxLength: number): string => {
+  return name.substring(0, maxLength) + '...'
+}
+
+const processFileNameWithSingleWord = (name: string) => {
+  if (name.length <= 25) {
+    return name
+  } else {
+    return truncateName(name, 22)
+  }
+}
+
+const processFileNameWithMultipleWords = (name: string, extension: string) => {
+  let truncatedName = ''
+  const words = name.split(' ')
+  for (const word of words) {
+    if (word.length > 24) {
+      truncatedName += (truncatedName ? ' ' : '') + truncateName(word, 21)
+    } else {
+      truncatedName += (truncatedName ? ' ' : '') + word
+    }
+  }
+  return truncatedName + (extension ? '.' + extension : '')
+}
+
 const formatFileName = (fileName: string) => {
   const extension = fileName.split('.').pop() || ''
   const nameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'))
   const isSingleWord = !nameWithoutExtension.includes(' ')
-  if (isSingleWord && fileName.length <= 25) {
-    return fileName
-  } else if (isSingleWord && fileName.length > 25) {
-    return nameWithoutExtension.substring(0, 22) + '...'
+  if (isSingleWord) {
+    return processFileNameWithSingleWord(nameWithoutExtension)
   } else {
-    let truncatedName = ''
-    const words = nameWithoutExtension.split(' ')
-    for (let i = 0; i < words.length; i++) {
-      const word = words[i]
-      if (word.length > 24) {
-        truncatedName += (truncatedName ? ' ' : '') + word.substring(0, 21) + '...'
-      } else {
-        truncatedName += (truncatedName ? ' ' : '') + word
-      }
-    }
-    return truncatedName + (extension ? '.' + extension : '')
+    return processFileNameWithMultipleWords(nameWithoutExtension, extension)
   }
 }
 

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -253,6 +253,8 @@
       "docDetails": "Documentation Details",
       "fileUpload": "File Upload",
       "uploadMultiple": "Upload one or more supporting documents",
+      "chooseSupportDocs": "Choose Supporting Documents",
+      "removeSupportDoc": "Remove",
       "supporting": "Supporting Documents",
       "fileRequirements": "File must be a .pdf, .jpg, .doc, or .png. Maximum file size 50 MB.",
       "declaration": "Declaration",

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/22520

*Description of changes:*
 - [x] Clear document from the document picker after uploading it
 - [x] Display the full file name regardless of the length of the file name
 
Design:
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/273b70fd-665a-4cc7-8196-6637f03aebfd">

With this PR:
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/588f685b-7778-47e2-b327-b1c8aaffb0a7">
<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/516fdf8b-0fb4-490c-8ef7-3cb2b11f3a5a">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
