### PR TITLE
Fix Registration Details page. Show PR if available

### DIFF
--- a/strr-web/package.json
+++ b/strr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strr-web",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Short Term Rental Registration UI - Mono repo workspace",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/strr-web/pages/registration-details/[id]/index.vue
+++ b/strr-web/pages/registration-details/[id]/index.vue
@@ -168,7 +168,6 @@
           </h2>
           <div class="bg-white p-8 mobile:px-5">
             <BcrosFormSectionReviewItem
-              v-if="application.unitDetails.prExemptReason"
               title="Exemption Reason"
             >
               <p>{{ tReview(`prExemptReason.${application.unitDetails.prExemptReason}`) }}</p>

--- a/strr-web/pages/registration-details/[id]/index.vue
+++ b/strr-web/pages/registration-details/[id]/index.vue
@@ -158,34 +158,20 @@
         </div>
 
         <!-- Principal Residence -->
-        <div class="mt-10" data-test-id="principal-residence">
+        <div
+          v-if="application.unitDetails?.prExemptReason"
+          class="mt-10"
+          data-test-id="principal-residence"
+        >
           <h2 class="font-bold mb-6 mobile:mx-2 text-xl">
             {{ tApplicationDetails('principalResidence') }}
           </h2>
           <div class="bg-white p-8 mobile:px-5">
-            <BcrosFormSectionReviewItem :title="tApplicationDetails('proof')">
-              <p data-test-id="principal-residence-proof">
-                {{
-                  application.principalResidence.isPrincipalResidence
-                    ? tApplicationDetails('principalResidenceApplies')
-                    : tApplicationDetails('principalResidenceNotApplies')
-                }}
-              </p>
-            </BcrosFormSectionReviewItem>
             <BcrosFormSectionReviewItem
-              v-if="application.principalResidence.nonPrincipalOption"
-              :title="tApplicationDetails('principalResidenceReason')"
-              class="mt-4"
+              v-if="application.unitDetails.prExemptReason"
+              title="Exemption Reason"
             >
-              <p>{{ application.principalResidence.nonPrincipalOption }}</p>
-            </BcrosFormSectionReviewItem>
-            <BcrosFormSectionReviewItem
-              v-if="application.principalResidence.specifiedServiceProvider &&
-                application.principalResidence.specifiedServiceProvider !== 'n/a'"
-              :title="tApplicationDetails('principalResidenceServiceProvider')"
-              class="mt-4"
-            >
-              <p>{{ application.principalResidence.specifiedServiceProvider }}</p>
+              <p>{{ tReview(`prExemptReason.${application.unitDetails.prExemptReason}`) }}</p>
             </BcrosFormSectionReviewItem>
           </div>
         </div>


### PR DESCRIPTION
*Issue:*

Registration Details page issues with PR info

*Description of changes:*
- Fix to show only one Principal Res requirement in Registration page

![Screenshot 2025-01-17 at 13 45 18](https://github.com/user-attachments/assets/a719168f-37ca-44b9-bb95-dc2d0315cba8)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
