### PR TITLE
Strata - UI: document upload optional

### DIFF
--- a/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
+++ b/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
@@ -81,7 +81,12 @@ useHead({
 
 definePageMeta({
   layout: 'connect-dashboard',
-  middleware: ['auth', 'require-account']
+  middleware: ['auth', 'require-account'],
+  onAccountChange: async () => {
+    const { $router, $i18n } = useNuxtApp()
+    await $router.push(`/${$i18n.locale.value}/dashboard`)
+    return true
+  }
 })
 
 setBreadcrumbs([

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-strata-web/app/components/form/StrataDetails.vue
+++ b/strr-strata-web/app/components/form/StrataDetails.vue
@@ -202,10 +202,7 @@ onMounted(async () => {
         :heading="{ label: $t('label.supportingDocs'), labelClass: 'font-bold md:ml-6' }"
       >
         <div class="space-y-10 py-10">
-          <ConnectFormSection
-            title="File Upload"
-            :error="hasFormErrors(documentFormRef, ['documents'])"
-          >
+          <ConnectFormSection :title="$t('label.fileUpload')">
             <div class="max-w-bcGovInput">
               <UFormGroup
                 name="documents"
@@ -216,12 +213,10 @@ onMounted(async () => {
               >
                 <DocumentUploadButton
                   id="supporting-documents"
-                  :label="$t('label.chooseDocs')"
+                  :label="$t('label.chooseDocsOpt')"
                   accept=".pdf"
-                  :is-required="true"
-                  :is-invalid="isComplete && hasFormErrors(documentFormRef, ['documents'])"
                   help-id="supporting-documents-help"
-                  @change="(e: FileList) => e[0] ? docStore.addStoredDocument(e[0]) : undefined"
+                  @change="(e: FileList | null) => e && e[0] ? docStore.addStoredDocument(e[0]) : undefined"
                 />
 
                 <template #label>

--- a/strr-strata-web/app/components/form/StrataDetails.vue
+++ b/strr-strata-web/app/components/form/StrataDetails.vue
@@ -202,7 +202,10 @@ onMounted(async () => {
         :heading="{ label: $t('label.supportingDocs'), labelClass: 'font-bold md:ml-6' }"
       >
         <div class="space-y-10 py-10">
-          <ConnectFormSection :title="$t('label.fileUpload')">
+          <ConnectFormSection 
+            :title="$t('label.fileUpload')"
+            :error="hasFormErrors(documentFormRef, ['documents'])"
+          >
             <div class="max-w-bcGovInput">
               <UFormGroup
                 name="documents"
@@ -215,6 +218,8 @@ onMounted(async () => {
                   id="supporting-documents"
                   :label="$t('label.chooseDocsOpt')"
                   accept=".pdf"
+                  :is-required="false"
+                  :is-invalid="isComplete && hasFormErrors(documentFormRef, ['documents'])"
                   help-id="supporting-documents-help"
                   @change="(e: FileList | null) => e && e[0] ? docStore.addStoredDocument(e[0]) : undefined"
                 />

--- a/strr-strata-web/app/locales/en-CA.ts
+++ b/strr-strata-web/app/locales/en-CA.ts
@@ -98,7 +98,9 @@ export default {
     lastStatusChange: 'Last Status Change',
     daysToExpiry: 'Days to Expiry (Pacific Time)',
     chooseDocs: 'Choose Supporting Documents',
-    supportingDocs: 'Supporting Documentation'
+    chooseDocsOpt: 'Choose Supporting Documents (Optional)',
+    supportingDocs: 'Supporting Documentation',
+    fileUpload: 'File Upload'
   },
   link: {
     strataHotelInfoPage: 'strata hotel information page',

--- a/strr-strata-web/app/pages/strata-hotel/dashboard/[applicationId].vue
+++ b/strr-strata-web/app/pages/strata-hotel/dashboard/[applicationId].vue
@@ -97,7 +97,12 @@ useHead({
 
 definePageMeta({
   layout: 'connect-dashboard',
-  middleware: ['auth', 'require-account']
+  middleware: ['auth', 'require-account'],
+  onAccountChange: async () => {
+    const { $router, $i18n } = useNuxtApp()
+    await $router.push(`/${$i18n.locale.value}/strata-hotel/dashboard`)
+    return true
+  }
 })
 
 setBreadcrumbs([

--- a/strr-strata-web/app/stores/document.ts
+++ b/strr-strata-web/app/stores/document.ts
@@ -90,7 +90,7 @@ export const useDocumentStore = defineStore('strata/document', () => {
   }
 
   const getDocumentSchema = () => z.array(z.any()).refine(
-    val => val.length >= 1,
+    val => val.length >= 0, // 0 is optional, set to 1 to require at least 1 doc
     {
       message: t('validation.min1Document'),
       path: ['documents']

--- a/strr-strata-web/nuxt.config.ts
+++ b/strr-strata-web/nuxt.config.ts
@@ -39,8 +39,8 @@ export default defineNuxtConfig({
   },
 
   extends: [
-    // ['github:bcgov/STRR/strr-base-web', { install: true }],
-    '../strr-base-web', // dev only
+    ['github:bcgov/STRR/strr-base-web', { install: true }],
+    // '../strr-base-web', // dev only
     '@daxiom/nuxt-core-layer-test' // extend again, this prevents the payApi plugin error
   ],
 

--- a/strr-strata-web/nuxt.config.ts
+++ b/strr-strata-web/nuxt.config.ts
@@ -39,8 +39,8 @@ export default defineNuxtConfig({
   },
 
   extends: [
-    ['github:bcgov/STRR/strr-base-web', { install: true }],
-    // '../strr-base-web', // dev only
+    // ['github:bcgov/STRR/strr-base-web', { install: true }],
+    '../strr-base-web', // dev only
     '@daxiom/nuxt-core-layer-test' // extend again, this prevents the payApi plugin error
   ],
 

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "0.0.35",
+  "version": "0.0.34",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/25122

*Description of changes:*
- make document upload in strata form optional
- navigate from /dashboard/:id  -->  /dashboard when user changes accounts in strata and host

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
