### PR TITLE
Strata/Hosts - UI: View btn

### DIFF
--- a/strr-host-pm-web/app/locales/en-CA.ts
+++ b/strr-host-pm-web/app/locales/en-CA.ts
@@ -229,7 +229,8 @@ export default {
     contWithReg: 'Continue with Registration',
     showDetails: 'Show Details',
     hideDetails: 'Hide Details',
-    returnToStep: 'Return to the step to finish it'
+    returnToStep: 'Return to the step to finish it',
+    ariaViewDetails: 'View details for property: {name}, {address}'
   },
   error: {
     createAccount: {

--- a/strr-host-pm-web/app/pages/dashboard/index.vue
+++ b/strr-host-pm-web/app/pages/dashboard/index.vue
@@ -178,6 +178,15 @@ async function handleItemSelect (row: any) {
           <template #actions-data="{ row }">
             <UButton
               :label="$t('btn.view')"
+              :aria-label="
+                $t('btn.ariaViewDetails', {
+                  name: row.name,
+                  address: `${row.address.unitNumber
+                    ? row.address.unitNumber + '-'
+                    : ''}${row.address.streetNumber} ${row.address.streetName}, ${row.address.city}`
+                })
+              "
+              :block="true"
               @click="handleItemSelect(row)"
             />
           </template>

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-strata-web/app/locales/en-CA.ts
+++ b/strr-strata-web/app/locales/en-CA.ts
@@ -87,7 +87,8 @@ export default {
   },
   btn: {
     addStrataHotel: 'Add a strata-titled hotel or motel',
-    view: 'View'
+    view: 'View',
+    ariaViewDetails: 'View details for property: {name}`'
   },
   label: {
     strataName: 'Strata Name',

--- a/strr-strata-web/app/pages/strata-hotel/dashboard/index.vue
+++ b/strr-strata-web/app/pages/strata-hotel/dashboard/index.vue
@@ -163,6 +163,8 @@ async function handleItemSelect (row: any) {
           <template #actions-data="{ row }">
             <UButton
               :label="$t('btn.view')"
+              :aria-label="$t('btn.ariaViewDetails', { name: row.strataName })"
+              :block="true"
               @click="handleItemSelect(row)"
             />
           </template>

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/24499

*Description of changes:*
- add descriptive aria labels for the 'View' button in the dashboard table

Hosts:
<img width="1009" alt="Screenshot 2024-12-18 at 10 33 25 AM" src="https://github.com/user-attachments/assets/6eab29fd-0846-4f0f-bde9-a2739ed58fb0" />
<img width="1395" alt="Screenshot 2024-12-18 at 10 32 56 AM" src="https://github.com/user-attachments/assets/628ec665-904a-42d0-97e8-e8887449d47e" />

Strata: 
<img width="1019" alt="Screenshot 2024-12-18 at 10 46 25 AM" src="https://github.com/user-attachments/assets/bf395190-7ad0-49b8-bb97-e1e6e52f8c5b" />
<img width="1364" alt="Screenshot 2024-12-18 at 10 46 15 AM" src="https://github.com/user-attachments/assets/dca742bc-7c4f-4349-8c7b-91dd2494ecd9" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the strr license (Apache 2.0).
