### PR TITLE
feat: Return allowed host and examiner actions for an application

### DIFF
--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -205,6 +205,8 @@ class ApplicationSerializer:
         Application.Status.DECLINED: "Declined",
     }
 
+    HOST_ACTIONS = {Application.Status.PAYMENT_DUE: ["SUBMIT_PAYMENT"]}
+
     EXAMINER_STATUSES = {
         Application.Status.DRAFT: "Draft",
         Application.Status.PAYMENT_DUE: "Payment Due",
@@ -215,6 +217,11 @@ class ApplicationSerializer:
         Application.Status.PROVISIONAL_REVIEW: "Provisional Examination",
         Application.Status.FULL_REVIEW: "Full Examination",
         Application.Status.DECLINED: "Declined",
+    }
+
+    EXAMINER_ACTIONS = {
+        Application.Status.FULL_REVIEW_APPROVED: ["ISSUE_CERTIFICATE"],
+        Application.Status.FULL_REVIEW: ["APPROVE", "REJECT"],
     }
 
     @staticmethod
@@ -239,6 +246,14 @@ class ApplicationSerializer:
         application_dict["header"]["examinerStatus"] = ApplicationSerializer.EXAMINER_STATUSES.get(
             application.status, ""
         )
+        application_dict["header"]["hostActions"] = ApplicationSerializer.HOST_ACTIONS.get(application.status, [])
+        application_dict["header"]["examinerActions"] = ApplicationSerializer.EXAMINER_ACTIONS.get(
+            application.status, []
+        )
+        if application.status == Application.Status.FULL_REVIEW_APPROVED:
+            certificates = application.registration.certificates
+            if certificates:
+                application_dict["header"]["examinerActions"] = []
         application_dict["header"]["applicationDateTime"] = application.application_date.isoformat()
         application_dict["header"]["decisionDate"] = (
             application.decision_date.isoformat() if application.decision_date else None

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from http import HTTPStatus
 from unittest.mock import patch
 
-from flask import g
-
 from strr_api.enums.enum import PaymentStatus
 from strr_api.exceptions import ExternalServiceException
 from strr_api.models import Application, Events
@@ -177,6 +175,11 @@ def test_issue_certificate_examiner(session, client, jwt):
         registration_id = response_json.get("header").get("registrationId")
         rv = client.post(f"/registrations/{registration_id}/certificate", headers=staff_headers)
         assert rv.status_code == HTTPStatus.CREATED
+        rv = client.get(f"/applications/{application_id}", headers=headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        assert response_json.get("header").get("examinerActions") == []
+        assert response_json.get("header").get("hostActions") == []
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/22831

*Description of changes:*

- Added host actions and examiner actions available for application statuses
- Added new tests and updated existing tests to assert the expected value for the new fields


Note: 

- Provisional Approval will not be supported for the MVP release. The actions related to Provisional Approval are not added.
- Registrar Decision, Re-assess application are new features yet to be implemented. Actions for these new statuses will be added when those features are implemented.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
