### PR TITLE
UI - cert component tweak

### DIFF
--- a/strr-base-web/app/components/connect/form/certify/index.vue
+++ b/strr-base-web/app/components/connect/form/certify/index.vue
@@ -2,7 +2,7 @@
 const checkboxModel = defineModel<boolean>({ default: false })
 
 defineProps<{
-  title: string
+  title?: string
   items: Array<{
     label?: string
     i18nKey?:string
@@ -16,42 +16,37 @@ defineProps<{
 </script>
 <template>
   <section class="flex flex-col gap-6">
-    <h3 class="text-lg">
-      {{ title }}
-    </h3>
+    <ConnectTypographyH2 :text="title || $t('label.confirmation')" custom-class="text-lg font-bold" />
     <UCard
       :ui="{
         ring: hasError ? 'ring-2 ring-red-600' : 'ring-1 ring-gray-200',
         body: {
           base: 'divide-y divide-gray-200',
-          padding: 'px-4 py-4 sm:p-8'
+          padding: 'p-4 sm:p-8'
         }
       }"
     >
-      <ol class="list-inside list-decimal divide-y divide-gray-200 marker:font-bold">
+      <ol v-if="items.length" class="list-outside list-decimal divide-y divide-gray-200 pl-4 marker:font-bold">
         <li
           v-for="item, i in items"
           :id="`${name}-item-${i}`"
           :key="i"
-          class="py-4 first:pt-0"
+          class="py-5 first:pt-0 last:pb-8"
         >
-          <template v-if="item.slot">
-            <slot :name="item.slot" />
-          </template>
-          <template v-else>
+          <slot :name="item.slot || 'listLabel'">
             <ConnectI18nBold
               v-if="item.i18nKey"
               :translation-path="item.i18nKey"
               v-bind="item.i18nProps"
             />
             <span v-else>{{ item.label }}</span>
-          </template>
+          </slot>
         </li>
       </ol>
       <UFormGroup :name>
         <UCheckbox
           v-model="checkboxModel"
-          class="pt-4"
+          :class="items.length ? 'mt-8' : ''"
           aria-required="true"
           :aria-describedby="items.map((_, i) => `${name}-item-${i}`).join(' ')"
           :aria-invalid="hasError"

--- a/strr-base-web/app/locales/en-CA.ts
+++ b/strr-base-web/app/locales/en-CA.ts
@@ -469,26 +469,6 @@ export default {
       confirm: {
         infoAccuracy: 'I confirm that the information contained in the application for registration is accurate and true. I understand that, if I have provided inaccurate or false information, I may be the subject of enforcement action under Part 4 of the Short-Term Rental Accommodations Act. Enforcement action may include being ordered to pay an administrative penalty.',
         delistAndCancelBookings: 'I confirm agreement to delist and cancel existing bookings for unregistered listings as required under s. 17 (2) (a) and [relevant section of the forthcoming regulation].'
-      },
-      certify: {
-        1: {
-          title: 'Terms and Conditions.',
-          text: 'I agree to comply with the {link} of registration.'
-        },
-        2: {
-          title: 'Tax Auditing.',
-          text: 'I understand that my registration information will be shared with the Ministry of Finance and the Canada Revenue Agency for the purposes of tax auditing.'
-        },
-        3: {
-          title: 'Principal Residence Declaration.',
-          text: "As required by section 14 (2) of the Short-Term Rental Accommodations Act (the Act), I declare that I will comply with the principal residence requirement in the Act and provide the short-term rental accommodation services described in this registration in one or both of: a. the property host's principal residence, and b. not more than one secondary suite or accessory dwelling unit on the same property. I understand that if I do not comply with the principal residence requirement, I may be subject to enforcement action under Part 4 of the Act, including being ordered to pay an administrative penalty."
-        },
-        4: {
-          title: 'Accuracy of Information.',
-          text: 'I confirm that the information contained in the application for registration is accurate and true. I understand that if I have knowingly provided inaccurate or false information, I may be subject to enforcement action under Part 4 of the Short-Term Rental Accommodations Act.'
-        },
-        confirm: 'I, {name}, confirm that I understand and agree to all of the requirements listed above.',
-        authorization: 'I, {boldStart}{name}{boldEnd}, have relevant knowledge of and am authorized to submit this registration.'
       }
     }
   }

--- a/strr-host-pm-web/app/components/form/ReviewConfirm.vue
+++ b/strr-host-pm-web/app/components/form/ReviewConfirm.vue
@@ -204,83 +204,55 @@ const getCompPartyName = computed(() => {
       :schema="applicationStore.confirmationSchema"
       class="space-y-10"
     >
-      <ConnectTypographyH2 :text="$t('label.confirmation')" custom-class="text-lg font-bold" />
-      <ConnectFormSection
-        class="rounded bg-white py-5"
-        :error="isComplete && hasFormErrors(confirmationFormRef, ['agreedToRentalAct'])"
+      <ConnectFormCertify
+        v-model="applicationStore.userConfirmation.agreedToRentalAct"
+        :items="[{ slot: 'item-1' }, { i18nKey: 'certify.2' }, { i18nKey: 'certify.3' }, { i18nKey: 'certify.4' }]"
+        :checkbox-label="{ key: 'certify.confirm', props: { name: getCompPartyName } }"
+        :has-error="isComplete && hasFormErrors(confirmationFormRef, ['agreedToRentalAct'])"
+        name="agreedToRentalAct"
       >
-        <ul class="list-outside list-decimal divide-y font-bold *:py-7">
-          <li>
-            <span class="font-bold">{{ $t('strr.review.certify.1.title') }}</span>&nbsp;
-            <span class="font-normal">
-              <i18n-t keypath="strr.review.certify.1.text" scope="global">
-                <template #link>
-                  <UButton
-                    :label="$t('link.hostTAC')"
-                    :to="hostTacUrl"
-                    :padded="false"
-                    variant="link"
-                    target="_blank"
-                    class="text-base underline"
-                  />
-                </template>
-              </i18n-t>
-            </span>
-          </li>
-          <li v-for="i of [2, 3, 4]" :key="i">
-            <p>
-              <span class="font-bold">{{ $t(`strr.review.certify.${i}.title`) }}</span>&nbsp;
-              <span class="font-normal">{{ $t(`strr.review.certify.${i}.text`) }}</span>
-            </p>
-          </li>
-          <li class="-ml-5 mt-2 list-none">
-            <UFormGroup name="agreedToRentalAct" class="mt-2">
-              <UCheckbox
-                v-model="applicationStore.userConfirmation.agreedToRentalAct"
-                aria-required="true"
-                :aria-invalid="hasFormErrors(confirmationFormRef, ['agreedToRentalAct'])"
-              >
-                <template #label>
-                  <i18n-t keypath="strr.review.certify.confirm" scope="global">
-                    <template #name>
-                      <b>{{ getCompPartyName }}</b>
-                    </template>
-                  </i18n-t>
-                </template>
-              </UCheckbox>
-            </UFormGroup>
-          </li>
-        </ul>
-      </ConnectFormSection>
-      <ConnectTypographyH2 :text="$t('label.authorization')" custom-class="text-lg font-bold" />
-      <ConnectFormSection
-        class="rounded bg-white py-12"
-        :error="isComplete && hasFormErrors(confirmationFormRef, ['agreedToSubmit'])"
-      >
-        <UFormGroup name="agreedToSubmit" class="-ml-5">
-          <UCheckbox
-            v-model="applicationStore.userConfirmation.agreedToSubmit"
-            aria-required="true"
-            :aria-invalid="hasFormErrors(confirmationFormRef, ['agreedToSubmit'])"
-          >
-            <template #label>
-              <div>
-                <ConnectI18nBold
-                  class="text-bcGovGray-700"
-                  translation-path="strr.review.certify.authorization"
-                  :name="getCompPartyName"
-                />
-                <dl class="mt-4 flex gap-2">
-                  <dt class="font-bold">
-                    {{ $t('label.date') }}:
-                  </dt>
-                  <dd>{{ dateToStringPacific(new Date(), 'DDD') }}</dd>
-                </dl>
-              </div>
+        <template #item-1>
+          <i18n-t keypath="certify.1" scope="global">
+            <template #terms>
+              <strong>{{ $t('certify.tac') }}.</strong>
             </template>
-          </UCheckbox>
-        </UFormGroup>
-      </ConnectFormSection>
+            <template #link>
+              <UButton
+                :label="$t('link.hostTAC')"
+                :to="hostTacUrl"
+                :padded="false"
+                variant="link"
+                target="_blank"
+                class="text-base underline"
+              />
+            </template>
+          </i18n-t>
+        </template>
+      </ConnectFormCertify>
+      <ConnectFormCertify
+        v-model="applicationStore.userConfirmation.agreedToSubmit"
+        :title="$t('label.authorization')"
+        :items="[]"
+        :checkbox-label="{ key: 'certify.authorization', props: { name: getCompPartyName } }"
+        :has-error="isComplete && hasFormErrors(confirmationFormRef, ['agreedToSubmit'])"
+        name="agreedToSubmit"
+      >
+        <template #checkboxLabel>
+          <div>
+            <ConnectI18nBold
+              class="text-bcGovGray-700"
+              translation-path="certify.authorization"
+              :name="getCompPartyName"
+            />
+            <dl class="mt-4 flex gap-2">
+              <dt class="font-bold">
+                {{ $t('label.date') }}:
+              </dt>
+              <dd>{{ dateToStringPacific(new Date(), 'DDD') }}</dd>
+            </dl>
+          </div>
+        </template>
+      </ConnectFormCertify>
     </UForm>
   </div>
 </template>

--- a/strr-host-pm-web/app/locales/en-CA.ts
+++ b/strr-host-pm-web/app/locales/en-CA.ts
@@ -19,6 +19,15 @@ export default {
       title: '{boldStart}Important:{boldEnd} {propertytype} requires a unit number as part of the Rental Unit Residential Address above. If you do not include a unit number, your registration {boldStart}may be declined{boldEnd}.'
     }
   },
+  certify: {
+    1: '{terms} I agree to comply with the {link} of registration.',
+    2: '{boldStart}Tax Auditing.{boldEnd} I understand that my registration information will be shared with the Ministry of Finance and the Canada Revenue Agency for the purposes of tax auditing.',
+    3: "{boldStart}Principal Residence Declaration.{boldEnd} As required by section 14 (2) of the Short-Term Rental Accommodations Act (the Act), I declare that I will comply with the principal residence requirement in the Act and provide the short-term rental accommodation services described in this registration in one or both of: a. the property host's principal residence, and b. not more than one secondary suite or accessory dwelling unit on the same property. I understand that if I do not comply with the principal residence requirement, I may be subject to enforcement action under Part 4 of the Act, including being ordered to pay an administrative penalty.",
+    4: '{boldStart}Accuracy of Information.{boldEnd} I confirm that the information contained in the application for registration is accurate and true. I understand that if I have knowingly provided inaccurate or false information, I may be subject to enforcement action under Part 4 of the Short-Term Rental Accommodations Act.',
+    confirm: 'I, {boldStart}{name}{boldEnd}, confirm that I understand and agree to all of the requirements listed above.',
+    authorization: 'I, {boldStart}{name}{boldEnd}, have relevant knowledge of and am authorized to submit this registration.',
+    tac: 'Terms and Conditions.'
+  },
   feeSummary: {
     itemLabels: {
       HOSTREG_1: 'STR Application Fee',


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/24702

*Description of changes:*
- use common certify component in hosts
- tweak common component
  - text wrap on outside of numbering
  - tweak spacing (checkbox is a bit more separate like the design)
Look after update (platforms):
![Screenshot 2024-12-06 at 9 50 13 AM](https://github.com/user-attachments/assets/9c0295bd-5c8c-40a6-8f3c-c1b67608dfec)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
