### PR TITLE
Remove Use Same Address Checkbox

### DIFF
--- a/strr-web/components/bcros/form-section/property/Address.vue
+++ b/strr-web/components/bcros/form-section/property/Address.vue
@@ -7,15 +7,6 @@
         </UFormGroup>
       </div>
       <div class="flex flex-row justify-between w-full mb-[40px] mobile:mb-[16px]">
-        <UFormGroup name="useMailing" class="d:pr-[16px] flex-grow mobile:text-[16px]">
-          <UCheckbox
-            v-model="useMailing"
-            aria-label="use mailing address"
-            :label="t('createAccount.propertyForm.useMailing')"
-          />
-        </UFormGroup>
-      </div>
-      <div class="flex flex-row justify-between w-full mb-[40px] mobile:mb-[16px]">
         <UFormGroup name="country" class="d:pr-[16px] flex-grow">
           <USelect
             v-model="country"
@@ -86,7 +77,6 @@ const addressLineTwo = defineModel<string>('addressLineTwo')
 const city = defineModel<string>('city')
 const province = defineModel<string>('province')
 const postalCode = defineModel<string>('postalCode')
-const useMailing = defineModel<string>('useMailing')
 const nickname = defineModel<string>('nickname')
 const countryItems = ref<CountryItem[]>([])
 

--- a/strr-web/interfaces/account-i.ts
+++ b/strr-web/interfaces/account-i.ts
@@ -155,7 +155,6 @@ export interface CreateAccountFormStateI {
     businessLicense: string | undefined
     propertyType: string | undefined
     ownershipType: string | undefined
-    useMailing: boolean
     nickname: string | undefined
     country: string | undefined
     address: string | undefined

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -184,7 +184,6 @@
       "yourName": "Your Name",
       "addSecondaryContact": "Add Another Contact",
       "remove": "Remove",
-      "useMailing": "Use my mailing address for the rental property address",
       "addPlatform": "Add another platform"
     },
     "contactForm": {
@@ -226,7 +225,6 @@
       "businessLicense": "Local Government Business License (Optional)",
       "propertyType": "Type of Property",
       "ownershipType": "Ownership Type",
-      "useMailing": "Use my mailing address for the rental property address",
       "rentalUnitDetails": "Rental Unit Details",
       "internetListingDetails": "Internet Listing Details",
       "rentalUnitAddress": "Rental Unit Address",

--- a/strr-web/nuxt.config.ts
+++ b/strr-web/nuxt.config.ts
@@ -1,4 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { version } from './package.json'
+
 export default defineNuxtConfig({
   ssr: false,
   ui: {
@@ -74,7 +76,7 @@ export default defineNuxtConfig({
       payApiURL: `${process.env.VUE_APP_PAY_API_URL || ''}${process.env.VUE_APP_PAY_API_VERSION || ''}`,
       registryHomeURL: process.env.VUE_APP_REGISTRY_HOME_URL || '',
       appEnv: `${process.env.VUE_APP_POD_NAMESPACE || 'unknown'}`,
-      version: '0.1.0'
+      version
     }
   },
   css: ['~/./assets/scss/global.scss'],

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/strr-web/stores/strr.ts
+++ b/strr-web/stores/strr.ts
@@ -206,8 +206,7 @@ export const propertyDetailsSchema = z.object({
   parcelIdentifier: optionalPID,
   postalCode: requiredNonEmptyString,
   propertyType: requiredNonEmptyString,
-  province: requiredNonEmptyString.refine(province => province === 'BC', { message: 'Province must be set to BC' }),
-  useMailing: z.boolean()
+  province: requiredNonEmptyString.refine(province => province === 'BC', { message: 'Province must be set to BC' })
 })
 
 export const formState: CreateAccountFormStateI = reactive({
@@ -220,7 +219,6 @@ export const formState: CreateAccountFormStateI = reactive({
     ownershipType: undefined,
     primaryResidence: undefined,
     whichPlatform: undefined,
-    useMailing: false,
     nickname: '',
     country: 'CAN',
     address: undefined,

--- a/strr-web/tests/unit/utils/formStateToApi.spec.ts
+++ b/strr-web/tests/unit/utils/formStateToApi.spec.ts
@@ -60,7 +60,6 @@ it('begins with empty address', () => {
       businessLicense: 'businessLicense',
       propertyType: 'propertyType',
       ownershipType: 'ownershipType',
-      useMailing: false,
       nickname: 'nickname',
       country: 'country',
       address: 'address',


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/22519

*Description of changes:*
- Remove Use Same Address Checkbox
- Show correct UI version in app footer

![Screenshot 2024-09-03 at 17 21 33](https://github.com/user-attachments/assets/19f3e439-659f-499e-ac4e-61d10416a1fd)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
