### PR TITLE
UI: Application Status Followup Fixes 

### DIFF
--- a/strr-web/composables/useChipFlavour.ts
+++ b/strr-web/composables/useChipFlavour.ts
@@ -10,11 +10,11 @@ export const useChipFlavour = () => {
     text: tStatuses(translationKey)
   })
 
-  const examinerOrHostStatusMap = (flavour: AlertsFlavourE, key: string) => ({
+  const examinerOrHostStatusMap = (flavour: AlertsFlavourE, examinerKey: string, hostKey: string) => ({
     alert: flavour,
     text: isExaminer
-      ? tStatuses(`examinerStatuses.${key}`)
-      : tStatuses(`hostStatuses.${key}`)
+      ? tStatuses(`examinerStatuses.${examinerKey}`)
+      : tStatuses(`hostStatuses.${hostKey}`)
   })
 
   const getChipFlavour = (status: string): StatusChipFlavoursI['flavour'] => {
@@ -46,27 +46,28 @@ export const useChipFlavour = () => {
       case ApplicationStatusE.PAID:
       case HostApplicationStatusE.PAID:
       case ExaminerApplicationStatusE.PAID:
-        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'paid')
+        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'paid', 'paid')
       case ApplicationStatusE.AUTO_APPROVED:
       case HostApplicationStatusE.AUTO_APPROVED:
       case ExaminerApplicationStatusE.AUTO_APPROVED:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'autoApproved')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'autoApproved', 'autoApproved')
       case ApplicationStatusE.PROVISIONALLY_APPROVED:
       case HostApplicationStatusE.PROVISIONALLY_APPROVED:
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalApproved', 'provisionalApproved')
       case ExaminerApplicationStatusE.PROVISIONALLY_APPROVED:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalApproved')
+      case HostApplicationStatusE.PROVISIONAL_REVIEW:
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalApproved', 'provisionalReview')
       case ApplicationStatusE.FULL_REVIEW_APPROVED:
       case HostApplicationStatusE.FULL_REVIEW_APPROVED:
       case ExaminerApplicationStatusE.FULL_REVIEW_APPROVED:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'fullReviewApproved')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'fullReviewApproved', 'fullReviewApproved')
       case ApplicationStatusE.PROVISIONAL_REVIEW:
-      case HostApplicationStatusE.PROVISIONAL_REVIEW:
       case ExaminerApplicationStatusE.PROVISIONAL_REVIEW:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalReview')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalReview', 'provisionalReview')
       case ApplicationStatusE.FULL_REVIEW:
       case HostApplicationStatusE.FULL_REVIEW:
       case ExaminerApplicationStatusE.FULL_REVIEW:
-        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'fullReview')
+        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'fullReview', 'fullReview')
       default:
         return { alert: AlertsFlavourE.MESSAGE, text: '' }
     }

--- a/strr-web/composables/useChipFlavour.ts
+++ b/strr-web/composables/useChipFlavour.ts
@@ -10,11 +10,11 @@ export const useChipFlavour = () => {
     text: tStatuses(translationKey)
   })
 
-  const examinerOrHostStatusMap = (flavour: AlertsFlavourE, key: string, hostSpecificKey?: string) => ({
+  const examinerOrHostStatusMap = (flavour: AlertsFlavourE, commonKey: string, hostSpecificKey?: string) => ({
     alert: flavour,
     text: isExaminer
-      ? tStatuses(`examinerStatuses.${key}`)
-      : tStatuses(`hostStatuses.${key || hostSpecificKey}`)
+      ? tStatuses(`examinerStatuses.${commonKey}`)
+      : tStatuses(`hostStatuses.${commonKey || hostSpecificKey}`)
   })
 
   const getChipFlavour = (status: string): StatusChipFlavoursI['flavour'] => {

--- a/strr-web/composables/useChipFlavour.ts
+++ b/strr-web/composables/useChipFlavour.ts
@@ -14,7 +14,7 @@ export const useChipFlavour = () => {
     alert: flavour,
     text: isExaminer
       ? tStatuses(`examinerStatuses.${commonKey}`)
-      : tStatuses(`hostStatuses.${commonKey || hostSpecificKey}`)
+      : tStatuses(`hostStatuses.${hostSpecificKey || commonKey}`)
   })
 
   const getChipFlavour = (status: string): StatusChipFlavoursI['flavour'] => {

--- a/strr-web/composables/useChipFlavour.ts
+++ b/strr-web/composables/useChipFlavour.ts
@@ -10,11 +10,11 @@ export const useChipFlavour = () => {
     text: tStatuses(translationKey)
   })
 
-  const examinerOrHostStatusMap = (flavour: AlertsFlavourE, examinerKey: string, hostKey: string) => ({
+  const examinerOrHostStatusMap = (flavour: AlertsFlavourE, key: string, hostSpecificKey?: string) => ({
     alert: flavour,
     text: isExaminer
-      ? tStatuses(`examinerStatuses.${examinerKey}`)
-      : tStatuses(`hostStatuses.${hostKey}`)
+      ? tStatuses(`examinerStatuses.${key}`)
+      : tStatuses(`hostStatuses.${key || hostSpecificKey}`)
   })
 
   const getChipFlavour = (status: string): StatusChipFlavoursI['flavour'] => {
@@ -46,28 +46,28 @@ export const useChipFlavour = () => {
       case ApplicationStatusE.PAID:
       case HostApplicationStatusE.PAID:
       case ExaminerApplicationStatusE.PAID:
-        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'paid', 'paid')
+        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'paid')
       case ApplicationStatusE.AUTO_APPROVED:
       case HostApplicationStatusE.AUTO_APPROVED:
       case ExaminerApplicationStatusE.AUTO_APPROVED:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'autoApproved', 'autoApproved')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'autoApproved')
       case ApplicationStatusE.PROVISIONALLY_APPROVED:
       case HostApplicationStatusE.PROVISIONALLY_APPROVED:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalApproved', 'provisionalApproved')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalApproved')
       case ExaminerApplicationStatusE.PROVISIONALLY_APPROVED:
       case HostApplicationStatusE.PROVISIONAL_REVIEW:
         return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalApproved', 'provisionalReview')
       case ApplicationStatusE.FULL_REVIEW_APPROVED:
       case HostApplicationStatusE.FULL_REVIEW_APPROVED:
       case ExaminerApplicationStatusE.FULL_REVIEW_APPROVED:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'fullReviewApproved', 'fullReviewApproved')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'fullReviewApproved')
       case ApplicationStatusE.PROVISIONAL_REVIEW:
       case ExaminerApplicationStatusE.PROVISIONAL_REVIEW:
-        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalReview', 'provisionalReview')
+        return examinerOrHostStatusMap(AlertsFlavourE.SUCCESS, 'provisionalReview')
       case ApplicationStatusE.FULL_REVIEW:
       case HostApplicationStatusE.FULL_REVIEW:
       case ExaminerApplicationStatusE.FULL_REVIEW:
-        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'fullReview', 'fullReview')
+        return examinerOrHostStatusMap(AlertsFlavourE.APPLIED, 'fullReview')
       default:
         return { alert: AlertsFlavourE.MESSAGE, text: '' }
     }

--- a/strr-web/enums/application-status-e.ts
+++ b/strr-web/enums/application-status-e.ts
@@ -19,7 +19,7 @@ export enum HostApplicationStatusE {
   AUTO_APPROVED = 'Approved', // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
   PROVISIONALLY_APPROVED = 'Approved', // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
   FULL_REVIEW_APPROVED = 'Approved',
-  PROVISIONAL_REVIEW = 'Approved – Provisional', // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  PROVISIONAL_REVIEW = 'Approved \u2013 Provisional', // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
   FULL_REVIEW = 'Pending Approval',
   DECLINED = 'Declined'
 }
@@ -28,9 +28,9 @@ export enum ExaminerApplicationStatusE {
   DRAFT = 'Draft',
   PAYMENT_DUE = 'Payment Due',
   PAID = 'Paid',
-  AUTO_APPROVED = 'Approved – Automatic',
-  PROVISIONALLY_APPROVED = 'Approved – Provisional',
-  FULL_REVIEW_APPROVED = 'Approved – Examined',
+  AUTO_APPROVED = 'Approved \u2013 Automatic',
+  PROVISIONALLY_APPROVED = 'Approved \u2013 Provisional',
+  FULL_REVIEW_APPROVED = 'Approved \u2013 Examined',
   PROVISIONAL_REVIEW = 'Provisional Examination',
   FULL_REVIEW = 'Full Examination',
   DECLINED = 'Declined'

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -64,17 +64,17 @@
   "statuses": {
     "examinerStatuses": {
       "paid": "Paid",
-      "autoApproved": "Approved - Automatic",
-      "provisionalApproved": "Approved - Provisional",
+      "autoApproved": "Approved \u2013 Automatic",
+      "provisionalApproved": "Approved \u2013 Provisional",
       "provisionalReview": "Provisional Examination",
-      "fullReviewApproved": "Approved - Examined",
+      "fullReviewApproved": "Approved \u2013 Examined",
       "fullReview": "Full Examination"
     },
     "hostStatuses": {
       "paid": "Pending Approval",
       "autoApproved": "Approved",
       "provisionalApproved": "Approved",
-      "provisionalReview": "Approved - Provisional",
+      "provisionalReview": "Approved \u2013 Provisional",
       "fullReviewApproved": "Approved",
       "fullReview": "Pending Approval"
     },

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -81,7 +81,7 @@
     "draft": "Draft",
     "paymentDue": "Payment Due",
     "declined": "Declined",
-    "additionalInfoRequested": "ADDITIONAL INFO REQUESTED",
+    "additionalInfoRequested": "Additional Info Requested",
     "active": "Active",
     "expired": "Expired",
     "suspended": "Suspended",

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/22832

*Description of changes:*
Includes a lang change suggested by Andy. Status collision fix between `PROVISIONALLY_APPROVED` [examiner] AND `PROVISIONAL_REVIEW` [host]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
