### PR TITLE
Update default view for Examiners

### DIFF
--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -110,7 +110,7 @@ const { data: applicationListResp, status } = await useAsyncData(
       }
 
       const applications = res.applications.map((app: HousApplicationResponse) => ({
-        applicationNumber: app.header.registrationNumber || app.header.applicationNumber,
+        applicationNumber: app.header.applicationNumber,
         registrationType: t(`registrationType.${app.registration.registrationType}`),
         requirements: getRequirementsColumn(app),
         applicantName: getApplicantNameColumn(app),
@@ -205,7 +205,7 @@ function handleColumnSort (column: string) {
               size="sm"
             >
               <template #trailing>
-                <UIcon name="i-mdi-search" class="size-5 shrink-0 text-bcGovColor-activeBlue" />
+                <UIcon name="i-mdi-search" class="text-bcGovColor-activeBlue size-5 shrink-0" />
               </template>
             </UInput>
             <ConnectI18nHelper translation-path="label.resultsInTable" :count="applicationListResp?.total || 0" />

--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -12,7 +12,7 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
     requirements: [],
     applicantName: '',
     propertyAddress: '',
-    status: [ApplicationStatus.FULL_REVIEW],
+    status: [],
     submissionDate: { start: null, end: null },
     lastModified: { start: null, end: null },
     adjudicator: []

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

*Description of changes:*
- Show all Statuses for the Examiners in the Dashboard View

![Screenshot 2025-02-18 at 11 22 24](https://github.com/user-attachments/assets/b6108548-e9a9-4296-8af6-e5e2d5b1fb86)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
