### PR TITLE
Host UI - Only Allow PDF Document Upload

### DIFF
--- a/strr-web/components/bcros/form-section/principal-residence/Form.vue
+++ b/strr-web/components/bcros/form-section/principal-residence/Form.vue
@@ -106,7 +106,7 @@
                   :key="fileInputKey"
                   required
                   aria-label="Supporting document file upload"
-                  accept=".pdf,.jpg,.png,.doc"
+                  accept=".pdf"
                   type="file"
                   class="w-full pl-10 cursor-pointer"
                   :placeholder="tPrincipalResidence('chooseSupportDocs')"
@@ -223,7 +223,7 @@ if (isComplete) {
 
 const uploadFile = (file: FileList) => {
   const extension = file[0].name.substring(file[0].name.length - 3)
-  const validType = ['pdf', 'jpg', 'doc', 'png']
+  const validType = ['pdf']
   const fileSize = file[0].size / 1024 / 1024 // in MiB
   const validFileType = validType.includes(extension)
   const validFileSize = fileSize <= 50

--- a/strr-web/lang/en.json
+++ b/strr-web/lang/en.json
@@ -390,7 +390,7 @@
       "chooseSupportDocs": "Choose Supporting Documents",
       "removeSupportDoc": "Remove",
       "supporting": "Supporting Documents",
-      "fileRequirements": "File must be a .pdf, .jpg, .doc, or .png. Maximum file size 50 MB.",
+      "fileRequirements": "File must be a .pdf. Maximum file size is 50 MB.",
       "declaration": "Declaration",
       "declare": "As required by section 14 (2) of the Short-Term Accommodations Rental Act (the Act), I declare the property host will comply with the principal residence restriction in the Act and provide the short-term rental accommodation services described in this registration in one or both of: \n a. the property host’s principal residence, \n b.not more than one secondary suite or other accessory dwelling unit that is on the land parcel associated with the property host's principal residence. \n I understand that if the property host does not comply with the requirement to provide the short-term rental accommodation services in the principal residence, I may be subject to enforcement action under Part 4 of the Act, including being ordered to pay an administrative penalty.",
       "consent": "I consent to the Ministry of Finance sharing data and information about me with the Short-Term Rental Branch. I understand the information will be shared to confirm that the property being registered is my principal residence or a secondary suite or accessory dwelling unit on the same land parcel as my principal residence. If you provide consent, it may speed our review and approval of your registration.",
@@ -408,7 +408,7 @@
       "strataGuest": "Strata corporation guest suite",
       "service": "Service Provider",
       "fileSizeError": "File must be less than 50MB in size",
-      "fileTypeError": "File must be of type pdf, doc, jpg, png",
+      "fileTypeError": "File must be of type pdf",
       "fileRequiredError": "Please upload a supporting document"
     },
     "review": {

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/23014

*Description of changes:*
Only allow .pdf supporting document upload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
