### PR TITLE
fix: Fake link should appear as plain text in email

### DIFF
--- a/queue_services/strr-email/email-templates/common/strr-important-next-steps.md
+++ b/queue_services/strr-email/email-templates/common/strr-important-next-steps.md
@@ -1,5 +1,5 @@
 # Important Next Steps
-1. Go to a platform that your short-term rental is listed on (e.g., https://str-platform-example.com).
+1. Go to a platform that your short-term rental is listed on (e.g., https\://str-platform-example.com).
 
 1. Follow the platform instructions to update your listing with your registration information below.
   ^**Registration Number:** 


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/25878

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
