### PR TITLE
UI - Platform: Validation checkpoint

### DIFF
--- a/strr-platform-web/app/components/connect/Stepper.vue
+++ b/strr-platform-web/app/components/connect/Stepper.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-// const { activeStep } = defineProps<{ activeStep: number }>()
-// const { steps, activeStep } = defineProps<{ steps: Step[], activeStep: number }>()
-// const props = defineProps<{ steps: Step[] }>()
-
 const emit = defineEmits<{ newStep: [stepIndex: number] }>()
 
 const { t } = useI18n()
@@ -15,21 +11,12 @@ const activeStepModel = defineModel('activeStep', {
 })
 
 function setActiveStep (newStep: number) {
-  const totalSteps = stepsModel.value.length
+  activeStepModel.value.complete = true // set currently active step to complete
 
-  // If the user is on the last step and moves back, mark the last step as complete
-  if (activeStepIndexModel.value === totalSteps - 1) {
-    const lastStep = stepsModel.value[totalSteps - 1]
-    if (lastStep) {
-      lastStep.complete = true
-    }
-  }
+  activeStepIndexModel.value = newStep // update active step index
+  activeStepModel.value = stepsModel.value[newStep] as Step // update active step model
 
-  // Set the active step to the new step
-  activeStepIndexModel.value = newStep
-  activeStepModel.value = stepsModel.value[activeStepIndexModel.value] as Step
-
-  // Mark all previous steps as complete
+  // mark all previous steps as complete
   for (let i = 0; i < newStep; i++) {
     if (stepsModel.value[i]) {
       // @ts-expect-error
@@ -44,7 +31,7 @@ function setNextStep () {
   const totalSteps = stepsModel.value.length
   const currentStep = activeStepIndexModel.value
 
-  // Check if we're not on the last step
+  // check if not on last step
   if (currentStep < totalSteps - 1) {
     setActiveStep(currentStep + 1)
   }
@@ -53,7 +40,7 @@ function setNextStep () {
 function setPreviousStep () {
   const currentStep = activeStepIndexModel.value
 
-  // Check if we're not on the first step
+  // check if not on first step
   if (currentStep > 0) {
     setActiveStep(currentStep - 1)
   }
@@ -62,7 +49,7 @@ function setPreviousStep () {
 defineExpose({ setActiveStep, setNextStep, setPreviousStep })
 
 onMounted(() => {
-  if (stepsModel.value.length > 0) {
+  if (stepsModel.value.length > 0) { // init first step based on activeStepIndexModel default value
     activeStepModel.value = stepsModel.value[activeStepIndexModel.value] as Step
   }
 })

--- a/strr-platform-web/app/components/connect/Stepper.vue
+++ b/strr-platform-web/app/components/connect/Stepper.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 const emit = defineEmits<{ newStep: [stepIndex: number] }>()
 
-const { t } = useI18n()
-
 const stepsModel = defineModel<Step[]>('steps', { default: () => [] })
 const activeStepIndexModel = defineModel<number>('activeStepIndex', { default: 0 })
 const activeStepModel = defineModel<Step>('activeStep', { default: () => {} })
@@ -97,7 +95,7 @@ onMounted(() => {
                     ? '/icons/valid_step.svg'
                     : '/icons/invalid_step.svg'
                   "
-                  :alt="t(`validation.step.${step.isValid}`)"
+                  :alt="$t(`validation.step.${step.isValid}`)"
                   class="absolute right-[-10px] top-[-10px]"
                 >
               </div>
@@ -111,7 +109,7 @@ onMounted(() => {
                 v-else
                 :src="`${index === activeStepIndexModel ? `${step.activeIconPath}`: step.inactiveIconPath}`"
                 class="size-5 sm:size-6 md:size-8"
-                :alt="step.i18nPrefix ? t(`${step.i18nPrefix}.description.${index}`) : step.alt"
+                :alt="step.i18nPrefix ? $t(`${step.i18nPrefix}.description.${index}`) : step.alt"
               >
             </div>
           </div>
@@ -122,7 +120,7 @@ onMounted(() => {
             "
             :class="index === activeStepIndexModel ? 'font-bold text-black' : 'text-blue-500'"
           >
-            {{ step.label ? t(step.label) : t(`${step.i18nPrefix}.description.${index}`) }}
+            {{ step.label ? $t(step.label) : $t(`${step.i18nPrefix}.description.${index}`) }}
           </p>
         </button>
         <div
@@ -135,9 +133,9 @@ onMounted(() => {
     </div>
   </div>
   <div v-if="stepsModel[activeStepIndexModel]?.i18nPrefix" class="space-y-5 py-5">
-    <ConnectTypographyH2 :text="t(`${stepsModel[activeStepIndexModel]?.i18nPrefix}.title.${activeStepIndexModel}`)" />
+    <ConnectTypographyH2 :text="$t(`${stepsModel[activeStepIndexModel]?.i18nPrefix}.title.${activeStepIndexModel}`)" />
     <p>
-      {{ t(`${stepsModel[activeStepIndexModel]?.i18nPrefix}.info.${activeStepIndexModel}`) }}
+      {{ $t(`${stepsModel[activeStepIndexModel]?.i18nPrefix}.info.${activeStepIndexModel}`) }}
     </p>
   </div>
 </template>

--- a/strr-platform-web/app/components/connect/Stepper.vue
+++ b/strr-platform-web/app/components/connect/Stepper.vue
@@ -16,11 +16,17 @@ async function setActiveStep (newStep: number) {
   activeStepIndexModel.value = newStep // update active step index
   activeStepModel.value = stepsModel.value[newStep] as Step // update active step model
 
-  // mark all previous steps as complete
+  // mark and validate all previous steps
   for (let i = 0; i < newStep; i++) {
-    if (stepsModel.value[i]) {
-      // @ts-expect-error
-      stepsModel.value[i].complete = true
+    const previousStep = stepsModel.value[i]
+
+    if (previousStep) {
+      previousStep.complete = true
+
+      if (previousStep.validationFn) {
+        const isValid = await previousStep.validationFn()
+        setStepValidity(i, !!isValid)
+      }
     }
   }
 

--- a/strr-platform-web/app/components/form/platform/BusinessDetails.vue
+++ b/strr-platform-web/app/components/form/platform/BusinessDetails.vue
@@ -19,23 +19,36 @@ watch(() => platformBusiness.value.hasCpbc, () => {
   platformBusiness.value.cpbcLicenceNumber = ''
 })
 
-// manage regOfficeOrAtt
-watchEffect(() => {
-  // set regOfficeOrAtt.mailingAddress to match business mailing address if sameAsMailAddress checkbox checked
-  if (platformBusiness.value.regOfficeOrAtt.sameAsMailAddress) {
-    platformBusiness.value.regOfficeOrAtt.mailingAddress = { ...platformBusiness.value.mailingAddress }
+// set regOfficeOrAtt.mailingAddress to match business mailing address if sameAsMailAddress checkbox checked
+watch(() => platformBusiness.value.regOfficeOrAtt.sameAsMailAddress,
+  (newVal) => {
+    if (newVal) {
+      platformBusiness.value.regOfficeOrAtt.mailingAddress = { ...platformBusiness.value.mailingAddress }
+      // revalidate fields to update/remove form errors
+      platformBusinessFormRef.value?.validate([
+        'regOfficeOrAtt.mailingAddress.country',
+        'regOfficeOrAtt.mailingAddress.street',
+        'regOfficeOrAtt.mailingAddress.city',
+        'regOfficeOrAtt.mailingAddress.region',
+        'regOfficeOrAtt.mailingAddress.postalCode'
+      ], { silent: true })
+    }
   }
+)
 
+watch(() => platformBusiness.value.hasRegOffAtt,
+  (newVal) => {
   // reset regOfficeOrAtt if hasRegOffAtt radio set to false
-  if (platformBusiness.value.hasRegOffAtt === false) {
-    platformBusiness.value.regOfficeOrAtt.attorneyName = ''
-    platformBusiness.value.regOfficeOrAtt.sameAsMailAddress = false
-    Object.keys(platformBusiness.value.regOfficeOrAtt.mailingAddress).forEach((key) => {
+    if (!newVal) {
+      platformBusiness.value.regOfficeOrAtt.attorneyName = ''
+      platformBusiness.value.regOfficeOrAtt.sameAsMailAddress = false
+      Object.keys(platformBusiness.value.regOfficeOrAtt.mailingAddress).forEach((key) => {
       // @ts-expect-error - ts doesnt recognize key type
-      platformBusiness.value.regOfficeOrAtt.mailingAddress[key] = ''
-    })
+        platformBusiness.value.regOfficeOrAtt.mailingAddress[key] = ''
+      })
+    }
   }
-})
+)
 
 // address stuff
 const {
@@ -175,7 +188,14 @@ onMounted(async () => {
         <div class="h-px w-full border-b border-gray-100" />
         <ConnectSection
           :title="$t('platform.section.subTitle.regOfficeAttSvcAddrress')"
-          :error="hasFormErrors(platformBusinessFormRef, ['regOfficeOrAtt'])"
+          :error="hasFormErrors(platformBusinessFormRef, [
+            'hasRegOffAtt',
+            'regOfficeOrAtt.mailingAddress.country',
+            'regOfficeOrAtt.mailingAddress.street',
+            'regOfficeOrAtt.mailingAddress.city',
+            'regOfficeOrAtt.mailingAddress.region',
+            'regOfficeOrAtt.mailingAddress.postalCode'
+          ])"
         >
           <div class="max-w-bcGovInput space-y-5">
             <UFormGroup id="platform-business-hasRegOffAtt" name="hasRegOffAtt">

--- a/strr-platform-web/app/components/form/platform/BusinessDetails.vue
+++ b/strr-platform-web/app/components/form/platform/BusinessDetails.vue
@@ -46,6 +46,15 @@ watch(() => platformBusiness.value.hasRegOffAtt,
       // @ts-expect-error - ts doesnt recognize key type
         platformBusiness.value.regOfficeOrAtt.mailingAddress[key] = ''
       })
+
+      // revalidate fields to update/remove form errors
+      platformBusinessFormRef.value?.validate([
+        'regOfficeOrAtt.mailingAddress.country',
+        'regOfficeOrAtt.mailingAddress.street',
+        'regOfficeOrAtt.mailingAddress.city',
+        'regOfficeOrAtt.mailingAddress.region',
+        'regOfficeOrAtt.mailingAddress.postalCode'
+      ], { silent: true })
     }
   }
 )

--- a/strr-platform-web/app/components/form/platform/BusinessDetails.vue
+++ b/strr-platform-web/app/components/form/platform/BusinessDetails.vue
@@ -1,83 +1,43 @@
 <script setup lang="ts">
+import type { Form } from '#ui/types'
 const { t } = useI18n()
-const tPlat = (path: string) => t(`platform.${path}`)
-
-const { isComplete } = defineProps<{ isComplete: boolean }>()
-
 const { getBusinessSchema } = useStrrPlatformBusiness()
 const { platformBusiness } = storeToRefs(useStrrPlatformBusiness())
 
+const props = defineProps<{ isComplete: boolean }>()
+
+// cant set form schema type as businessDetailsSchema is a computed property
+const platformBusinessFormRef = ref<Form<any>>()
+
 const getRadioOptions = () => [
   { value: true, label: t('word.Yes') },
-  { value: false, label: t('word.No') }]
+  { value: false, label: t('word.No') }
+]
 
-// data manipulation stuff
-
+// reset cpbcLicenceNumber if hasCpbc radio button changed
 watch(() => platformBusiness.value.hasCpbc, () => {
   platformBusiness.value.cpbcLicenceNumber = ''
 })
 
-const businessdetailsSchema = computed(() => getBusinessSchema(
-  platformBusiness.value.hasCpbc, platformBusiness.value.hasRegOffAtt))
-
-watch(() => platformBusiness.value.regOfficeOrAtt.sameAsMailAddress, (val) => {
-  if (val) {
+// manage regOfficeOrAtt
+watchEffect(() => {
+  // set regOfficeOrAtt.mailingAddress to match business mailing address if sameAsMailAddress checkbox checked
+  if (platformBusiness.value.regOfficeOrAtt.sameAsMailAddress) {
     platformBusiness.value.regOfficeOrAtt.mailingAddress = { ...platformBusiness.value.mailingAddress }
   }
+
+  // reset regOfficeOrAtt if hasRegOffAtt radio set to false
+  if (platformBusiness.value.hasRegOffAtt === false) {
+    platformBusiness.value.regOfficeOrAtt.attorneyName = ''
+    platformBusiness.value.regOfficeOrAtt.sameAsMailAddress = false
+    Object.keys(platformBusiness.value.regOfficeOrAtt.mailingAddress).forEach((key) => {
+      // @ts-expect-error - ts doesnt recognize key type
+      platformBusiness.value.regOfficeOrAtt.mailingAddress[key] = ''
+    })
+  }
 })
-watch(() => platformBusiness.value.mailingAddress, (val) => {
-  if (platformBusiness.value.regOfficeOrAtt.sameAsMailAddress) {
-    platformBusiness.value.regOfficeOrAtt.mailingAddress = { ...val }
-  }
-}, { deep: true })
-
-// form validation / error styling
-
-const showErrorBusIds = ref(false)
-const showErrorBusAddr = ref(false)
-const showErrorRegOffAtt = ref(false)
-const showErrorNonComp = ref(false)
-const showErrorTakedownReq = ref(false)
-
-const platformBusinessRef = ref()
-
-const formHasErrors = (paths: string[]) => {
-  for (const path of paths) {
-    // @ts-ignore
-    if (platformBusinessRef.value.getErrors(path)?.length) {
-      return true
-    }
-  }
-  return false
-}
-
-const validateForm = async () => {
-  if (platformBusinessRef.value && isComplete) {
-    try {
-      await platformBusinessRef.value.validate()
-    } catch (e) {
-      console.info(e)
-    }
-    showErrorBusIds.value = platformBusiness.value.hasCpbc === undefined ||
-      formHasErrors(['legalName', 'homeJurisdiction', 'cpbcLicenceNumber'])
-    showErrorBusAddr.value = formHasErrors([
-      'mailingAddress.country',
-      'mailingAddress.street',
-      'mailingAddress.city',
-      'mailingAddress.region',
-      'mailingAddress.postalCode'
-    ])
-    showErrorRegOffAtt.value = formHasErrors(['regOfficeOrAtt'])
-    showErrorNonComp.value = formHasErrors(['nonComplianceEmail'])
-    showErrorTakedownReq.value = formHasErrors(['takeDownEmail'])
-  }
-}
-
-watch(platformBusinessRef, validateForm)
-watch(platformBusiness, validateForm, { deep: true })
 
 // address stuff
-
 const {
   activeAddressField,
   address: canadaPostAddress,
@@ -92,23 +52,51 @@ const activeAddressPath = computed(() => {
 })
 
 watch(canadaPostAddress, (newAddress) => {
-  platformBusinessRef.value.clear(`${activeAddressPath.value}.city`)
-  platformBusinessRef.value.clear(`${activeAddressPath.value}.region`)
-  platformBusinessRef.value.clear(`${activeAddressPath.value}.postalCode`)
-  if (newAddress && activeAddressPath.value === 'mailingAddress') {
-    platformBusiness.value.mailingAddress.street = newAddress.street
-    platformBusiness.value.mailingAddress.streetAdditional = newAddress.streetAdditional
-    platformBusiness.value.mailingAddress.country = newAddress.country
-    platformBusiness.value.mailingAddress.city = newAddress.city
-    platformBusiness.value.mailingAddress.region = newAddress.region
-    platformBusiness.value.mailingAddress.postalCode = newAddress.postalCode
-  } else if (newAddress) {
-    platformBusiness.value.regOfficeOrAtt.mailingAddress.street = newAddress.street
-    platformBusiness.value.regOfficeOrAtt.mailingAddress.streetAdditional = newAddress.streetAdditional
-    platformBusiness.value.regOfficeOrAtt.mailingAddress.country = newAddress.country
-    platformBusiness.value.regOfficeOrAtt.mailingAddress.city = newAddress.city
-    platformBusiness.value.regOfficeOrAtt.mailingAddress.region = newAddress.region
-    platformBusiness.value.regOfficeOrAtt.mailingAddress.postalCode = newAddress.postalCode
+  if (platformBusinessFormRef.value) {
+    // reset form validation for city/region/postalCode if address is changed
+    platformBusinessFormRef.value.clear(`${activeAddressPath.value}.city`)
+    platformBusinessFormRef.value.clear(`${activeAddressPath.value}.region`)
+    platformBusinessFormRef.value.clear(`${activeAddressPath.value}.postalCode`)
+    if (newAddress && activeAddressPath.value === 'mailingAddress') {
+      platformBusiness.value.mailingAddress.street = newAddress.street
+      platformBusiness.value.mailingAddress.streetAdditional = newAddress.streetAdditional
+      platformBusiness.value.mailingAddress.country = newAddress.country
+      platformBusiness.value.mailingAddress.city = newAddress.city
+      platformBusiness.value.mailingAddress.region = newAddress.region
+      platformBusiness.value.mailingAddress.postalCode = newAddress.postalCode
+    } else if (newAddress) {
+      platformBusiness.value.regOfficeOrAtt.mailingAddress.street = newAddress.street
+      platformBusiness.value.regOfficeOrAtt.mailingAddress.streetAdditional = newAddress.streetAdditional
+      platformBusiness.value.regOfficeOrAtt.mailingAddress.country = newAddress.country
+      platformBusiness.value.regOfficeOrAtt.mailingAddress.city = newAddress.city
+      platformBusiness.value.regOfficeOrAtt.mailingAddress.region = newAddress.region
+      platformBusiness.value.regOfficeOrAtt.mailingAddress.postalCode = newAddress.postalCode
+    }
+  }
+})
+
+onMounted(async () => {
+  // validate form if step marked as complete
+  if (props.isComplete) {
+    // validate all form refs
+    const validations = [
+      validateForm(platformBusinessFormRef.value, props.isComplete)
+    ]
+    await Promise.all(validations) // remove this if adding the scroll into view stuff
+
+    // TODO: implement ?
+    // disabled scrolling to errors as validation results must be sorted
+    // in order to match the form input order for the first element to be consistently correct
+
+    // get all errors and filter out undefined results (conditional form may return undefined if not mounted)
+    // const validationResults = (await Promise.all(validations)).filter(item => item !== undefined)
+
+    // if (validationResults.length > 0) {
+    //   const firstError = validationResults[0]?.[0]?.path // get first error found
+    //   if (firstError) {
+    //     focusAndScrollToInputByName(firstError)
+    //   }
+    // }
   }
 })
 </script>
@@ -117,45 +105,50 @@ watch(canadaPostAddress, (newAddress) => {
   <div data-testid="business-details">
     <ConnectPageSection
       class="bg-white"
-      :heading="{ label: tPlat('section.title.businessInfo'), labelClass: 'font-bold md:ml-6' }"
+      :heading="{ label: $t('platform.section.title.businessInfo'), labelClass: 'font-bold md:ml-6' }"
     >
       <UForm
-        ref="platformBusinessRef"
-        :schema="businessdetailsSchema"
+        ref="platformBusinessFormRef"
+        :schema="getBusinessSchema()"
         :state="platformBusiness"
         class="space-y-10 py-10"
       >
-        <ConnectSection :title="tPlat('section.subTitle.businessIds')" :error="showErrorBusIds">
+        <ConnectSection
+          :title="$t('platform.section.subTitle.businessIds')"
+          :error="isComplete && (platformBusiness.hasCpbc === undefined ||
+            hasFormErrors(platformBusinessFormRef, ['legalName', 'homeJurisdiction', 'cpbcLicenceNumber']))
+          "
+        >
           <div class="space-y-5">
             <ConnectFieldGroup
               id="platform-business-legal-name"
               v-model="platformBusiness.legalName"
-              :aria-label="t('label.busNameLegal')"
-              :help="tPlat('hint.businessLegalName')"
+              :aria-label="$t('label.busNameLegal')"
+              :help="$t('platform.hint.businessLegalName')"
               name="legalName"
               :placeholder="t('label.busNameLegal')"
             />
             <ConnectFieldGroup
               id="platform-business-home-jur"
               v-model="platformBusiness.homeJurisdiction"
-              :aria-label="t('label.homeJurisdiction')"
-              :help="tPlat('hint.humeJurisdiction')"
+              :aria-label="$t('label.homeJurisdiction')"
+              :help="$t('platform.hint.humeJurisdiction')"
               name="homeJurisdiction"
               :placeholder="t('label.homeJurisdiction')"
             />
             <ConnectFieldGroup
               id="platform-business-number"
               v-model="platformBusiness.businessNumber"
-              :aria-label="t('label.busNumOpt')"
+              :aria-label="$t('label.busNumOpt')"
               name="businessNumber"
-              :placeholder="t('label.busNumOpt')"
+              :placeholder="$t('label.busNumOpt')"
             />
             <UFormGroup id="platform-business-hasCpbc" name="hasCpbc">
               <URadioGroup
                 v-model="platformBusiness.hasCpbc"
                 class="p-2"
                 :class="isComplete && platformBusiness.hasCpbc === undefined ? 'border-red-600 border-2' : ''"
-                :legend="tPlat('text.hasCpbc')"
+                :legend="$t('platform.text.hasCpbc')"
                 :options="getRadioOptions()"
                 :ui="{ legend: 'mb-3 text-default font-bold text-gray-700' }"
                 :ui-radio="{ inner: 'space-y-2' }"
@@ -165,14 +158,23 @@ watch(canadaPostAddress, (newAddress) => {
               v-if="platformBusiness.hasCpbc"
               id="platform-cpbc"
               v-model="platformBusiness.cpbcLicenceNumber"
-              :aria-label="t('label.cpbcLicNum')"
+              :aria-label="$t('label.cpbcLicNum')"
               name="cpbcLicenceNumber"
-              :placeholder="t('label.cpbcLicNum')"
+              :placeholder="$t('label.cpbcLicNum')"
             />
           </div>
         </ConnectSection>
         <div class="h-px w-full border-b border-gray-100" />
-        <ConnectSection :title="tPlat('section.subTitle.businessMailAddress')" :error="showErrorBusAddr">
+        <ConnectSection
+          :title="$t('platform.section.subTitle.businessMailAddress')"
+          :error="hasFormErrors(platformBusinessFormRef, [
+            'mailingAddress.country',
+            'mailingAddress.street',
+            'mailingAddress.city',
+            'mailingAddress.region',
+            'mailingAddress.postalCode'
+          ])"
+        >
           <div class="max-w-bcGovInput">
             <ConnectAddress
               id="platform-business-address"
@@ -189,14 +191,17 @@ watch(canadaPostAddress, (newAddress) => {
           </div>
         </ConnectSection>
         <div class="h-px w-full border-b border-gray-100" />
-        <ConnectSection :title="tPlat('section.subTitle.regOfficeAttSvcAddrress')" :error="showErrorRegOffAtt">
+        <ConnectSection
+          :title="$t('platform.section.subTitle.regOfficeAttSvcAddrress')"
+          :error="hasFormErrors(platformBusinessFormRef, ['regOfficeOrAtt'])"
+        >
           <div class="max-w-bcGovInput space-y-5">
             <UFormGroup id="platform-business-hasRegOffAtt" name="hasRegOffAtt">
               <URadioGroup
                 v-model="platformBusiness.hasRegOffAtt"
                 class="p-2"
                 :class="isComplete && platformBusiness.hasRegOffAtt === undefined ? 'border-red-600 border-2' : ''"
-                :legend="tPlat('text.regOffOrAtt')"
+                :legend="$t('platform.text.regOffOrAtt')"
                 :options="getRadioOptions()"
                 :ui="{ legend: 'mb-3 text-default font-bold text-gray-700' }"
                 :ui-radio="{ inner: 'space-y-2' }"
@@ -233,44 +238,50 @@ watch(canadaPostAddress, (newAddress) => {
           </div>
         </ConnectSection>
         <div class="h-px w-full border-b border-gray-100" />
-        <ConnectSection :title="tPlat('section.subTitle.noticeNonCompliance')" :error="showErrorNonComp">
+        <ConnectSection
+          :title="$t('platform.section.subTitle.noticeNonCompliance')"
+          :error="hasFormErrors(platformBusinessFormRef, ['nonComplianceEmail'])"
+        >
           <div class="space-y-5">
             <p>
-              {{ tPlat('text.nonComplianceEmail') }}
+              {{ $t('platform.text.nonComplianceEmail') }}
             </p>
             <ConnectFieldGroup
               id="platform-business-noncompliance-email"
               v-model="platformBusiness.nonComplianceEmail"
-              :aria-label="t('label.emailAddress')"
+              :aria-label="$t('label.emailAddress')"
               name="nonComplianceEmail"
-              :placeholder="t('label.emailAddress')"
+              :placeholder="$t('label.emailAddress')"
             />
             <ConnectFieldGroup
               id="platform-business-noncompliance-email-optional"
               v-model="platformBusiness.nonComplianceEmailOptional"
-              :aria-label="t('label.emailAddressOpt')"
+              :aria-label="$t('label.emailAddressOpt')"
               name="nonComplianceEmailOptional"
-              :placeholder="t('label.emailAddressOpt')"
+              :placeholder="$t('label.emailAddressOpt')"
             />
           </div>
         </ConnectSection>
         <div class="h-px w-full border-b border-gray-100" />
-        <ConnectSection :title="tPlat('section.subTitle.takedownRequest')" :error="showErrorTakedownReq">
+        <ConnectSection
+          :title="$t('platform.section.subTitle.takedownRequest')"
+          :error="hasFormErrors(platformBusinessFormRef, ['takeDownEmail'])"
+        >
           <div class="space-y-5">
-            <p>{{ tPlat('text.takedownEmail') }}</p>
+            <p>{{ $t('platform.text.takedownEmail') }}</p>
             <ConnectFieldGroup
               id="platform-business-takedown-email"
               v-model="platformBusiness.takeDownEmail"
-              :aria-label="t('label.emailAddress')"
+              :aria-label="$t('label.emailAddress')"
               name="takeDownEmail"
-              :placeholder="t('label.emailAddress')"
+              :placeholder="$t('label.emailAddress')"
             />
             <ConnectFieldGroup
               id="platform-business-takedown-email-optional"
               v-model="platformBusiness.takeDownEmailOptional"
-              :aria-label="t('label.emailAddressOpt')"
+              :aria-label="$t('label.emailAddressOpt')"
               name="takeDownEmailOptional"
-              :placeholder="t('label.emailAddressOpt')"
+              :placeholder="$t('label.emailAddressOpt')"
             />
           </div>
         </ConnectSection>

--- a/strr-platform-web/app/components/form/platform/BusinessDetails.vue
+++ b/strr-platform-web/app/components/form/platform/BusinessDetails.vue
@@ -78,25 +78,7 @@ watch(canadaPostAddress, (newAddress) => {
 onMounted(async () => {
   // validate form if step marked as complete
   if (props.isComplete) {
-    // validate all form refs
-    const validations = [
-      validateForm(platformBusinessFormRef.value, props.isComplete)
-    ]
-    await Promise.all(validations) // remove this if adding the scroll into view stuff
-
-    // TODO: implement ?
-    // disabled scrolling to errors as validation results must be sorted
-    // in order to match the form input order for the first element to be consistently correct
-
-    // get all errors and filter out undefined results (conditional form may return undefined if not mounted)
-    // const validationResults = (await Promise.all(validations)).filter(item => item !== undefined)
-
-    // if (validationResults.length > 0) {
-    //   const firstError = validationResults[0]?.[0]?.path // get first error found
-    //   if (firstError) {
-    //     focusAndScrollToInputByName(firstError)
-    //   }
-    // }
+    await validateForm(platformBusinessFormRef.value, props.isComplete)
   }
 })
 </script>

--- a/strr-platform-web/app/components/form/platform/ContactInfo.vue
+++ b/strr-platform-web/app/components/form/platform/ContactInfo.vue
@@ -46,7 +46,7 @@ onMounted(async () => {
     ]
     await Promise.all(validations) // remove this if adding the scroll into view stuff
 
-    // TODO: implement ?
+    // TODO: implement ? leaving this here for reference
     // disabled scrolling to errors as validation results must be sorted
     // in order to match the form input order for the first element to be consistently correct
 

--- a/strr-platform-web/app/components/form/platform/ContactInfo.vue
+++ b/strr-platform-web/app/components/form/platform/ContactInfo.vue
@@ -36,7 +36,7 @@ watch(isCompletingPartyRep, (val) => {
 })
 
 onMounted(async () => {
-  // only try to validate if step marked as complete
+  // validate form if step marked as complete
   if (props.isComplete) {
     // validate all form refs
     const validations = [
@@ -44,16 +44,21 @@ onMounted(async () => {
       validateForm(primaryRepFormRef.value, props.isComplete),
       validateForm(secondaryRepFormRef.value, props.isComplete)
     ]
+    await Promise.all(validations) // remove this if adding the scroll into view stuff
+
+    // TODO: implement ?
+    // disabled scrolling to errors as validation results must be sorted
+    // in order to match the form input order for the first element to be consistently correct
 
     // get all errors and filter out undefined results (secondary rep form validate might return undefined)
-    const validationResults = (await Promise.all(validations)).filter(item => item !== undefined)
+    // const validationResults = (await Promise.all(validations)).filter(item => item !== undefined)
 
-    if (validationResults.length > 0) {
-      const firstError = validationResults[0]?.[0]?.path // get first error found
-      if (firstError) {
-        focusAndScrollToInputByName(firstError)
-      }
-    }
+    // if (validationResults.length > 0) {
+    //   const firstError = validationResults[0]?.[0]?.path // get first error found
+    //   if (firstError) {
+    //     focusAndScrollToInputByName(firstError)
+    //   }
+    // }
   }
 })
 </script>

--- a/strr-platform-web/app/components/form/platform/Details.vue
+++ b/strr-platform-web/app/components/form/platform/Details.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 const { t } = useI18n()
-const tPlat = (path: string) => t(`platform.${path}`)
+const { addNewEmptyBrand, getPlatformBrandSchema, removeBrandAtIndex, getPlatformDetailsSchema } = useStrrPlatformDetails()
+const { platformDetails } = storeToRefs(useStrrPlatformDetails())
 
 const { isComplete } = defineProps<{ isComplete: boolean }>()
 
-const { addNewEmptyBrand, getPlatformBrandSchema, removeBrandAtIndex } = useStrrPlatformDetails()
-const { platformDetails } = storeToRefs(useStrrPlatformDetails())
+const tPlat = (path: string) => t(`platform.${path}`)
+const radioOptions = [
+  { value: ListingSize.THOUSAND_OR_MORE, label: tPlat('text.thousandOrMore') },
+  { value: ListingSize.UNDER_THOUSAND, label: tPlat('text.lessThanThousand') }]
 
 const validateBrand = (index: number, field: 'name' | 'website', isBlur = false) => {
   if (platformDetails.value.brands[index]) {
@@ -30,11 +33,6 @@ onMounted(() => {
     }
   }
 })
-
-const radioOptions = [
-  { value: ListingSize.THOUSAND_OR_MORE, label: tPlat('text.thousandOrMore') },
-  { value: ListingSize.UNDER_THOUSAND, label: tPlat('text.lessThanThousand') }]
-
 </script>
 
 <template>

--- a/strr-platform-web/app/components/form/platform/Details.vue
+++ b/strr-platform-web/app/components/form/platform/Details.vue
@@ -1,36 +1,22 @@
 <script setup lang="ts">
+import type { Form } from '#ui/types'
+import { z } from 'zod'
 const { t } = useI18n()
-const { addNewEmptyBrand, getPlatformBrandSchema, removeBrandAtIndex, getPlatformDetailsSchema } = useStrrPlatformDetails()
+const { addNewEmptyBrand, removeBrandAtIndex, platformDetailSchema } = useStrrPlatformDetails()
 const { platformDetails } = storeToRefs(useStrrPlatformDetails())
 
-const { isComplete } = defineProps<{ isComplete: boolean }>()
+const props = defineProps<{ isComplete: boolean }>()
 
-const tPlat = (path: string) => t(`platform.${path}`)
+const platformDetailsFormRef = ref<Form<z.output<typeof platformDetailSchema>>>()
 const radioOptions = [
-  { value: ListingSize.THOUSAND_OR_MORE, label: tPlat('text.thousandOrMore') },
-  { value: ListingSize.UNDER_THOUSAND, label: tPlat('text.lessThanThousand') }]
+  { value: ListingSize.THOUSAND_OR_MORE, label: t('platform.text.thousandOrMore') },
+  { value: ListingSize.UNDER_THOUSAND, label: t('platform.text.lessThanThousand') }
+]
 
-const validateBrand = (index: number, field: 'name' | 'website', isBlur = false) => {
-  if (platformDetails.value.brands[index]) {
-    const existingErrors = platformDetails.value.brands[index].errors
-    const errors = getPlatformBrandSchema().safeParse(platformDetails.value.brands[index]).error?.format()
-    if (!isBlur && !isComplete && errors?.[field]?._errors && !existingErrors?.[field]) {
-      // only update the error message if one already exists (otherwise allow user to finish typing)
-      return
-    }
-    platformDetails.value.brands[index].errors = {
-      ...(platformDetails.value.brands[index].errors || {}),
-      [field]: errors?.[field]?._errors[0]
-    }
-  }
-}
-
-onMounted(() => {
-  if (isComplete) {
-    for (const i in platformDetails.value.brands) {
-      validateBrand(Number(i), 'name', true)
-      validateBrand(Number(i), 'website', true)
-    }
+onMounted(async () => {
+  // validate form if step marked as complete
+  if (props.isComplete) {
+    await validateForm(platformDetailsFormRef.value, props.isComplete)
   }
 })
 </script>
@@ -39,17 +25,21 @@ onMounted(() => {
   <div data-testid="platform-details">
     <ConnectPageSection
       class="bg-white"
-      :heading="{ label: tPlat('section.title.details'), labelClass: 'font-bold md:ml-6' }"
+      :heading="{ label: $t('platform.section.title.details'), labelClass: 'font-bold md:ml-6' }"
     >
-      <div class="space-y-10 py-10">
+      <UForm
+        ref="platformDetailsFormRef"
+        :schema="platformDetailSchema"
+        :state="platformDetails"
+        class="space-y-10 py-10"
+      >
         <div
           v-for="brand, i in platformDetails.brands"
           :key="'brand' + i"
         >
           <ConnectSection
-            :title="tPlat('section.subTitle.brand') + ((i > 0) ? ` ${ i + 1 }` : '')"
-            :error="isComplete && !!(platformDetails.brands[i]?.errors?.name
-              || platformDetails.brands[i]?.errors?.website)"
+            :title="$t('platform.section.subTitle.brand') + ((i > 0) ? ` ${ i + 1 }` : '')"
+            :error="hasFormErrors(platformDetailsFormRef, [`brands.${i}.name`, `brands.${i}.website`])"
           >
             <div class="space-y-5">
               <div class="flex flex-col gap-5 sm:flex-row-reverse">
@@ -66,39 +56,33 @@ onMounted(() => {
                 </div>
                 <div class="grow space-y-5">
                   <UFormGroup
-                    :aria-label="(i > 0) ? tPlat('label.brandNameOpt') : tPlat('label.brandName')"
-                    :help="tPlat('hint.brandName')"
-                    :name="`brands.${i}.brandName`"
-                    :error="brand.errors?.name"
+                    :aria-label="(i > 0) ? $t('platform.label.brandNameOpt') : $t('platform.label.brandName')"
+                    :help="$t('platform.hint.brandName')"
+                    :name="`brands.${i}.name`"
                   >
                     <ConnectField
                       :id="'platform-brand-name-' + i"
                       v-model="brand.name"
-                      :placeholder="(i > 0) ? tPlat('label.brandNameOpt') : tPlat('label.brandName')"
-                      @blur="validateBrand(i, 'name', true)"
-                      @input="validateBrand(i, 'name', false)"
+                      :placeholder="(i > 0) ? $t('platform.label.brandNameOpt') : $t('platform.label.brandName')"
                     />
                   </UFormGroup>
                   <UFormGroup
-                    :aria-label="(i > 0) ? tPlat('label.brandSiteOpt') : tPlat('label.brandSite')"
-                    :help="tPlat('hint.brandSite')"
+                    :aria-label="(i > 0) ? $t('platform.label.brandSiteOpt') : $t('platform.label.brandSite')"
+                    :help="$t('platform.hint.brandSite')"
                     :name="`brands.${i}.website`"
-                    :error="brand.errors?.website"
                   >
                     <ConnectField
                       :id="'platform-brand-site-' + i"
                       v-model="brand.website"
                       name="website"
-                      :placeholder="(i > 0) ? tPlat('label.brandSiteOpt') : tPlat('label.brandSite')"
-                      @blur="validateBrand(i, 'website', true)"
-                      @input="validateBrand(i, 'website', false)"
+                      :placeholder="(i > 0) ? $t('platform.label.brandSiteOpt') : $t('platform.label.brandSite')"
                     />
                   </UFormGroup>
                 </div>
               </div>
               <UButton
                 v-if="i === platformDetails.brands.length - 1"
-                :label="tPlat('label.addBrand')"
+                :label="$t('platform.label.addBrand')"
                 class="px-5 py-3"
                 color="primary"
                 icon="i-mdi-domain-plus"
@@ -109,18 +93,23 @@ onMounted(() => {
           </ConnectSection>
         </div>
         <div class="h-px w-full border-b border-gray-100" />
-        <ConnectSection :title="tPlat('section.subTitle.size')" :error="isComplete && !platformDetails.listingSize">
-          <URadioGroup
-            v-model="platformDetails.listingSize"
-            class="p-1"
-            :class="isComplete && !platformDetails.listingSize ? 'border-red-600 border-2' : ''"
-            :legend="tPlat('text.listingSize')"
-            :options="radioOptions"
-            :ui="{ legend: 'mb-3 text-default font-bold text-gray-700' }"
-            :ui-radio="{ inner: 'space-y-2' }"
-          />
+        <ConnectSection
+          :title="$t('platform.section.subTitle.size')"
+          :error="hasFormErrors(platformDetailsFormRef, ['listingSize'])"
+        >
+          <UFormGroup name="listingSize">
+            <URadioGroup
+              v-model="platformDetails.listingSize"
+              class="p-1"
+              :class="hasFormErrors(platformDetailsFormRef, ['listingSize']) ? 'border-red-600 border-2' : ''"
+              :legend="$t('platform.text.listingSize')"
+              :options="radioOptions"
+              :ui="{ legend: 'mb-3 text-default font-bold text-gray-700' }"
+              :ui-radio="{ inner: 'space-y-2' }"
+            />
+          </UFormGroup>
         </ConnectSection>
-      </div>
+      </UForm>
     </ConnectPageSection>
   </div>
 </template>

--- a/strr-platform-web/app/composables/useStrrModals.ts
+++ b/strr-platform-web/app/composables/useStrrModals.ts
@@ -5,12 +5,13 @@ export const useStrrModals = () => {
   const modal = useModal()
   const { t } = useI18n()
 
-  function openAppSubmitError () {
+  function openAppSubmitError (e: any) {
     modal.open(ModalBase, {
       error: {
         title: 'Error submitting application', // need to come up with different error messages for different scenarios
         description: 'Some description here.'
       },
+      content: `Do something with errors: ${JSON.stringify(e)}`,
       actions: [{ label: t('btn.close'), handler: () => close() }]
     })
   }

--- a/strr-platform-web/app/interfaces/step.ts
+++ b/strr-platform-web/app/interfaces/step.ts
@@ -3,6 +3,7 @@ export interface Step {
   icon?: string
   complete: boolean
   isValid: boolean
+  validationFn?: () => boolean | Promise<boolean>
   // below can be ommitted if using i18nPrefix + icon
   alt?: string
   activeIconPath?: string

--- a/strr-platform-web/app/interfaces/validation.ts
+++ b/strr-platform-web/app/interfaces/validation.ts
@@ -1,0 +1,7 @@
+import type { ZodIssue } from 'zod'
+
+export type MultiFormValidationResult = {
+  formId: string
+  success: boolean
+  errors: ZodIssue[]
+}[]

--- a/strr-platform-web/app/pages/platform/application.vue
+++ b/strr-platform-web/app/pages/platform/application.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ConnectFeeCode, ConnectFeeEntityType, type ConnectFeeItem, type Step } from '#imports'
 import type { ConnectBtnControlItem } from '~/interfaces/connect-btn-control/item-i'
 import { FormPlatformContactInfo, ConnectStepper } from '#components'
 
@@ -7,6 +6,7 @@ const { t } = useI18n()
 
 const { validatePlatformContact } = useStrrPlatformContact()
 const { validatePlatformBusiness } = useStrrPlatformBusiness()
+const { validatePlatformDetails } = useStrrPlatformDetails()
 const { submitPlatformApplication } = useStrrPlatformApplication()
 // fee stuff
 const { addReplaceFee, getFee, removeFee, setPlaceholderFilingTypeCode, setPlaceholderServiceFee } = useConnectFee()
@@ -87,7 +87,8 @@ const steps = ref<Step[]>([
     i18nPrefix: 'platform.step',
     icon: 'i-mdi-earth',
     complete: false,
-    isValid: false
+    isValid: false,
+    validationFn: async () => await validatePlatformDetails(true) as boolean
   },
   {
     i18nPrefix: 'platform.step',

--- a/strr-platform-web/app/pages/platform/application.vue
+++ b/strr-platform-web/app/pages/platform/application.vue
@@ -154,6 +154,7 @@ const handlePlatformSubmit = async () => {
     }
   } catch (e) {
     logFetchError(e, 'Error creating platform application')
+    // TODO: handle backend errors
   } finally {
     // set buttons back to non loading state
     setButtonControl({

--- a/strr-platform-web/app/pages/platform/application.vue
+++ b/strr-platform-web/app/pages/platform/application.vue
@@ -6,6 +6,7 @@ import { FormPlatformContactInfo, ConnectStepper } from '#components'
 const { t } = useI18n()
 
 const { validatePlatformContact } = useStrrPlatformContact()
+const { validatePlatformBusiness } = useStrrPlatformBusiness()
 const { submitPlatformApplication } = useStrrPlatformApplication()
 // fee stuff
 const { addReplaceFee, getFee, removeFee, setPlaceholderFilingTypeCode, setPlaceholderServiceFee } = useConnectFee()
@@ -79,7 +80,8 @@ const steps = ref<Step[]>([
     i18nPrefix: 'platform.step',
     icon: 'i-mdi-domain-plus',
     complete: false,
-    isValid: false
+    isValid: false,
+    validationFn: async () => await validatePlatformBusiness(true) as boolean
   },
   {
     i18nPrefix: 'platform.step',

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -12,6 +12,7 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
     confirmDelistAndCancelBookings: false
   })
 
+  // TODO: add validation messages
   const getConfirmationSchema = () => z.object({
     confirmInfoAccuracy: z.literal(true),
     confirmDelistAndCancelBookings: z.literal(true)
@@ -62,10 +63,14 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
 
     console.info('submitting application: ', body)
 
-    return await $strrApi('/applications', {
+    const response = await $strrApi('/applications', {
       method: 'POST',
       body
     })
+
+    console.info('strr api response: ', response)
+
+    return response
   }
 
   return {

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -1,9 +1,10 @@
 export const useStrrPlatformApplication = defineStore('strr/platformApplication', () => {
   // const { $strrApi } = useNuxtApp()
-  const { platformDetails } = storeToRefs(useStrrPlatformDetails())
+  // const { platformDetails } = storeToRefs(useStrrPlatformDetails())
   const strrModal = useStrrModals()
   const platContactStore = useStrrPlatformContact()
   const platBusinessStore = useStrrPlatformBusiness()
+  const platDetailsStore = useStrrPlatformDetails()
 
   const confirmInfoAccuracy = ref(false)
   const confirmDelistAndCancelBookings = ref(false)
@@ -15,7 +16,7 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
         completingParty: formatParty(platContactStore.completingParty),
         platformRepresentatives: [],
         businessDetails: formatBusinessDetails(platBusinessStore.platformBusiness),
-        platformDetails: formatPlatformDetails(platformDetails.value)
+        platformDetails: formatPlatformDetails(platDetailsStore.platformDetails)
       }
     }
 
@@ -38,9 +39,11 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
     try {
       const contactResults = await platContactStore.validatePlatformContact()
       const businessResults = await platBusinessStore.validatePlatformBusiness()
+      const detailsResults = await platDetailsStore.validatePlatformDetails()
 
       console.info('contact validations: ', contactResults)
       console.info('business validations: ', businessResults)
+      console.info('details validations: ', detailsResults)
 
       const body = createApplicationBody()
 

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -1,10 +1,9 @@
 export const useStrrPlatformApplication = defineStore('strr/platformApplication', () => {
   // const { $strrApi } = useNuxtApp()
-  const { completingParty, primaryRep, secondaryRep } = storeToRefs(useStrrPlatformContact())
-  const { platformBusiness } = storeToRefs(useStrrPlatformBusiness())
   const { platformDetails } = storeToRefs(useStrrPlatformDetails())
   const strrModal = useStrrModals()
   const platContactStore = useStrrPlatformContact()
+  const platBusinessStore = useStrrPlatformBusiness()
 
   const confirmInfoAccuracy = ref(false)
   const confirmDelistAndCancelBookings = ref(false)
@@ -13,22 +12,22 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
     const applicationBody: PlatformApplicationPayload = {
       registration: {
         registrationType: ApplicationType.PLATFORM,
-        completingParty: formatParty(completingParty.value),
+        completingParty: formatParty(platContactStore.completingParty),
         platformRepresentatives: [],
-        businessDetails: formatBusinessDetails(platformBusiness.value),
+        businessDetails: formatBusinessDetails(platBusinessStore.platformBusiness),
         platformDetails: formatPlatformDetails(platformDetails.value)
       }
     }
 
-    if (primaryRep.value !== undefined) {
+    if (platContactStore.primaryRep !== undefined) {
       applicationBody.registration.platformRepresentatives.push(
-        formatRepresentative(primaryRep.value)
+        formatRepresentative(platContactStore.primaryRep)
       )
     }
 
-    if (secondaryRep.value !== undefined) {
+    if (platContactStore.secondaryRep !== undefined) {
       applicationBody.registration.platformRepresentatives.push(
-        formatRepresentative(secondaryRep.value)
+        formatRepresentative(platContactStore.secondaryRep)
       )
     }
 
@@ -37,9 +36,11 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
 
   async function submitPlatformApplication () {
     try {
-      const results = await platContactStore.validatePlatformContact()
+      const contactResults = await platContactStore.validatePlatformContact()
+      const businessResults = await platBusinessStore.validatePlatformBusiness()
 
-      console.info('platform contact info results: ', results)
+      console.info('contact validations: ', contactResults)
+      console.info('business validations: ', businessResults)
 
       const body = createApplicationBody()
 

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -12,7 +12,7 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
     confirmDelistAndCancelBookings: false
   })
 
-  // TODO: add validation messages
+  // TODO: add validation messages - will add in future pr
   const getConfirmationSchema = () => z.object({
     confirmInfoAccuracy: z.literal(true),
     confirmDelistAndCancelBookings: z.literal(true)

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import type { MultiFormValidationResult } from '~/interfaces/validation'
 
 export const useStrrPlatformApplication = defineStore('strr/platformApplication', () => {
-  // const { $strrApi } = useNuxtApp()
+  const { $strrApi } = useNuxtApp()
   const platContactStore = useStrrPlatformContact()
   const platBusinessStore = useStrrPlatformBusiness()
   const platDetailsStore = useStrrPlatformDetails()
@@ -21,7 +21,7 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
 
   const validatePlatformConfirmation = (returnBool = false): MultiFormValidationResult | boolean => {
     const result = validateSchemaAgainstState(
-      getConfirmationSchema(), platformConfirmation, 'platform-confirmation-form'
+      platformConfirmationSchema, platformConfirmation, 'platform-confirmation-form'
     )
 
     if (returnBool) {
@@ -61,18 +61,16 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
     const body = createApplicationBody()
 
     console.info('submitting application: ', body)
-    // await $strrApi('/applications', {
-    //   method: 'POST',
-    //   body
-    // })
+
+    return await $strrApi('/applications', {
+      method: 'POST',
+      body
+    })
   }
 
   return {
     platformConfirmation,
     platformConfirmationSchema,
-    // confirmInfoAccuracy,
-    // confirmDelistAndCancelBookings,
-    // getPlatformApplication,
     submitPlatformApplication,
     validatePlatformConfirmation
   }

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -1,9 +1,10 @@
 export const useStrrPlatformApplication = defineStore('strr/platformApplication', () => {
-  const { $strrApi } = useNuxtApp()
+  // const { $strrApi } = useNuxtApp()
   const { completingParty, primaryRep, secondaryRep } = storeToRefs(useStrrPlatformContact())
   const { platformBusiness } = storeToRefs(useStrrPlatformBusiness())
   const { platformDetails } = storeToRefs(useStrrPlatformDetails())
   const strrModal = useStrrModals()
+  const platContactStore = useStrrPlatformContact()
 
   const confirmInfoAccuracy = ref(false)
   const confirmDelistAndCancelBookings = ref(false)
@@ -35,15 +36,18 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
   }
 
   async function submitPlatformApplication () {
-    // validate all forms/fields first??
     try {
+      const results = await platContactStore.validatePlatformContact()
+
+      console.info('platform contact info results: ', results)
+
       const body = createApplicationBody()
 
-      // console.log('submitting application: ', body)
-      await $strrApi('/applications', {
-        method: 'POST',
-        body
-      })
+      console.info('submitting application: ', body)
+      // await $strrApi('/applications', {
+      //   method: 'POST',
+      //   body
+      // })
     } catch (e) {
       logFetchError(e, 'Error creating platform application')
       strrModal.openAppSubmitError() // pass in error object ??

--- a/strr-platform-web/app/stores/platformApplication.ts
+++ b/strr-platform-web/app/stores/platformApplication.ts
@@ -63,14 +63,16 @@ export const useStrrPlatformApplication = defineStore('strr/platformApplication'
 
     console.info('submitting application: ', body)
 
-    const response = await $strrApi('/applications', {
-      method: 'POST',
-      body
-    })
+    // TODO: implement
+    // commenting this out now until payment is complete
+    // const response = await $strrApi('/applications', {
+    //   method: 'POST',
+    //   body
+    // })
 
-    console.info('strr api response: ', response)
+    // console.info('strr api response: ', response)
 
-    return response
+    // return response
   }
 
   return {

--- a/strr-platform-web/app/stores/platformBusiness.ts
+++ b/strr-platform-web/app/stores/platformBusiness.ts
@@ -1,4 +1,4 @@
-import { z, type ZodIssue } from 'zod'
+import { z } from 'zod'
 import {
   getOptionalEmail, getRequiredAddress, getRequiredEmail, getRequiredNonEmptyString, optionalOrEmptyString
 } from '~/utils/connect-validation'
@@ -81,19 +81,13 @@ export const useStrrPlatformBusiness = defineStore('strr/platformBusiness', () =
   //   platformBusiness.value.hasCpbc, platformBusiness.value.hasRegOffAtt)
   // )
 
-  const validatePlatformBusiness = async (returnBool = false): Promise<
-    { formId: string; success: boolean; errors: ZodIssue[] }[] | boolean
-  > => {
-    const validations = [
-      validateSchemaAgainstState(getBusinessSchema(), platformBusiness.value, 'business-details-form')
-    ]
-
-    const results = await Promise.all(validations)
+  const validatePlatformBusiness = (returnBool = false): MultiFormValidationResult | boolean => {
+    const result = validateSchemaAgainstState(getBusinessSchema(), platformBusiness.value, 'business-details-form')
 
     if (returnBool) {
-      return results.every(result => result.success === true)
+      return result.success === true
     } else {
-      return results
+      return [result]
     }
   }
 

--- a/strr-platform-web/app/stores/platformBusiness.ts
+++ b/strr-platform-web/app/stores/platformBusiness.ts
@@ -77,10 +77,6 @@ export const useStrrPlatformBusiness = defineStore('strr/platformBusiness', () =
     }
   })
 
-  // const businessDetailsSchema = computed(() => getBusinessSchema(
-  //   platformBusiness.value.hasCpbc, platformBusiness.value.hasRegOffAtt)
-  // )
-
   const validatePlatformBusiness = (returnBool = false): MultiFormValidationResult | boolean => {
     const schema = getBusinessSchema()
     const result = validateSchemaAgainstState(schema, platformBusiness.value, 'business-details-form')

--- a/strr-platform-web/app/stores/platformBusiness.ts
+++ b/strr-platform-web/app/stores/platformBusiness.ts
@@ -29,7 +29,7 @@ export const useStrrPlatformBusiness = defineStore('strr/platformBusiness', () =
       regOfficeOrAtt: platformBusiness.value.hasRegOffAtt
         ? z.object({
           attorneyName: optionalOrEmptyString,
-          sameAsMailing: z.boolean(),
+          sameAsMailAddress: z.boolean(),
           mailingAddress: getRequiredAddress(
             t('validation.address.street'),
             t('validation.address.city'),
@@ -82,7 +82,8 @@ export const useStrrPlatformBusiness = defineStore('strr/platformBusiness', () =
   // )
 
   const validatePlatformBusiness = (returnBool = false): MultiFormValidationResult | boolean => {
-    const result = validateSchemaAgainstState(getBusinessSchema(), platformBusiness.value, 'business-details-form')
+    const schema = getBusinessSchema()
+    const result = validateSchemaAgainstState(schema, platformBusiness.value, 'business-details-form')
 
     if (returnBool) {
       return result.success === true

--- a/strr-platform-web/app/stores/platformContact.ts
+++ b/strr-platform-web/app/stores/platformContact.ts
@@ -1,8 +1,9 @@
-import { z, type ZodIssue } from 'zod'
+import { z } from 'zod'
 import type { Contact, PlatformContact } from '#imports'
 import {
   optionalOrEmptyString, getRequiredEmail, getRequiredNonEmptyString, getRequiredPhone
 } from '~/utils/connect-validation'
+import type { MultiFormValidationResult } from '~/interfaces/validation'
 
 export const useStrrPlatformContact = defineStore('strr/platformContact', () => {
   const { t } = useI18n()
@@ -85,9 +86,7 @@ export const useStrrPlatformContact = defineStore('strr/platformContact', () => 
   const primaryRepSchema = getContactSchema(false)
   const secondaryRepSchema = getContactSchema(false)
 
-  const validatePlatformContact = async (returnBool = false): Promise<
-    { formId: string; success: boolean; errors: ZodIssue[] }[] | boolean
-  > => {
+  const validatePlatformContact = async (returnBool = false): Promise<MultiFormValidationResult | boolean> => {
     const validations = [
       validateSchemaAgainstState(compPartySchema, completingParty.value, 'completing-party-form'),
       validateSchemaAgainstState(primaryRepSchema, primaryRep.value, 'primary-rep-form')

--- a/strr-platform-web/app/stores/platformDetails.ts
+++ b/strr-platform-web/app/stores/platformDetails.ts
@@ -8,6 +8,11 @@ export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => 
     website: getRequiredUrl(t('validation.brand.site'))
   })
 
+  const getPlatformDetailsSchema = () => z.object({
+    listingSize: z.enum([ListingSize.UNDER_THOUSAND, ListingSize.THOUSAND_OR_MORE]),
+    brands: z.array(getPlatformBrandSchema())
+  })
+
   const platformDetails = ref<{ brands: PlatBrand[], listingSize: ListingSize | undefined }>({
     brands: [{ name: '', website: '' }],
     listingSize: undefined
@@ -22,6 +27,7 @@ export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => 
   return {
     platformDetails,
     getPlatformBrandSchema,
+    getPlatformDetailsSchema,
     addNewEmptyBrand,
     removeBrandAtIndex
   }

--- a/strr-platform-web/app/stores/platformDetails.ts
+++ b/strr-platform-web/app/stores/platformDetails.ts
@@ -1,8 +1,9 @@
-import { z } from 'zod'
+import { z, type ZodIssue } from 'zod'
 import { getRequiredNonEmptyString, getRequiredUrl } from '~/utils/connect-validation'
 
 export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => {
   const { t } = useI18n()
+
   const getPlatformBrandSchema = () => z.object({
     name: getRequiredNonEmptyString(t('validation.brand.name')),
     website: getRequiredUrl(t('validation.brand.site'))
@@ -12,6 +13,8 @@ export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => 
     listingSize: z.enum([ListingSize.UNDER_THOUSAND, ListingSize.THOUSAND_OR_MORE]),
     brands: z.array(getPlatformBrandSchema())
   })
+
+  const platformDetailSchema = getPlatformDetailsSchema()
 
   const platformDetails = ref<{ brands: PlatBrand[], listingSize: ListingSize | undefined }>({
     brands: [{ name: '', website: '' }],
@@ -24,11 +27,30 @@ export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => 
   const removeBrandAtIndex = (index: number) => {
     platformDetails.value.brands.splice(index, 1)
   }
+
+  const validatePlatformDetails = async (returnBool = false): Promise<
+    { formId: string; success: boolean; errors: ZodIssue[] }[] | boolean
+  > => {
+    const validations = [
+      validateSchemaAgainstState(platformDetailSchema, platformDetails.value, 'platform-details-form')
+    ]
+
+    const results = await Promise.all(validations)
+
+    if (returnBool) {
+      return results.every(result => result.success === true)
+    } else {
+      return results
+    }
+  }
+
   return {
     platformDetails,
+    platformDetailSchema,
     getPlatformBrandSchema,
     getPlatformDetailsSchema,
     addNewEmptyBrand,
-    removeBrandAtIndex
+    removeBrandAtIndex,
+    validatePlatformDetails
   }
 })

--- a/strr-platform-web/app/stores/platformDetails.ts
+++ b/strr-platform-web/app/stores/platformDetails.ts
@@ -1,4 +1,4 @@
-import { z, type ZodIssue } from 'zod'
+import { z } from 'zod'
 import { getRequiredNonEmptyString, getRequiredUrl } from '~/utils/connect-validation'
 
 export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => {
@@ -28,19 +28,13 @@ export const useStrrPlatformDetails = defineStore('strr/platformDetails', () => 
     platformDetails.value.brands.splice(index, 1)
   }
 
-  const validatePlatformDetails = async (returnBool = false): Promise<
-    { formId: string; success: boolean; errors: ZodIssue[] }[] | boolean
-  > => {
-    const validations = [
-      validateSchemaAgainstState(platformDetailSchema, platformDetails.value, 'platform-details-form')
-    ]
-
-    const results = await Promise.all(validations)
+  const validatePlatformDetails = (returnBool = false): MultiFormValidationResult | boolean => {
+    const result = validateSchemaAgainstState(platformDetailSchema, platformDetails.value, 'platform-details-form')
 
     if (returnBool) {
-      return results.every(result => result.success === true)
+      return result.success === true
     } else {
-      return results
+      return [result]
     }
   }
 

--- a/strr-platform-web/app/utils/formHelpers.ts
+++ b/strr-platform-web/app/utils/formHelpers.ts
@@ -1,4 +1,4 @@
-import type { Form } from '#ui/types'
+import type { Form, FormError } from '#ui/types'
 import type { ZodSchema } from 'zod'
 
 export const getOwnershipTypeDisplay = (ownershipType: string | null, t: (key: string) => string) => {
@@ -40,3 +40,15 @@ export const validateSchemaAgainstState = (schema: ZodSchema<any>, state: any, f
     }
   }
 }
+
+// export const validateForm = async (form: Form<any> | undefined, isComplete: boolean): Promise<
+//   { errors: FormError<string>[]} | undefined
+// > => {
+//   if (form && isComplete) {
+//     try {
+//       await form.validate()
+//     } catch {
+//       return { errors: toValue(form.errors) }
+//     }
+//   }
+// }

--- a/strr-platform-web/app/utils/formHelpers.ts
+++ b/strr-platform-web/app/utils/formHelpers.ts
@@ -63,6 +63,8 @@ export const focusAndScrollToInputByName = (inputName: string) => {
   if (!el) { return }
 
   if (el.hasAttribute('readonly')) {
+    // some elements (eg: UInputMenu) display the form group name on a readonly input
+    // get actual input and apply focus
     const visibleInput = el.closest('div')?.querySelector('input:not([readonly])') as HTMLInputElement | null
     if (visibleInput) {
       focusAndScroll(visibleInput)

--- a/strr-platform-web/app/utils/formHelpers.ts
+++ b/strr-platform-web/app/utils/formHelpers.ts
@@ -41,14 +41,33 @@ export const validateSchemaAgainstState = (schema: ZodSchema<any>, state: any, f
   }
 }
 
-// export const validateForm = async (form: Form<any> | undefined, isComplete: boolean): Promise<
-//   { errors: FormError<string>[]} | undefined
-// > => {
-//   if (form && isComplete) {
-//     try {
-//       await form.validate()
-//     } catch {
-//       return { errors: toValue(form.errors) }
-//     }
-//   }
-// }
+export const validateForm = async (form: Form<any> | undefined, isComplete: boolean): Promise<
+  FormError<string>[] | undefined
+> => {
+  if (form && isComplete) {
+    try {
+      await form.validate()
+    } catch {
+      return toValue(form.errors)
+    }
+  }
+}
+
+export const focusAndScroll = (element: HTMLInputElement) => {
+  element.focus()
+  element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+}
+
+export const focusAndScrollToInputByName = (inputName: string) => {
+  const el = document.querySelector(`input[name='${inputName}']`) as HTMLInputElement | null
+  if (!el) { return }
+
+  if (el.hasAttribute('readonly')) {
+    const visibleInput = el.closest('div')?.querySelector('input:not([readonly])') as HTMLInputElement | null
+    if (visibleInput) {
+      focusAndScroll(visibleInput)
+    }
+  } else {
+    focusAndScroll(el)
+  }
+}

--- a/strr-platform-web/app/utils/formHelpers.ts
+++ b/strr-platform-web/app/utils/formHelpers.ts
@@ -1,3 +1,5 @@
+import type { Form } from '#ui/types'
+
 export const getOwnershipTypeDisplay = (ownershipType: string | null, t: (key: string) => string) => {
   switch (ownershipType) {
     case 'CO_OWN':
@@ -9,4 +11,13 @@ export const getOwnershipTypeDisplay = (ownershipType: string | null, t: (key: s
     default:
       return ownershipType ?? '-'
   }
+}
+
+export const hasFormErrors = (form: Form<any> | undefined, paths: string[]) => {
+  for (const path of paths) {
+    if (form && form.getErrors(path)?.length) {
+      return true
+    }
+  }
+  return false
 }

--- a/strr-platform-web/app/utils/formHelpers.ts
+++ b/strr-platform-web/app/utils/formHelpers.ts
@@ -1,4 +1,5 @@
 import type { Form } from '#ui/types'
+import type { ZodSchema } from 'zod'
 
 export const getOwnershipTypeDisplay = (ownershipType: string | null, t: (key: string) => string) => {
   switch (ownershipType) {
@@ -20,4 +21,22 @@ export const hasFormErrors = (form: Form<any> | undefined, paths: string[]) => {
     }
   }
   return false
+}
+
+export const validateSchemaAgainstState = (schema: ZodSchema<any>, state: any, formId: string) => {
+  const result = schema.safeParse(state)
+
+  if (result.success) {
+    return {
+      formId,
+      success: true,
+      errors: []
+    }
+  } else {
+    return {
+      formId,
+      success: false,
+      errors: result.error.issues
+    }
+  }
 }

--- a/strr-platform-web/nuxt.config.ts
+++ b/strr-platform-web/nuxt.config.ts
@@ -80,7 +80,7 @@ export default defineNuxtConfig({
       addressCompleteKey: process.env.NUXT_ADDRESS_COMPLETE_KEY,
       payApiURL: `${process.env.NUXT_PAY_API_URL}${process.env.NUXT_PAY_API_VERSION}`,
       legalApiURL: `${process.env.NUXT_LEGAL_API_URL}${process.env.NUXT_LEGAL_API_VERSION}`,
-      strrApiURL: `${process.env.NUXT_STRR_API_URL}${process.env.NUXT_STRR_API_VERSION}`,
+      strrApiURL: process.env.NUXT_STRR_API_URL,
       paymentPortalUrl: process.env.NUXT_PAYMENT_PORTAL_URL,
       baseUrl: process.env.NUXT_BASE_URL,
       environment: process.env.NUXT_ENVIRONMENT_HEADER || '',


### PR DESCRIPTION
*Description of changes:*

Refactor stepper component and handle validation for first step.

Main changes:
- all stepper logic is managed by the stepper and used in the parent through defineExpose and defineModel
- added a validationFn to the Step object so the stepper can validate itself if a validateFn is provided
- all ContactInfo forms in the step are validated onMounted if the isComplete prop = true, the form will still validate on input/blur/etc as the default UForm settings
- separated some of the form methods into the formHelpers util file
- a different validation function is defined in the contact info store which is then called in the application store on submit (this is different than the form validation function which is local to the form/step component, passing the form errors from the form.validate() turned out to be more difficult then i thought originally, but they use the same schema reference so i dont see any issues here)
- fixed the strr api url in the nuxt config

I'm pretty sure the way I have it now I just need to set up a similar onMounted in the businessDetails and platformDetails forms and a validation function for their stores, then use that validation fn in the application store and it should be good to go

Form onMounted validation and scroll into view, scroll to errored field when clicking edit button on review page:
(clicking this will make you download the video as its too large)
https://github.com/user-attachments/assets/2a7cef0e-bb76-478f-8665-36ac71359010

Step validation using validationFn prop on Step object:

https://github.com/user-attachments/assets/73ad6c83-0dd8-4dad-a065-7330f7387125

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
