### PR TITLE
fix : AutoApproval job failure

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.0.10"
+version = "0.0.11"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/services/approval_service.py
+++ b/strr-api/src/strr_api/services/approval_service.py
@@ -158,7 +158,7 @@ class ApprovalService:
                         postal_code=registration.unitAddress.postalCode,
                         country=registration.unitAddress.country,
                     )
-                    if not compare_addresses(rental_address, bcsc_address):
+                    if not bcsc_address or not compare_addresses(rental_address, bcsc_address):
                         auto_approval.addressMatch = False
                         application.status = Application.Status.FULL_REVIEW
                         application.save()

--- a/strr-api/src/strr_api/services/auth_service.py
+++ b/strr-api/src/strr_api/services/auth_service.py
@@ -99,10 +99,20 @@ class AuthService:
     @classmethod
     def get_sbc_accounts_mailing_address(cls, bearer_token, account_id):
         """Return mailing address for given sbc account"""
-
+        mailing_address = None
         endpoint = f"{current_app.config.get('AUTH_SVC_URL')}/orgs/{account_id}"
         user_account_details = RestService.get(endpoint=endpoint, token=bearer_token).json()
-        return SBCMailingAddress(**user_account_details["mailingAddress"])
+        if mailing_address_dict := user_account_details.get("mailingAddress", {}):
+            if mailing_address_dict.get("street"):
+                mailing_address = SBCMailingAddress(
+                    street=mailing_address_dict.get("street"),
+                    city=mailing_address_dict.get("city"),
+                    region=mailing_address_dict.get("region"),
+                    postalCode=mailing_address_dict.get("postalCode"),
+                    country=mailing_address_dict.get("country"),
+                    streetAdditional=mailing_address_dict.get("streetAdditional", None),
+                )
+        return mailing_address
 
     @classmethod
     @user_context


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/23606

*Description of changes:*
In GET Org response, Contact Info is present in mailing address object along with the address fields and sometimes only contact info is present even when there is no mailing address for that account.  The fix returns SBCMailingAddress only if address fields are present with in the mailing object in the Org response.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
