### PR TITLE
API - List Applications OrderBy

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.0.45"
+version = "0.0.46"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -166,7 +166,11 @@ class Application(BaseModel):
             query = query.filter_by(status=filter_criteria.status.upper())
         if filter_criteria.registration_type:
             query = query.filter_by(registration_type=filter_criteria.registration_type.upper())
-        query = query.order_by(Application.id.desc())
+        sort_column = getattr(Application, filter_criteria.sort_by, Application.application_date)
+        if filter_criteria.sort_order and filter_criteria.sort_order.lower() == "desc":
+            query = query.order_by(sort_column.desc())
+        else:
+            query = query.order_by(sort_column)
 
         paginated_result = query.paginate(per_page=filter_criteria.limit, page=filter_criteria.page)
         return paginated_result

--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -166,11 +166,11 @@ class Application(BaseModel):
             query = query.filter_by(status=filter_criteria.status.upper())
         if filter_criteria.registration_type:
             query = query.filter_by(registration_type=filter_criteria.registration_type.upper())
-        sort_column = getattr(Application, filter_criteria.sort_by, Application.application_date)
-        if filter_criteria.sort_order and filter_criteria.sort_order.lower() == "desc":
-            query = query.order_by(sort_column.desc())
+        sort_column = getattr(Application, filter_criteria.sort_by, Application.id)
+        if filter_criteria.sort_order and filter_criteria.sort_order.lower() == "asc":
+            query = query.order_by(sort_column.asc())
         else:
-            query = query.order_by(sort_column)
+            query = query.order_by(sort_column.desc())
 
         paginated_result = query.paginate(per_page=filter_criteria.limit, page=filter_criteria.page)
         return paginated_result
@@ -197,7 +197,11 @@ class Application(BaseModel):
             query = query.filter_by(status=filter_criteria.status.upper())
         else:
             query = query.filter(Application.status != Application.Status.DRAFT)
-        query = query.order_by(Application.id.desc())
+        sort_column = getattr(Application, filter_criteria.sort_by, Application.id)
+        if filter_criteria.sort_order and filter_criteria.sort_order.lower() == "asc":
+            query = query.order_by(sort_column.asc())
+        else:
+            query = query.order_by(sort_column.desc())
         paginated_result = query.paginate(per_page=filter_criteria.limit, page=filter_criteria.page)
         return paginated_result
 

--- a/strr-api/src/strr_api/models/dataclass.py
+++ b/strr-api/src/strr_api/models/dataclass.py
@@ -41,7 +41,7 @@ class ApplicationSearch:
     page: int
     limit: int
     status: str
-    sort_by: str = "application_date"
-    sort_order: str = "asc"
+    sort_by: str = "id"
+    sort_order: str = "desc"
     search_text: str = None
     registration_type: str = None

--- a/strr-api/src/strr_api/models/dataclass.py
+++ b/strr-api/src/strr_api/models/dataclass.py
@@ -41,5 +41,7 @@ class ApplicationSearch:
     page: int
     limit: int
     status: str
+    sort_by: str = "application_date"
+    sort_order: str = "asc"
     search_text: str = None
     registration_type: str = None

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -80,6 +80,8 @@ from strr_api.validators.RegistrationRequestValidator import validate_request
 logger = logging.getLogger("api")
 bp = Blueprint("applications", __name__)
 
+VALID_SORT_FIELDS = ["application_date", "id", "application_number", "decision_date", "invoice_id"]
+
 
 @bp.route("", methods=("POST",))
 @bp.route("/<string:application_number>", methods=["POST", "PUT"])
@@ -167,6 +169,17 @@ def get_applications():
         name: Account-Id
         required: true
         type: string
+      - in: query
+        name: sortBy
+        type: string
+        default: application_date
+        description: Field to sort by (e.g., application_date, id, status)
+      - in: query
+        name: sortOrder
+        type: string
+        enum: [asc, desc]
+        default: asc
+        description: Sort order (ascending or descending)
     responses:
       200:
         description:
@@ -182,8 +195,19 @@ def get_applications():
         page = request.args.get("page", 1)
         limit = request.args.get("limit", 50)
         registration_type = request.args.get("registrationType")
+        sort_by = request.args.get("sortBy", "application_date")
+        sort_order = request.args.get("sortOrder", "asc")
+        if sort_by not in VALID_SORT_FIELDS:
+            sort_by = "application_date"
+        if sort_order not in ["asc", "desc"]:
+            sort_order = "asc"
         filter_criteria = ApplicationSearch(
-            status=status, page=int(page), limit=int(limit), registration_type=registration_type
+            status=status,
+            page=int(page),
+            limit=int(limit),
+            registration_type=registration_type,
+            sort_by=sort_by,
+            sort_order=sort_order
         )
         application_list = ApplicationService.list_applications(account_id, filter_criteria=filter_criteria)
         return jsonify(application_list), HTTPStatus.OK

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -172,13 +172,13 @@ def get_applications():
       - in: query
         name: sortBy
         type: string
-        default: application_date
+        default: id
         description: Field to sort by (e.g., application_date, id, status)
       - in: query
         name: sortOrder
         type: string
         enum: [asc, desc]
-        default: asc
+        default: desc
         description: Sort order (ascending or descending)
     responses:
       200:
@@ -195,19 +195,19 @@ def get_applications():
         page = request.args.get("page", 1)
         limit = request.args.get("limit", 50)
         registration_type = request.args.get("registrationType")
-        sort_by = request.args.get("sortBy", "application_date")
-        sort_order = request.args.get("sortOrder", "asc")
+        sort_by = request.args.get("sortBy", "id")
+        sort_order = request.args.get("sortOrder", "desc")
         if sort_by not in VALID_SORT_FIELDS:
-            sort_by = "application_date"
+            sort_by = "id"
         if sort_order not in ["asc", "desc"]:
-            sort_order = "asc"
+            sort_order = "desc"
         filter_criteria = ApplicationSearch(
             status=status,
             page=int(page),
             limit=int(limit),
             registration_type=registration_type,
             sort_by=sort_by,
-            sort_order=sort_order
+            sort_order=sort_order,
         )
         application_list = ApplicationService.list_applications(account_id, filter_criteria=filter_criteria)
         return jsonify(application_list), HTTPStatus.OK
@@ -754,6 +754,17 @@ def search_applications():
         name: limit
         type: integer
         default: 50
+      - in: query
+        name: sortBy
+        type: string
+        default: id
+        description: Field to sort by (e.g., application_date, id, status)
+      - in: query
+        name: sortOrder
+        type: string
+        enum: [asc, desc]
+        default: desc
+        description: Sort order (ascending or descending)
     responses:
       200:
         description:
@@ -767,11 +778,23 @@ def search_applications():
         status = request.args.get("status", None)
         page = request.args.get("page", 1)
         limit = request.args.get("limit", 50)
-
+        sort_by = request.args.get("sortBy", "id")
+        sort_order = request.args.get("sortOrder", "desc")
+        if sort_by not in VALID_SORT_FIELDS:
+            sort_by = "id"
+        if sort_order not in ["asc", "desc"]:
+            sort_order = "desc"
         if search_text and len(search_text) < 3:
             return error_response(HTTPStatus.BAD_REQUEST, "Search term must be at least 3 characters long.")
 
-        filter_criteria = ApplicationSearch(status=status, page=int(page), limit=int(limit), search_text=search_text)
+        filter_criteria = ApplicationSearch(
+            status=status,
+            page=int(page),
+            limit=int(limit),
+            search_text=search_text,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
 
         application_list = ApplicationService.search_applications(filter_criteria=filter_criteria)
         return jsonify(application_list), HTTPStatus.OK

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -80,7 +80,7 @@ from strr_api.validators.RegistrationRequestValidator import validate_request
 logger = logging.getLogger("api")
 bp = Blueprint("applications", __name__)
 
-VALID_SORT_FIELDS = ["application_date", "id", "application_number", "decision_date", "invoice_id"]
+VALID_SORT_FIELDS = ["application_date", "id", "application_number", "decision_date"]
 
 
 @bp.route("", methods=("POST",))

--- a/strr-api/tests/postman/strr-api.postman_collection.json
+++ b/strr-api/tests/postman/strr-api.postman_collection.json
@@ -286,7 +286,7 @@
 					"response": []
 				},
 				{
-					"name": "List applications (default sort)",
+					"name": "List applications (sort by application_date ascending)",
 					"event": [
 						{
 							"listen": "test",
@@ -346,19 +346,29 @@
 							}
 						],
 						"url": {
-							"raw": "{{api_url}}/applications",
+							"raw": "{{api_url}}/applications?sortBy=application_date&sortOrder=asc",
 							"host": [
 								"{{api_url}}"
 							],
 							"path": [
 								"applications"
+							],
+							"query": [
+								{
+									"key": "sortBy",
+									"value": "application_date"
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc"
+								}
 							]
 						}
 					},
 					"response": []
 				},
 				{
-					"name": "List applications (sort by id descending)",
+					"name": "List applications (default sort)",
 					"event": [
 						{
 							"listen": "test",
@@ -417,22 +427,12 @@
 							}
 						],
 						"url": {
-							"raw": "{{api_url}}/applications?sortBy=id&sortOrder=desc",
+							"raw": "{{api_url}}/applications",
 							"host": [
 								"{{api_url}}"
 							],
 							"path": [
 								"applications"
-							],
-							"query": [
-								{
-									"key": "sortBy",
-									"value": "id"
-								},
-								{
-									"key": "sortOrder",
-									"value": "desc"
-								}
 							]
 						}
 					},
@@ -553,6 +553,45 @@
 				},
 				{
 					"name": "Search Applications",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response contains applications array\", function () {",
+									"    pm.expect(jsonData).to.have.property('applications');",
+									"    pm.expect(jsonData.applications).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Applications are sorted by id in descending order by default\", function () {",
+									"    if (jsonData.applications.length < 2) {",
+									"        pm.test.skip(\"Not enough applications to verify sorting\");",
+									"        return;",
+									"    }",
+									"    ",
+									"    let isSorted = true;",
+									"    for (let i = 1; i < jsonData.applications.length; i++) {",
+									"        const prevId = jsonData.applications[i-1].header.registrationId || 0;",
+									"        const currId = jsonData.applications[i].header.registrationId || 0;",
+									"        if (prevId < currId) {",
+									"            isSorted = false;",
+									"            break;",
+									"        }",
+									"    }",
+									"    pm.expect(isSorted).to.be.true;",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
 					"request": {
 						"auth": {
 							"type": "bearer",
@@ -593,6 +632,101 @@
 								{
 									"key": "page",
 									"value": "1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Search Applications (sort by application_date ascending)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response contains applications array\", function () {",
+									"    pm.expect(jsonData).to.have.property('applications');",
+									"    pm.expect(jsonData.applications).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Applications are sorted by application_date in ascending order\", function () {",
+									"    if (jsonData.applications.length < 2) {",
+									"        pm.test.skip(\"Not enough applications to verify sorting\");",
+									"        return;",
+									"    }",
+									"    ",
+									"    let isSorted = true;",
+									"    for (let i = 1; i < jsonData.applications.length; i++) {",
+									"        const prevDate = new Date(jsonData.applications[i-1].header.applicationDateTime);",
+									"        const currDate = new Date(jsonData.applications[i].header.applicationDateTime);",
+									"        if (prevDate > currDate) {",
+									"            isSorted = false;",
+									"            break;",
+									"        }",
+									"    }",
+									"    pm.expect(isSorted).to.be.true;",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{api_url}}/applications/search?text=018-851-570&limit=10&page=1&sortBy=application_date&sortOrder=asc",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"applications",
+								"search"
+							],
+							"query": [
+								{
+									"key": "text",
+									"value": "018-851-570"
+								},
+								{
+									"key": "limit",
+									"value": "10"
+								},
+								{
+									"key": "page",
+									"value": "1"
+								},
+								{
+									"key": "sortBy",
+									"value": "application_date"
+								},
+								{
+									"key": "sortOrder",
+									"value": "asc"
 								}
 							]
 						}

--- a/strr-api/tests/postman/strr-api.postman_collection.json
+++ b/strr-api/tests/postman/strr-api.postman_collection.json
@@ -286,7 +286,7 @@
 					"response": []
 				},
 				{
-					"name": "List applications",
+					"name": "List applications (default sort)",
 					"event": [
 						{
 							"listen": "test",
@@ -296,6 +296,29 @@
 									"",
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response contains applications array\", function () {",
+									"    pm.expect(jsonData).to.have.property('applications');",
+									"    pm.expect(jsonData.applications).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Default sort is by application_date ascending\", function () {",
+									"    if (jsonData.applications.length < 2) {",
+									"        pm.test.skip(\"Not enough applications to verify sorting\");",
+									"        return;",
+									"    }",
+									"    ",
+									"    let isSorted = true;",
+									"    for (let i = 1; i < jsonData.applications.length; i++) {",
+									"        const prevDate = new Date(jsonData.applications[i-1].header.applicationDateTime);",
+									"        const currDate = new Date(jsonData.applications[i].header.applicationDateTime);",
+									"        if (prevDate > currDate) {",
+									"            isSorted = false;",
+									"            break;",
+									"        }",
+									"    }",
+									"    pm.expect(isSorted).to.be.true;",
 									"});"
 								],
 								"type": "text/javascript",
@@ -329,6 +352,87 @@
 							],
 							"path": [
 								"applications"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List applications (sort by id descending)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Response contains applications array\", function () {",
+									"    pm.expect(jsonData).to.have.property('applications');",
+									"    pm.expect(jsonData.applications).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Applications are sorted by id in descending order\", function () {",
+									"    if (jsonData.applications.length < 2) {",
+									"        pm.test.skip(\"Not enough applications to verify sorting\");",
+									"        return;",
+									"    }",
+									"    ",
+									"    let isSorted = true;",
+									"    for (let i = 1; i < jsonData.applications.length; i++) {",
+									"        const prevId = jsonData.applications[i-1].header.registrationId || 0;",
+									"        const currId = jsonData.applications[i].header.registrationId || 0;",
+									"        if (prevId < currId) {",
+									"            isSorted = false;",
+									"            break;",
+									"        }",
+									"    }",
+									"    pm.expect(isSorted).to.be.true;",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{api_url}}/applications?sortBy=id&sortOrder=desc",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"applications"
+							],
+							"query": [
+								{
+									"key": "sortBy",
+									"value": "id"
+								},
+								{
+									"key": "sortOrder",
+									"value": "desc"
+								}
 							]
 						}
 					},

--- a/strr-host-pm-web/tests/e2e/test-utils/page-helpers.ts
+++ b/strr-host-pm-web/tests/e2e/test-utils/page-helpers.ts
@@ -107,7 +107,7 @@ export const completeStep1 = async (
   await scenarioSpecificItems()
 
   // fill out unit details
-  await page.getByLabel('Property Type').click()
+  await page.getByLabel('Rental Unit Type').click()
   await page.getByRole('option', { name: propertyType }).click()
   await page.locator('#rental-type-radio-group').getByLabel(typeOfSpace).check() // 'Entire home (guests have the entire place to themselves)'
   await page.locator('#rental-unit-setup-radio-group').getByLabel(rentalUnitSetupType).check() // "This unit is the host's principal residence"


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/26041

*Description of changes:*
Addresses @dimak1 comment:
One item is missing from the list - the logic for "get next" application that we did not finalized.
Currently, if examiner clicks 'Examine` tab or Approve/Refuse buttons, they are navigated to next application details page. The next application by default is first Host application under Full Review returned by API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
