### PR TITLE
UI: Generic Dashboard Table for Examiners

### DIFF
--- a/strr-web/components/bcros/status-card/StatusCard.vue
+++ b/strr-web/components/bcros/status-card/StatusCard.vue
@@ -31,7 +31,7 @@
       />
 
       <BcrosButtonsPrimary
-        v-if="showDownloadButton"
+        v-if="isCertificateIssued"
         :action="() => downloadCertificate(registrationId.toString())"
         :label="tRegistrationStatus('download')"
         class-name="px-4 py-1 mobile:grow-0"
@@ -42,8 +42,8 @@
 </template>
 
 <script setup lang="ts">
-import { RegistrationStatusE, HostApplicationStatusE, ExaminerApplicationStatusE } from '#imports'
-const { downloadCertificate, isCertificateIssued } = useDownloadCertificate()
+import { HostApplicationStatusE, ExaminerApplicationStatusE } from '#imports'
+const { downloadCertificate } = useDownloadCertificate()
 
 const { t } = useTranslation()
 const tRegistrationStatus = (translationKey: string) => t(`registrationStatus.${translationKey}`)
@@ -59,9 +59,16 @@ const {
   isSingle: boolean,
 }>()
 
-const canDownloadCertificate = ref(false)
-const { registrationId, registrationNumber, status, hostStatus, examinerStatus, registrationStatus } = applicationHeader
-const applicationNumber = applicationHeader.applicationNumber
+const {
+  registrationId,
+  registrationNumber,
+  status,
+  hostStatus,
+  examinerStatus,
+  isCertificateIssued,
+  applicationNumber
+} = applicationHeader
+
 const flavour = computed(() => {
   if (isExaminer) {
     return getChipFlavour(examinerStatus || status)
@@ -70,7 +77,6 @@ const flavour = computed(() => {
   }
 })
 
-const isRegistrationActive: boolean = registrationStatus === RegistrationStatusE.ACTIVE
 const isApproved = computed(() => {
   if (isExaminer) {
     return [
@@ -85,11 +91,5 @@ const isApproved = computed(() => {
       HostApplicationStatusE.FULL_REVIEW_APPROVED
     ].includes(hostStatus)
   }
-})
-const showDownloadButton = computed(() => isRegistrationActive && canDownloadCertificate.value)
-onMounted(async () => {
-  canDownloadCertificate.value = registrationId
-    ? await isCertificateIssued(registrationId.toString())
-    : false
 })
 </script>

--- a/strr-web/composables/useDownloadCertificate.ts
+++ b/strr-web/composables/useDownloadCertificate.ts
@@ -15,17 +15,7 @@ export const useDownloadCertificate = () => {
     URL.revokeObjectURL(link.href)
   }
 
-  const isCertificateIssued = async (id: string): Promise<boolean> => {
-    try {
-      await getCertificate(id)
-      return true
-    } catch (error) {
-      return false
-    }
-  }
-
   return {
-    downloadCertificate,
-    isCertificateIssued
+    downloadCertificate
   }
 }

--- a/strr-web/composables/useDownloadCertificate.ts
+++ b/strr-web/composables/useDownloadCertificate.ts
@@ -1,0 +1,31 @@
+export const useDownloadCertificate = () => {
+  const { t } = useTranslation()
+  const tRegistrationStatus = (translationKey: string) => t(`registrationStatus.${translationKey}`)
+  const { getCertificate } = useRegistrations()
+
+  const downloadCertificate = async (id: string) => {
+    const file = await getCertificate(id)
+    const link = document.createElement('a')
+    const blob = new Blob([file], { type: 'application/pdf' })
+    link.href = window.URL.createObjectURL(blob)
+    link.target = '_blank'
+    link.download = `${tRegistrationStatus('strrCertificate')}.pdf`
+    document.body.appendChild(link)
+    link.click()
+    URL.revokeObjectURL(link.href)
+  }
+
+  const isCertificateIssued = async (id: string): Promise<boolean> => {
+    try {
+      await getCertificate(id)
+      return true
+    } catch (error) {
+      return false
+    }
+  }
+
+  return {
+    downloadCertificate,
+    isCertificateIssued
+  }
+}

--- a/strr-web/enums/registration-type-e.ts
+++ b/strr-web/enums/registration-type-e.ts
@@ -1,4 +1,4 @@
 export enum RegistrationTypeE {
- HOST = 'HOST',
+  HOST = 'HOST',
   PLATFORM = 'PLATFORM'
 }

--- a/strr-web/interfaces/application-i.ts
+++ b/strr-web/interfaces/application-i.ts
@@ -19,6 +19,7 @@ export interface ApplicationHeaderI {
   registrationId: number
   registrationNumber: string
   registrationStartDate: string
+  isCertificateIssued: boolean,
   registrationStatus: RegistrationStatusE
   reviewer: {
     displayName: string

--- a/strr-web/interfaces/examiner-dashboard-row-i.ts
+++ b/strr-web/interfaces/examiner-dashboard-row-i.ts
@@ -1,0 +1,12 @@
+export interface ExaminerDashboardRowI {
+  applicationNumber: string;
+  registrationNumber: string;
+  registrationId: string;
+  isCertificateIssued: boolean;
+  registrationType: string;
+  unitAddressCity: string;
+  unitAddressPostalCode: string;
+  unitAddress: string;
+  status: string;
+  submissionDate: string | Date;
+}

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -13,6 +13,8 @@
     "applicationNumber": "Application #",
     "registrationNumber": "Registration #",
     "status": "Status",
+    "registrationType": "Type",
+    "contact": "Contact",
     "nickname": "Listing Nickname",
     "address": "Listing Address",
     "owner": "Owner",

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/strr-web/pages/registry-dashboard.vue
+++ b/strr-web/pages/registry-dashboard.vue
@@ -93,9 +93,10 @@
             {{ row.registrationType }}
           </div>
         </template>
-        <template #unitAddress-data="{ row }">
+        <template #address-data="{ row }">
           <div class="cursor-pointer w-full" @click="navigateToDetails(row.applicationNumber)">
-            {{ row.unitAddress }}
+            <div>{{ row.unitAddress }}</div>
+            <div>{{ row.unitAddressCity }} {{ row.unitAddressPostalCode }}</div>
           </div>
         </template>
         <template #contact-data="{ row }">
@@ -247,7 +248,9 @@ const registrationsToTableRows = async (applications: PaginatedApplicationsI): P
       registrationId: header.registrationId ? header.registrationId.toString() : '',
       isCertificateIssued: certificateIssued,
       registrationType: getRegistrationTypeLabel(registrationType),
-      unitAddress: `${unitAddress.address}, ${unitAddress.city}, ${unitAddress.province} ${unitAddress.postalCode}`,
+      unitAddressCity: unitAddress.city,
+      unitAddressPostalCode: unitAddress.postalCode,
+      unitAddress: unitAddress.address,
       contact: contactPerson
         ? `${contactPerson.firstName} ${contactPerson.middleName ?? ''} ${contactPerson.lastName}`.trim()
         : '-',
@@ -295,7 +298,7 @@ const columns = [
   { key: 'application', label: tRegistryDashboard('applicationNumber'), sortable: true },
   { key: 'registrationNumber', label: tRegistryDashboard('registrationNumber'), sortable: true },
   { key: 'registrationType', label: tRegistryDashboard('registrationType'), sortable: true },
-  { key: 'unitAddress', label: tRegistryDashboard('address'), sortable: true },
+  { key: 'address', label: tRegistryDashboard('address'), sortable: true },
   { key: 'contact', label: tRegistryDashboard('contact'), sortable: true },
   { key: 'status', label: tRegistryDashboard('status'), sortable: true },
   { key: 'submission', label: tRegistryDashboard('submissionDate'), sortable: true }

--- a/strr-web/pages/registry-dashboard.vue
+++ b/strr-web/pages/registry-dashboard.vue
@@ -93,6 +93,11 @@
             {{ row.registrationType }}
           </div>
         </template>
+        <template #unitAddress-data="{ row }">
+          <div class="cursor-pointer w-full" @click="navigateToDetails(row.applicationNumber)">
+            {{ row.unitAddress }}
+          </div>
+        </template>
         <template #contact-data="{ row }">
           <div class="cursor-pointer w-full" @click="navigateToDetails(row.applicationNumber)">
             {{ row.contact }}
@@ -229,7 +234,7 @@ const updateTableRows = async () => {
 const registrationsToTableRows = async (applications: PaginatedApplicationsI): Promise<Record<string, string>[]> => {
   const rows: Record<string, string>[] = []
   for (const application of applications.applications) {
-    const { header, registration: { primaryContact, registrationType } } = application
+    const { header, registration: { primaryContact, registrationType, unitAddress } } = application
     const contactPerson = primaryContact?.name
     let certificateIssued = false
     if (header.registrationStatus === RegistrationStatusE.ACTIVE && header.registrationId) {
@@ -242,6 +247,7 @@ const registrationsToTableRows = async (applications: PaginatedApplicationsI): P
       registrationId: header.registrationId ? header.registrationId.toString() : '',
       isCertificateIssued: certificateIssued,
       registrationType: getRegistrationTypeLabel(registrationType),
+      unitAddress: `${unitAddress.address}, ${unitAddress.city}, ${unitAddress.province} ${unitAddress.postalCode}`,
       contact: contactPerson
         ? `${contactPerson.firstName} ${contactPerson.middleName ?? ''} ${contactPerson.lastName}`.trim()
         : '-',
@@ -289,6 +295,7 @@ const columns = [
   { key: 'application', label: tRegistryDashboard('applicationNumber'), sortable: true },
   { key: 'registrationNumber', label: tRegistryDashboard('registrationNumber'), sortable: true },
   { key: 'registrationType', label: tRegistryDashboard('registrationType'), sortable: true },
+  { key: 'unitAddress', label: tRegistryDashboard('address'), sortable: true },
   { key: 'contact', label: tRegistryDashboard('contact'), sortable: true },
   { key: 'status', label: tRegistryDashboard('status'), sortable: true },
   { key: 'submission', label: tRegistryDashboard('submissionDate'), sortable: true }

--- a/strr-web/pages/registry-dashboard.vue
+++ b/strr-web/pages/registry-dashboard.vue
@@ -86,7 +86,7 @@
             </span>
             <UIcon
               v-if="row.isCertificateIssued"
-              name="i-heroicons-document-text"
+              name="i-mdi-file-document-outline"
               class="h-[20px] w-[20px] ml-3 text-blue-600 cursor-pointer"
               alt="certificate download"
               @click="downloadCertificate(row.registrationId)"
@@ -211,7 +211,7 @@ const updateFilterOptions = async () => {
   ]
 }
 
-const navigateToApplicationDetails = (id: number) => navigateTo(`/application-details/${id.toString()}`)
+const navigateToApplicationDetails = (appNumber: string) => navigateTo(`/application-details/${appNumber}`)
 const navigateToRegistrationDetails = (id: number) => navigateTo(`/registration-details/${id.toString()}`)
 
 const updateTableRows = async () => {
@@ -227,7 +227,7 @@ const updateTableRows = async () => {
   const applications = await getPaginatedApplications(paginationObject)
   if (applications) {
     totalResults.value = applications.total
-    tableRows.value = await registrationsToTableRows(applications)
+    tableRows.value = registrationsToTableRows(applications)
   }
 
   updateMaxPageResults()

--- a/strr-web/tests/mocks/mockApplication.ts
+++ b/strr-web/tests/mocks/mockApplication.ts
@@ -64,6 +64,7 @@ export const mockApplicationApproved: ApplicationI = {
     registrationNumber: 'BCH24527283787',
     registrationStartDate: '2024-08-16T11:08:40.935161+00:00',
     registrationStatus: RegistrationStatusE.ACTIVE,
+    isCertificateIssued: true,
     reviewer: {
       displayName: 'Joe Smith',
       username: 'joes@idir'
@@ -98,6 +99,7 @@ export const mockApplicationPaymentDue: ApplicationI = {
     registrationNumber: 'BCH24527283787',
     registrationStartDate: '2024-08-16T11:08:40.935161+00:00',
     registrationStatus: RegistrationStatusE.ACTIVE,
+    isCertificateIssued: false,
     reviewer: {
       displayName: 'Joe Smith',
       username: 'joes@idir'
@@ -132,6 +134,7 @@ export const mockApplicationFullReview: ApplicationI = {
     registrationNumber: 'BCH24527283787',
     registrationStartDate: '2024-08-16T11:08:40.935161+00:00',
     registrationStatus: RegistrationStatusE.ACTIVE,
+    isCertificateIssued: false,
     reviewer: {
       displayName: 'Joe Smith',
       username: 'joes@idir'


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/23532

*Description of changes:*
Generic dashboard - Registration number link will open registration detail page. If certificate has been issued for that registration then a document icon will be displayed, clicking it will download certificate. Otherwise it will open application details [same as before with all rows except status]. 
Status Card - Download certificate button will only show if the certificate has been issued.

![image](https://github.com/user-attachments/assets/41c5ae3d-01ae-44f4-b6a7-22ac9640e25c)
![image](https://github.com/user-attachments/assets/39fd0d5d-5ee9-4ac5-9ecc-9645405ed377)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
