### PR TITLE
UI - STRB Contact Modal [Application Status Page]

### DIFF
--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -174,7 +174,14 @@
     "view": "View",
     "download": "Download Certificate",
     "renewal": "Renewal",
-    "strrCertificate": "Short Term Rental Registry Certificate"
+    "strrCertificate": "Short Term Rental Registry Certificate",
+    "modal":{
+      "contactInfo": {
+        "header": "Need Help?",
+        "openButtonLabel": "Help with using this dashboard",
+        "contactUs": "If you need help with setting up your BC Registries and Online Services account, please contact us."
+      }
+    }
   },
   "feeWidget": {
     "summary": "Fee Summary",

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -44,7 +44,10 @@
       "contactInfo": {
         "header": "Need Help?",
         "openButtonLabel": "Help with using this dashboard",
-        "contactUs": "If you need help with setting up your BC Registries and Online Services account, please contact us."
+        "contactUsFirstPart": "For information about the Short-Term Rental Registry, visit the short-term ",
+        "contactUsSecondPart": ". If you need help with registering your rental unit, using the My STR Registry Dashboard, or resolving a technical issue, you can also contact us directly.",
+        "informationPageLabel": "Information Page",
+        "informationPageLink": "https://www2.gov.bc.ca/gov/content/housing-tenancy/short-term-rentals/registry"
       }
     }
   },
@@ -179,7 +182,10 @@
       "contactInfo": {
         "header": "Need Help?",
         "openButtonLabel": "Help with using this dashboard",
-        "contactUs": "If you need help with setting up your BC Registries and Online Services account, please contact us."
+        "contactUsFirstPart": "For information about the Short-Term Rental Registry, visit the short-term ",
+        "contactUsSecondPart": ". If you need help with registering your rental unit, using the My STR Registry Dashboard, or resolving a technical issue, you can also contact us directly.",
+        "informationPageLabel": "Information Page",
+        "informationPageLink": "https://www2.gov.bc.ca/gov/content/housing-tenancy/short-term-rentals/registry"
       }
     }
   },
@@ -210,7 +216,10 @@
       "contactInfo": {
         "header": "Need Help?",
         "openButtonLabel": "Help with registering a rental unit",
-        "contactUs": "If you need help with setting up your BC Registries and Online Services account, please contact us."
+        "contactUsFirstPart": "For information about the Short-Term Rental Registry, visit the short-term ",
+        "contactUsSecondPart": ". If you need help with registering your rental unit, using the My STR Registry Dashboard, or resolving a technical issue, you can also contact us directly.",
+        "informationPageLabel": "Information Page",
+        "informationPageLink": "https://www2.gov.bc.ca/gov/content/housing-tenancy/short-term-rentals/registry"
       }
     },
     "applicationConfirm": {

--- a/strr-web/pages/application-status.vue
+++ b/strr-web/pages/application-status.vue
@@ -12,7 +12,11 @@
       class="mb-6"
     >
       <p class="mb-10">
-        {{ tRegistrationStatus('modal.contactInfo.contactUs') }}
+        {{ tRegistrationStatus('modal.contactInfo.contactUsFirstPart') }}
+        <a :href="`${tRegistrationStatus('modal.contactInfo.informationPageLink')}`">
+          {{ tRegistrationStatus('modal.contactInfo.informationPageLabel') }}
+        </a>
+        {{ tRegistrationStatus('modal.contactInfo.contactUsSecondPart') }}
       </p>
     </InfoModal>
     <div>

--- a/strr-web/pages/application-status.vue
+++ b/strr-web/pages/application-status.vue
@@ -5,6 +5,16 @@
       data-test-id="account-page-title"
       class="pb-[32px] mobile:pb-[24px]"
     />
+    <InfoModal
+      :header="tRegistrationStatus('modal.contactInfo.header')"
+      :open-button-label="tRegistrationStatus('modal.contactInfo.openButtonLabel')"
+      :hide-contact-info="false"
+      class="mb-6"
+    >
+      <p class="mb-10">
+        {{ tRegistrationStatus('modal.contactInfo.contactUs') }}
+      </p>
+    </InfoModal>
     <div>
       <div class="flex flex-row justify-between">
         <BcrosTypographyH2
@@ -79,6 +89,7 @@
 
 <script setup lang="ts">
 import { ApplicationI } from '~/interfaces/application-i'
+import InfoModal from '~/components/common/InfoModal.vue'
 
 definePageMeta({
   layout: 'wide-no-space'

--- a/strr-web/pages/create-account.vue
+++ b/strr-web/pages/create-account.vue
@@ -19,7 +19,11 @@
                 class="mb-6"
               >
                 <p class="mb-10">
-                  {{ t('createAccount.modal.contactInfo.contactUs') }}
+                  {{ t('createAccount.modal.contactInfo.contactUsFirstPart') }}
+                  <a :href="`${t('createAccount.modal.contactInfo.informationPageLink')}`">
+                    {{ t('createAccount.modal.contactInfo.informationPageLabel') }}
+                  </a>
+                  {{ t('createAccount.modal.contactInfo.contactUsSecondPart') }}
                 </p>
               </InfoModal>
               <div class="self-stretch w-px bg-gray-300 mx-4" />

--- a/strr-web/pages/registry-dashboard.vue
+++ b/strr-web/pages/registry-dashboard.vue
@@ -9,7 +9,11 @@
       class="mb-6"
     >
       <p class="mb-10">
-        {{ tRegistryDashboard('modal.contactInfo.contactUs') }}
+        {{ tRegistryDashboard('modal.contactInfo.contactUsFirstPart') }}
+        <a :href="`${tRegistryDashboard('modal.contactInfo.informationPageLink')}`">
+          {{ tRegistryDashboard('modal.contactInfo.informationPageLabel') }}
+        </a>
+        {{ tRegistryDashboard('modal.contactInfo.contactUsSecondPart') }}
       </p>
     </InfoModal>
     <UTabs


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/23083

*Description of changes:*
- [x] A visible and easily accessible help button should be present in Host Dashboard [`application-status` page]
- [x] When users click on the help button, a pop-up window is displayed.
- [x] Users can click "close" or "x" to close the pop-up window.
- [x] The contact information should include options for immediate help, such as a phone number, or email. (Contact info will be provided later, just put some placeholder)
- [x] Users should be able to access help without leaving the host dashboard

![image](https://github.com/user-attachments/assets/3fd2fd64-3e2c-47b8-be0b-be38d164833f)
![image](https://github.com/user-attachments/assets/a218a585-f38b-486b-b493-d3e8a62d75f7)
`Information Page` link redirects to https://www2.gov.bc.ca/gov/content/housing-tenancy/short-term-rentals/registry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
