### PR TITLE
Add Business Lic Exp Date to Details pages

### DIFF
--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -124,6 +124,7 @@
     "unitInfo": "Rental Unit Information",
     "nickname": "Nickname",
     "businessLicense": "Business License",
+    "businessLicenseExpiryDate": "Business License Expiry Date",
     "listingLink": "Listing Link",
     "listingLinkOptional": "Listing Link (Optional)",
     "listingLinkHelp": "e.g., https://www.airbnb.ca/your_listing123",

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/strr-web/pages/application-details/[id]/index.vue
+++ b/strr-web/pages/application-details/[id]/index.vue
@@ -47,19 +47,24 @@
         </p>
         <div class="bg-white py-[22px] px-[30px] mobile:px-5" data-test-id="rental-unit-info">
           <div class="flex flex-row justify-between w-full mobile:flex-col desktop:mb-6">
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('nickname')">
-              <p data-test-id="unit-nickname">
-                {{ applicationDetails?.unitAddress.nickname ?? '-' }}
-              </p>
-            </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('businessLicense')">
-              <p data-test-id="business-license">
-                {{ applicationDetails?.unitDetails.businessLicense ?? '-' }}
-              </p>
-            </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('ownership')">
-              <p data-test-id="ownership-type">
-                {{ getOwnershipTypeDisplay(applicationDetails?.unitDetails.ownershipType, tApplicationDetails) }}
+            <BcrosFormSectionReviewItem
+              :title="tApplicationDetails('nickname')"
+              :content="applicationDetails?.unitAddress.nickname || '-'"
+              data-test-id="unit-nickname"
+            />
+            <BcrosFormSectionReviewItem
+              :title="tApplicationDetails('ownership')"
+              :content="getOwnershipTypeDisplay(applicationDetails?.unitDetails.ownershipType, tApplicationDetails)"
+              data-test-id="ownership-type"
+            />
+            <BcrosFormSectionReviewItem :title="tApplicationDetails('propertyType')">
+              <p data-test-id="property-type">
+                {{ applicationDetails?.unitDetails.propertyType
+                  ? tPropertyForm(
+                    propertyTypeMap[applicationDetails?.unitDetails.propertyType as keyof PropertyTypeMapI]
+                  )
+                  : '-'
+                }}
               </p>
             </BcrosFormSectionReviewItem>
           </div>
@@ -82,17 +87,12 @@
                   : '-' }}
               </p>
             </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('propertyType')">
-              <p data-test-id="property-type">
-                {{ applicationDetails?.unitDetails.propertyType
-                  ? tPropertyForm(
-                    propertyTypeMap[applicationDetails?.unitDetails.propertyType as keyof PropertyTypeMapI]
-                  )
-                  : '-'
-                }}
-              </p>
-            </BcrosFormSectionReviewItem>
-            <div class="flex-1 max-w-[33.33%]">
+            <BcrosFormSectionReviewItem
+              :title="tApplicationDetails('businessLicense')"
+              :content="applicationDetails?.unitDetails.businessLicense || '-'"
+              data-test-id="business-license"
+            />
+            <div class="flex-1 d:max-w-[33.33%]">
               <template v-if="applicationDetails?.listingDetails && applicationDetails.listingDetails.length > 0">
                 <BcrosFormSectionReviewItem
                   :title="tApplicationDetails('listingLink')"
@@ -112,8 +112,14 @@
           </div>
           <div class="flex flex-row justify-between w-full mobile:flex-col">
             <div class="flex-1" />
-            <div class="flex-1" />
-            <div class="flex-1 max-w-[33.33%]">
+            <BcrosFormSectionReviewItem
+              v-if="applicationDetails?.unitDetails.businessLicenseExpiryDate"
+              :title="tApplicationDetails('businessLicenseExpiryDate')"
+              :content="convertDateToLongFormat(applicationDetails?.unitDetails.businessLicenseExpiryDate)"
+              data-test-id="business-exp-date"
+            />
+            <div v-else class="flex-1" />
+            <div class="flex-1 d:max-w-[33.33%]">
               <template v-if="applicationDetails?.listingDetails && applicationDetails.listingDetails.length > 1">
                 <div class="flex flex-col">
                   <div
@@ -146,30 +152,28 @@
           </p>
           <div class="d:hidden">
             <div class="bg-white py-[22px] px-[30px] mobile:px-5">
-              <BcrosFormSectionReviewItem :title="tApplicationDetails('name')">
-                <p data-test-id="primary-contact-name">
-                  {{ (applicationDetails ? getContactRows(applicationDetails?.primaryContact): [])[0].name }}
-                </p>
-              </BcrosFormSectionReviewItem>
-              <BcrosFormSectionReviewItem :title="tApplicationDetails('address')">
-                <p data-test-id="primary-contact-address">
-                  {{ (applicationDetails ? getContactRows(applicationDetails?.primaryContact): [])[0].address }}
-                </p>
-              </BcrosFormSectionReviewItem>
-              <BcrosFormSectionReviewItem :title="tApplicationDetails('email')">
-                <p data-test-id="primary-contact-email">
-                  {{
-                    (applicationDetails ? getContactRows(applicationDetails?.primaryContact): [])[0]['Email Address']
-                  }}
-                </p>
-              </BcrosFormSectionReviewItem>
-              <BcrosFormSectionReviewItem :title="tApplicationDetails('phone')">
-                <p data-test-id="primary-contact-phone">
-                  {{
-                    (applicationDetails ? getContactRows(applicationDetails?.primaryContact): [])[0]['Phone Number']
-                  }}
-                </p>
-              </BcrosFormSectionReviewItem>
+              <BcrosFormSectionReviewItem
+                :title="tApplicationDetails('name')"
+                :content="(applicationDetails ? getContactRows(applicationDetails?.primaryContact) : [])[0].name"
+                data-test-id="primary-contact-name"
+              />
+              <BcrosFormSectionReviewItem
+                :title="tApplicationDetails('address')"
+                :content="(applicationDetails ? getContactRows(applicationDetails?.primaryContact) : [])[0].address"
+                data-test-id="primary-contact-address"
+              />
+              <BcrosFormSectionReviewItem
+                :title="tApplicationDetails('email')"
+                :content="(applicationDetails
+                  ? getContactRows(applicationDetails?.primaryContact) : [])[0]['Email Address']"
+                data-test-id="primary-contact-email"
+              />
+              <BcrosFormSectionReviewItem
+                :title="tApplicationDetails('phone')"
+                :content="(applicationDetails
+                  ? getContactRows(applicationDetails?.primaryContact) : [])[0]['Phone Number']"
+                data-test-id="primary-contact-phone"
+              />
             </div>
           </div>
           <div class="bg-white py-[22px] px-[30px] mobile:px-5 m:hidden overflow-x-scroll w-[150%]">
@@ -425,7 +429,7 @@ const getContactRows = (contactBlock: ContactI) => [{
   `,
   address: `
     ${contactBlock.mailingAddress.address} 
-    ${contactBlock.mailingAddress.addressLineTwo} 
+    ${contactBlock.mailingAddress.addressLineTwo || ''}
     ${contactBlock.mailingAddress.city} 
     ${contactBlock.mailingAddress.province} 
     ${contactBlock.mailingAddress.postalCode}
@@ -434,10 +438,7 @@ const getContactRows = (contactBlock: ContactI) => [{
   'Phone Number':
     `
       ${contactBlock.details.phoneNumber}
-      ${contactBlock.details.extension
-        ? contactBlock.details.extension
-        : ''
-      }
+      ${contactBlock.details.extension || ''}
     `,
   SIN: contactBlock.socialInsuranceNumber,
   'BN (GST)': contactBlock.businessNumber

--- a/strr-web/pages/registration-details/[id]/index.vue
+++ b/strr-web/pages/registration-details/[id]/index.vue
@@ -34,14 +34,21 @@
         </p>
         <div class="bg-white py-[22px] px-[30px] mobile:px-2">
           <div class="flex flex-row justify-between w-full mobile:flex-col desktop:mb-6">
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('nickname')">
-              <p>{{ application?.unitAddress.nickname ?? '-' }}</p>
-            </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('businessLicense')">
-              <p>{{ application?.unitDetails.businessLicense ?? '-' }}</p>
-            </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('ownership')">
-              <p>{{ application?.unitDetails.ownershipType ?? '-' }}</p>
+            <BcrosFormSectionReviewItem
+              :title="tApplicationDetails('nickname')"
+              :content="application?.unitAddress.nickname || '-'"
+            />
+            <BcrosFormSectionReviewItem
+              :title="tApplicationDetails('ownership')"
+              :content="getOwnershipTypeDisplay(application?.unitDetails.ownershipType, tApplicationDetails)"
+            />
+            <BcrosFormSectionReviewItem :title="tApplicationDetails('propertyType')">
+              <p>
+                {{ application?.unitDetails.propertyType
+                  ? tPropertyForm(propertyTypeMap[application?.unitDetails.propertyType as keyof PropertyTypeMapI])
+                  : '-'
+                }}
+              </p>
             </BcrosFormSectionReviewItem>
           </div>
           <div class="flex flex-row justify-between w-full mobile:flex-col">
@@ -59,15 +66,17 @@
                 {{ application?.unitAddress.country ? regionNamesInEnglish.of(application?.unitAddress.country) : '-' }}
               </p>
             </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('propertyType')">
-              <p>
-                {{ application?.unitDetails.propertyType
-                  ? tPropertyForm(propertyTypeMap[application?.unitDetails.propertyType as keyof PropertyTypeMapI])
-                  : '-'
-                }}
-              </p>
-            </BcrosFormSectionReviewItem>
-            <div class="flex-1" />
+            <BcrosFormSectionReviewItem
+              :title="tApplicationDetails('businessLicense')"
+              :content="application?.unitDetails.businessLicense || '-'"
+            />
+            <BcrosFormSectionReviewItem
+              v-if="application?.unitDetails.businessLicenseExpiryDate"
+              :title="tApplicationDetails('businessLicenseExpiryDate')"
+              :content="convertDateToLongFormat(application?.unitDetails.businessLicenseExpiryDate)"
+              data-test-id="business-exp-date"
+            />
+            <div v-else class="flex-1" />
           </div>
         </div>
         <div class="mt-10 relative overflow-x-scroll">


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/23551

*Description of changes:*
- Add Business Lic Exp Date to Application and Registration Details pages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
