### PR TITLE
Allow to Navigate to Success Submission page

### DIFF
--- a/strr-web/middleware/setupAuth.global.ts
+++ b/strr-web/middleware/setupAuth.global.ts
@@ -29,6 +29,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
       await account.setAccountInfo()
     }
 
+    // allow to navigate to application submitted page after the payment
     if (redirectRoute && !to.path.startsWith('/' + RouteNamesE.APPLICATION_SUBMITTED)) {
       abortNavigation()
       return navigateTo('/' + redirectRoute)

--- a/strr-web/middleware/setupAuth.global.ts
+++ b/strr-web/middleware/setupAuth.global.ts
@@ -29,7 +29,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
       await account.setAccountInfo()
     }
 
-    if (redirectRoute) {
+    if (redirectRoute && !to.path.startsWith('/' + RouteNamesE.APPLICATION_SUBMITTED)) {
       abortNavigation()
       return navigateTo('/' + redirectRoute)
     } else {

--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/strr-web/stores/keycloak.ts
+++ b/strr-web/stores/keycloak.ts
@@ -53,7 +53,7 @@ export const useBcrosKeycloak = defineStore('bcros/keycloak', () => {
     sessionStorage.setItem(SessionStorageKeyE.KEYCLOAK_TOKEN_REFRESH, kc.value?.refreshToken || '')
     sessionStorage.setItem(SessionStorageKeyE.KEYCLOAK_TOKEN_ID, kc.value?.idToken || '')
     sessionStorage.setItem(SessionStorageKeyE.KEYCLOAK_SYNCED, 'true')
-    sessionStorage.removeItem(SessionStorageKeyE.CURRENT_ACCOUNT)
+    // sessionStorage.removeItem(SessionStorageKeyE.CURRENT_ACCOUNT)
   }
 
   async function initKeyCloak (

--- a/strr-web/stores/keycloak.ts
+++ b/strr-web/stores/keycloak.ts
@@ -53,7 +53,6 @@ export const useBcrosKeycloak = defineStore('bcros/keycloak', () => {
     sessionStorage.setItem(SessionStorageKeyE.KEYCLOAK_TOKEN_REFRESH, kc.value?.refreshToken || '')
     sessionStorage.setItem(SessionStorageKeyE.KEYCLOAK_TOKEN_ID, kc.value?.idToken || '')
     sessionStorage.setItem(SessionStorageKeyE.KEYCLOAK_SYNCED, 'true')
-    // sessionStorage.removeItem(SessionStorageKeyE.CURRENT_ACCOUNT)
   }
 
   async function initKeyCloak (


### PR DESCRIPTION
*Issue:*

When submitting a new Rental Application, the Success page was by-passed and user was navigated to Account Select page.

*Description of changes:*
- Fix to allow users to navigate to Success Submission page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
