### PR TITLE
fix: Business Licence expiry date format in registration response

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.0.11"
+version = "0.0.12"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/responses/RegistrationSerializer.py
+++ b/strr-api/src/strr_api/responses/RegistrationSerializer.py
@@ -112,7 +112,11 @@ class RegistrationSerializer:
         registration_data["unitDetails"] = {
             "parcelIdentifier": registration.rental_property.parcel_identifier,
             "businessLicense": registration.rental_property.local_business_licence,
-            "businessLicenseExpiryDate": registration.rental_property.local_business_licence_expiry_date,
+            "businessLicenseExpiryDate": registration.rental_property.local_business_licence_expiry_date.strftime(
+                "%Y-%m-%d"
+            )
+            if registration.rental_property.local_business_licence_expiry_date
+            else None,
             "propertyType": registration.rental_property.property_type.name,
             "ownershipType": registration.rental_property.ownership_type.name,
         }


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/23552

*Description of changes:*

- Fixed the format of the date in the registration response

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
