### PR TITLE
UI - Examiner NOC

### DIFF
--- a/strr-base-web/app/interfaces/strr-api.ts
+++ b/strr-base-web/app/interfaces/strr-api.ts
@@ -92,6 +92,8 @@ export interface ApplicationHeader {
     username: string
     displayName: string
   }
+  nocStartDate?: Date
+  nocEndDate?: Date
 }
 
 export interface ApiRegistrationResp extends ApiBaseRegistration, ApiExtraRegistrationDetails { }

--- a/strr-base-web/app/utils/date.ts
+++ b/strr-base-web/app/utils/date.ts
@@ -22,7 +22,12 @@ export function dateStringToDate (dateString: string): Date | null {
  * https://moment.github.io/luxon/#/formatting?id=table-of-tokens
 */
 export function dateToString (date: Date | string, format = 'y-MM-dd') {
-  return DateTime.fromJSDate(new Date(date)).toFormat(format)
+  const luxonFormat = format.replace('a', 't')
+  const formattedDate = DateTime.fromJSDate(new Date(date)).toFormat(luxonFormat)
+  if (format.includes('a')) {
+    return formattedDate.replace(/AM|PM/g, (match) => match.toLowerCase())
+  }
+  return formattedDate
 }
 
 /** Convert the date to pacific time and return as a string in the desired format

--- a/strr-base-web/app/utils/date.ts
+++ b/strr-base-web/app/utils/date.ts
@@ -25,7 +25,7 @@ export function dateToString (date: Date | string, format = 'y-MM-dd') {
   const luxonFormat = format.replace('a', 't')
   const formattedDate = DateTime.fromJSDate(new Date(date)).toFormat(luxonFormat)
   if (format.includes('a')) {
-    return formattedDate.replace(/AM|PM/g, (match) => match.toLowerCase())
+    return formattedDate.replace(/AM|PM/g, match => match.toLowerCase())
   }
   return formattedDate
 }

--- a/strr-examiner-web/app/components/ApplicationInfoHeader.vue
+++ b/strr-examiner-web/app/components/ApplicationInfoHeader.vue
@@ -13,7 +13,7 @@ const getBadgeColor = (status: ApplicationStatus): string => {
       return 'green'
     case ApplicationStatus.NOC_PENDING:
     case ApplicationStatus.NOC_EXPIRED:
-      return 'orange'
+      return 'yellow'
     default:
       return 'primary'
   }
@@ -36,7 +36,7 @@ const nocCountdown = computed(() => {
   const daysLeft = dayCountdown(activeHeader.value.nocEndDate.toString(), false)
   return {
     days: daysLeft,
-    isExpired: daysLeft < 0
+    isExpired: activeHeader.value.status === ApplicationStatus.NOC_EXPIRED
   }
 })
 
@@ -70,8 +70,9 @@ const nocCountdown = computed(() => {
         <strong>Submitted:</strong> {{ dateToString(activeHeader.applicationDateTime, 'y-MM-dd a') }}
         ({{ dayCountdown(activeHeader.applicationDateTime.toString(), true) }} days ago)
         <template v-if="activeHeader.nocEndDate">
-          | <strong>NOC Expiry:</strong> <span :class="{ 'font-bold text-red-500': nocCountdown.isExpired }">
-            {{ nocCountdown.isExpired ? 'EXPIRED' : `${nocCountdown.days} days left` }}</span>
+          | <strong>NOC Expiry:</strong> {{ dateToString(activeHeader.nocEndDate, 'y-MM-dd a') }}
+          <span v-if="!nocCountdown.isExpired">{{ `(${nocCountdown.days} days left)` }}</span>
+          <span v-else class="font-bold text-red-500"> (EXPIRED)</span>
         </template>
       </div>
     </div>

--- a/strr-examiner-web/app/components/ApplicationInfoHeader.vue
+++ b/strr-examiner-web/app/components/ApplicationInfoHeader.vue
@@ -11,6 +11,9 @@ const getBadgeColor = (status: ApplicationStatus): string => {
     case ApplicationStatus.FULL_REVIEW_APPROVED:
     case ApplicationStatus.PROVISIONALLY_APPROVED:
       return 'green'
+    case ApplicationStatus.NOC_PENDING:
+    case ApplicationStatus.NOC_EXPIRED:
+      return 'orange'
     default:
       return 'primary'
   }
@@ -28,6 +31,14 @@ const getApplicationName = (): string => {
       return ''
   }
 }
+
+const nocCountdown = computed(() => {
+  const daysLeft = dayCountdown(activeHeader.value.nocEndDate.toString(), false)
+  return {
+    days: daysLeft,
+    isExpired: daysLeft < 0
+  }
+})
 
 </script>
 <template>
@@ -56,8 +67,12 @@ const getApplicationName = (): string => {
         />
         <strong>Type:</strong>
         {{ $t(`applicationType.${activeReg?.registrationType}`) }} |
-        <strong>Submitted:</strong> {{ dateToString(activeHeader.applicationDateTime, 'y-MM-dd t') }}
+        <strong>Submitted:</strong> {{ dateToString(activeHeader.applicationDateTime, 'y-MM-dd a') }}
         ({{ dayCountdown(activeHeader.applicationDateTime.toString(), true) }} days ago)
+        <template v-if="activeHeader.nocEndDate">
+          | <strong>NOC Expiry:</strong> <span :class="{ 'font-bold text-red-500': nocCountdown.isExpired }">
+            {{ nocCountdown.isExpired ? 'EXPIRED' : `${nocCountdown.days} days left` }}</span>
+        </template>
       </div>
     </div>
   </div>

--- a/strr-examiner-web/app/components/ComposeNoc.vue
+++ b/strr-examiner-web/app/components/ComposeNoc.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+const { sendNocSchema, validateNocContent } = useExaminerStore()
+const { nocContent, showNocModal, nocFormRef } = storeToRefs(useExaminerStore())
+const { t } = useI18n()
+
+</script>
+
+<template>
+  <div v-if="showNocModal" class="app-inner-container">
+    <div class="mb-8 rounded bg-white py-6">
+      <UForm
+        ref="nocFormRef"
+        :schema="sendNocSchema"
+        :state="nocContent"
+        @input="validateNocContent()"
+      >
+        <div class="flex">
+          <div class="flex w-1/5 flex-col items-center">
+            <span class="pl-5 font-bold">{{ t('modal.noc.title') }}</span>
+          </div>
+          <div class="flex-auto pr-10">
+            <UFormGroup name="content">
+              <UTextarea
+                v-model="nocContent.content"
+                :placeholder="t('modal.noc.placeholder')"
+                :aria-label="t('modal.noc.placeholder')"
+                :color="'gray'"
+                class="text-bcGovColor-midGray focus:ring-0"
+                auto-resize
+                resize
+                :rows="3"
+              />
+            </UFormGroup>
+          </div>
+        </div>
+      </UForm>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/strr-examiner-web/app/components/ComposeNoc.vue
+++ b/strr-examiner-web/app/components/ComposeNoc.vue
@@ -37,5 +37,3 @@ const { t } = useI18n()
     </div>
   </div>
 </template>
-
-<style scoped></style>

--- a/strr-examiner-web/app/components/ComposeNoc.vue
+++ b/strr-examiner-web/app/components/ComposeNoc.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
-const { sendNocSchema, validateNocContent } = useExaminerStore()
+const { sendNocSchema } = useExaminerStore()
 const { nocContent, showNocModal, nocFormRef } = storeToRefs(useExaminerStore())
 const { t } = useI18n()
 
+const handleInput = () => {
+  if (nocContent.value.content.length > 1 && nocFormRef.value) {
+    nocFormRef.value.clear()
+  }
+}
 </script>
 
 <template>
@@ -12,7 +17,7 @@ const { t } = useI18n()
         ref="nocFormRef"
         :schema="sendNocSchema"
         :state="nocContent"
-        @input="validateNocContent()"
+        :validate-on="['submit']"
       >
         <div class="flex">
           <div class="flex w-1/5 flex-col items-center">
@@ -29,6 +34,7 @@ const { t } = useI18n()
                 auto-resize
                 resize
                 :rows="3"
+                @update:model-value="handleInput"
               />
             </UFormGroup>
           </div>

--- a/strr-examiner-web/app/components/RegistrationInfoHeader.vue
+++ b/strr-examiner-web/app/components/RegistrationInfoHeader.vue
@@ -71,8 +71,8 @@ const getRegistrationType = (): string => {
             :color="getBadgeColor(activeReg.status!)"
           />
           <strong>Registration Date:</strong>
-          {{ dateToString(activeReg.startDate, 'y-MM-dd t') }}
-          <strong>Expiry Date:</strong> {{ dateToString(activeReg.expiryDate, 'y-MM-dd t') }}
+          {{ dateToString(activeReg.startDate, 'y-MM-dd a') }} |
+          <strong>Expiry Date:</strong> {{ dateToString(activeReg.expiryDate, 'y-MM-dd a') }}
           ({{ dayCountdown(activeReg.expiryDate.toString()) }} days left)
         </div>
       </div>
@@ -82,9 +82,9 @@ const getRegistrationType = (): string => {
         <strong>Type:</strong>
         {{ getRegistrationType() }} |
         <strong>Submitted:</strong>
-        {{ activeHeader.applicationDateTime }} |
+        {{ dateToString(activeHeader.applicationDateTime, 'y-MM-dd a') }}
         <template v-if="activeHeader.reviewer?.username">
-          <strong>Approved By:</strong>
+          | <strong>Approved By:</strong>
           {{ activeHeader.reviewer.username }}
         </template>
       </div>

--- a/strr-examiner-web/app/composables/useExaminerActions.ts
+++ b/strr-examiner-web/app/composables/useExaminerActions.ts
@@ -1,3 +1,5 @@
+import { ApplicationActionsE, RegistrationActionsE } from '@/enums/actions'
+
 export const useExaminerActions = () => {
   const strrModal = useStrrModals()
   const { t } = useI18n()
@@ -18,7 +20,7 @@ export const useExaminerActions = () => {
    */
   const manageAction = async <T extends { id: string | number }, Args extends any[] = []>(
     item: T,
-    action: string,
+    action: ApplicationActionsE | RegistrationActionsE,
     actionFn: (id: T['id'], ...args: Args) => Promise<void>,
     buttonPosition: 'left' | 'right',
     buttonIndex: number,
@@ -29,12 +31,8 @@ export const useExaminerActions = () => {
     try {
       handleButtonLoading(false, buttonPosition, buttonIndex)
       if (validateFn) {
-        let isValid = true
-        if (action === 'SEND_NOC') {
-          isValid = await validateFn() as boolean
-        }
+        const isValid = await validateFn() as boolean
         if (!isValid) {
-          handleButtonLoading(true)
           return
         }
       }

--- a/strr-examiner-web/app/composables/useExaminerActions.ts
+++ b/strr-examiner-web/app/composables/useExaminerActions.ts
@@ -1,5 +1,6 @@
 export const useExaminerActions = () => {
   const strrModal = useStrrModals()
+  const { t } = useI18n()
   const { handleButtonLoading } = useButtonControl()
 
   /**
@@ -22,15 +23,27 @@ export const useExaminerActions = () => {
     buttonPosition: 'left' | 'right',
     buttonIndex: number,
     refresh: () => void,
-    additionalArgs: Args = [] as unknown as Args
+    additionalArgs: Args = [] as unknown as Args,
+    validateFn?: () => Promise<boolean> | MultiFormValidationResult | boolean
   ) => {
     try {
       handleButtonLoading(false, buttonPosition, buttonIndex)
+      if (validateFn) {
+        let isValid = true
+        if (action === 'SEND_NOC') {
+          isValid = await validateFn() as boolean
+        }
+        if (!isValid) {
+          handleButtonLoading(true)
+          return
+        }
+      }
       await actionFn(item.id, ...additionalArgs)
       refresh()
     } catch (error) {
       console.error(error)
-      strrModal.openErrorModal('Error', `An error occurred ${action.toLowerCase()}ing this item.`, false)
+      const errMsg = t(`error.action.${action.toLowerCase()}`)
+      strrModal.openErrorModal('Error', errMsg, false)
     } finally {
       handleButtonLoading(true)
     }

--- a/strr-examiner-web/app/composables/useExaminerActions.ts
+++ b/strr-examiner-web/app/composables/useExaminerActions.ts
@@ -26,15 +26,12 @@ export const useExaminerActions = () => {
     buttonIndex: number,
     refresh: () => void,
     additionalArgs: Args = [] as unknown as Args,
-    validateFn?: () => Promise<boolean> | MultiFormValidationResult | boolean
+    validateFn?: () => Promise<boolean>
   ) => {
     try {
       handleButtonLoading(false, buttonPosition, buttonIndex)
-      if (validateFn) {
-        const isValid = await validateFn() as boolean
-        if (!isValid) {
-          return
-        }
+      if (validateFn && !(await validateFn())) {
+        return
       }
       await actionFn(item.id, ...additionalArgs)
       refresh()

--- a/strr-examiner-web/app/composables/useExaminerRoute.ts
+++ b/strr-examiner-web/app/composables/useExaminerRoute.ts
@@ -15,8 +15,8 @@ export const useExaminerRoute = () => {
         action: (id: string) => void
         label: string
       }
-      suspend?: {
-        action: (id: number) => void
+      sendNotice?: {
+        action: (id: string) => void
         label: string
       }
       cancel?: {
@@ -31,13 +31,15 @@ export const useExaminerRoute = () => {
     }
 
     let id: string | number | undefined
-    let examinerActions: string[] | undefined = []
-    if (isApplication.value) {
+    let examinerActions: string[] = []
+    if (isApplication.value && activeHeader.value) {
       id = activeHeader.value.applicationNumber
-    } else {
+    } else if (activeReg.value) {
       id = activeReg.value.id
     }
-    examinerActions = activeHeader.value.examinerActions || []
+    if (activeHeader.value && activeHeader.value.examinerActions) {
+      examinerActions = activeHeader.value.examinerActions
+    }
 
     if (id) {
       window.history.replaceState(
@@ -50,41 +52,45 @@ export const useExaminerRoute = () => {
         const leftButtons: ConnectBtnControlItem[] = []
         const rightButtons: ConnectBtnControlItem[] = []
 
-        examinerActions.forEach((action) => {
-          if (action === 'APPROVE' && buttonConfig.approve) {
-            rightButtons.push({
-              action: () => buttonConfig.approve.action(id as string),
-              label: buttonConfig.approve.label,
-              variant: 'outline',
-              color: 'green',
-              icon: 'i-mdi-check'
-            })
-          } else if (action === 'REJECT' && buttonConfig.reject) {
-            rightButtons.push({
-              action: () => buttonConfig.reject.action(id as string),
-              label: buttonConfig.reject.label,
-              variant: 'outline',
-              color: 'red',
-              icon: 'i-mdi-close'
-            })
-          } else if (action === 'SUSPEND' && buttonConfig.suspend) {
-            rightButtons.push({
-              action: () => buttonConfig.suspend.action(id as number),
-              label: buttonConfig.suspend.label,
-              variant: 'outline',
-              color: 'blue',
-              icon: 'i-mdi-pause'
-            })
-          } else if (action === 'CANCEL' && buttonConfig.cancel) {
-            rightButtons.push({
-              action: () => buttonConfig.cancel.action(id as number),
-              label: buttonConfig.cancel.label,
-              variant: 'outline',
-              color: 'red',
-              icon: 'i-mdi-close'
-            })
-          }
-        })
+        if (examinerActions.includes('SEND_NOC') && buttonConfig.sendNotice) {
+          rightButtons.push({
+            action: () => buttonConfig.sendNotice.action(id as string),
+            label: buttonConfig.sendNotice.label,
+            variant: 'outline',
+            color: 'blue',
+            icon: 'i-mdi-send'
+          })
+        }
+
+        if (examinerActions.includes('REJECT') && buttonConfig.reject) {
+          rightButtons.push({
+            action: () => buttonConfig.reject.action(id as string),
+            label: buttonConfig.reject.label,
+            variant: 'outline',
+            color: 'red',
+            icon: 'i-mdi-close'
+          })
+        }
+
+        if (examinerActions.includes('APPROVE') && buttonConfig.approve) {
+          rightButtons.push({
+            action: () => buttonConfig.approve.action(id as string),
+            label: buttonConfig.approve.label,
+            variant: 'outline',
+            color: 'green',
+            icon: 'i-mdi-check'
+          })
+        }
+
+        if (examinerActions.includes('CANCEL') && buttonConfig.cancel) {
+          rightButtons.push({
+            action: () => buttonConfig.cancel.action(id as number),
+            label: buttonConfig.cancel.label,
+            variant: 'outline',
+            color: 'red',
+            icon: 'i-mdi-close'
+          })
+        }
 
         setButtonControl({
           leftButtons,

--- a/strr-examiner-web/app/composables/useExaminerRoute.ts
+++ b/strr-examiner-web/app/composables/useExaminerRoute.ts
@@ -1,3 +1,5 @@
+import { ApplicationActionsE, RegistrationActionsE } from '@/enums/actions'
+
 export const useExaminerRoute = () => {
   const localePath = useLocalePath()
   const { setButtonControl } = useButtonControl()
@@ -52,7 +54,7 @@ export const useExaminerRoute = () => {
         const leftButtons: ConnectBtnControlItem[] = []
         const rightButtons: ConnectBtnControlItem[] = []
 
-        if (examinerActions.includes('SEND_NOC') && buttonConfig.sendNotice) {
+        if (examinerActions.includes(ApplicationActionsE.SEND_NOC) && buttonConfig.sendNotice) {
           rightButtons.push({
             action: () => buttonConfig.sendNotice.action(id as string),
             label: buttonConfig.sendNotice.label,
@@ -62,7 +64,7 @@ export const useExaminerRoute = () => {
           })
         }
 
-        if (examinerActions.includes('REJECT') && buttonConfig.reject) {
+        if (examinerActions.includes(ApplicationActionsE.REJECT) && buttonConfig.reject) {
           rightButtons.push({
             action: () => buttonConfig.reject.action(id as string),
             label: buttonConfig.reject.label,
@@ -72,7 +74,7 @@ export const useExaminerRoute = () => {
           })
         }
 
-        if (examinerActions.includes('APPROVE') && buttonConfig.approve) {
+        if (examinerActions.includes(ApplicationActionsE.APPROVE) && buttonConfig.approve) {
           rightButtons.push({
             action: () => buttonConfig.approve.action(id as string),
             label: buttonConfig.approve.label,
@@ -82,7 +84,7 @@ export const useExaminerRoute = () => {
           })
         }
 
-        if (examinerActions.includes('CANCEL') && buttonConfig.cancel) {
+        if (examinerActions.includes(RegistrationActionsE.CANCEL) && buttonConfig.cancel) {
           rightButtons.push({
             action: () => buttonConfig.cancel.action(id as number),
             label: buttonConfig.cancel.label,

--- a/strr-examiner-web/app/enums/actions.ts
+++ b/strr-examiner-web/app/enums/actions.ts
@@ -1,0 +1,9 @@
+export enum ApplicationActionsE {
+    APPROVE = 'APPROVE',
+    REJECT = 'REJECT',
+    SEND_NOC = 'SEND_NOC'
+  }
+
+export enum RegistrationActionsE {
+    CANCEL = 'CANCEL'
+  }

--- a/strr-examiner-web/app/locales/en-CA.ts
+++ b/strr-examiner-web/app/locales/en-CA.ts
@@ -236,9 +236,16 @@ export default {
     decline: 'Refuse',
     approve: 'Approve',
     cancel: 'Cancel',
-    suspend: 'Suspend'
+    suspend: 'Suspend',
+    sendNotice: 'Send Notice'
   },
   error: {
+    action: {
+      approve: 'An error occurred approving this application.',
+      reject: 'An error occurred rejecting this application.',
+      send_noc: 'An error occurred sending the Notice of Consideration for this application.',
+      cancel: 'An error occurred cancelling this registration.'
+    },
     createAccount: {
       title: 'Error creating account',
       description: 'We could not create your account at this time. Please try again or if this issue persists, please contact us.'
@@ -311,6 +318,10 @@ export default {
       triggerBtn: 'Help with setting up an account',
       title: 'Need Help?',
       content: 'If you need help with setting up your BC Registries and Online Services account, please contact us.'
+    },
+    noc: {
+      title: 'Email to Completing Party',
+      placeholder: 'Email Body Text'
     }
   },
   table: {
@@ -386,7 +397,8 @@ export default {
     typeOfSpace: 'Please select the type of space of the unit',
     ownerRole: 'Please select the role',
     missingReqDocs: 'Missing required documents. Please see above for details.',
-    blExpiryDate: 'The expiry date must be greater than today and in less than 1 year.'
+    blExpiryDate: 'The expiry date must be greater than today and in less than 1 year.',
+    nocContent: 'Please enter email body text'
   },
   registrationType: {
     HOST: 'Host',

--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -516,14 +516,14 @@ function handleColumnSort (column: string) {
         <template #submissionDate-data="{ row }">
           <div class="flex flex-col">
             <span>{{ dateToStringPacific(row.submissionDate) }}</span>
-            <span>{{ dateToString(row.submissionDate, 't') }}</span>
+            <span>{{ dateToString(row.submissionDate, 'a') }}</span>
           </div>
         </template>
 
         <template #lastModified-data="{ row }">
           <div class="flex flex-col">
             <span>{{ dateToStringPacific(row.lastModified) }}</span>
-            <span>{{ dateToString(row.lastModified, 't') }}</span>
+            <span>{{ dateToString(row.lastModified, 'a') }}</span>
           </div>
         </template>
       </UTable>

--- a/strr-examiner-web/app/pages/examine/[applicationId].vue
+++ b/strr-examiner-web/app/pages/examine/[applicationId].vue
@@ -55,10 +55,7 @@ const handleApplicationAction = (
       refresh()
     }
     additionalArgs = [nocContent.value.content]
-    validateFn = async () => {
-      const errors = await validateForm(nocFormRef.value, true)
-      return !errors
-    }
+    validateFn = async () => await validateForm(nocFormRef.value, true).then(errors => !errors)
   } else if (action === ApplicationActionsE.APPROVE) {
     actionFn = approveApplication
   } else if (action === ApplicationActionsE.REJECT) {

--- a/strr-examiner-web/app/pages/examine/[applicationId].vue
+++ b/strr-examiner-web/app/pages/examine/[applicationId].vue
@@ -45,13 +45,15 @@ const handleApplicationAction = (
   buttonPosition: 'left' | 'right',
   buttonIndex: number
 ) => {
-  const actionFn = action === 'SEND_NOC'
-    ? sendNoticeOfConsideration
-    : action === 'APPROVE'
-      ? approveApplication
-      : action === 'REJECT'
-        ? rejectApplication
-        : undefined
+  let actionFn
+  if (action === 'SEND_NOC') {
+    actionFn = sendNoticeOfConsideration
+  } else if (action === 'APPROVE') {
+    actionFn = approveApplication
+  } else if (action === 'REJECT') {
+    actionFn = rejectApplication
+  }
+
   const additionalArgs = action === 'SEND_NOC' ? [nocContent.value.content] : []
   const validateFn = action === 'SEND_NOC'
     ? validateNocContent

--- a/strr-examiner-web/app/pages/registration/[registrationId].vue
+++ b/strr-examiner-web/app/pages/registration/[registrationId].vue
@@ -29,7 +29,7 @@ const { data: registration, status, error, refresh } = await useLazyAsyncData<
 
 const handleRegistrationAction = (
   id: number,
-  action: 'CANCEL',
+  action: RegistrationActionsE,
   buttonPosition: 'left' | 'right',
   buttonIndex: number
 ) => {
@@ -52,7 +52,7 @@ watch(
 
     updateRouteAndButtons(RoutesE.REGISTRATION, {
       cancel: {
-        action: (id: number) => handleRegistrationAction(id, 'CANCEL', 'right', 0),
+        action: (id: number) => handleRegistrationAction(id, RegistrationActionsE.CANCEL, 'right', 0),
         label: t('btn.cancel')
       }
     })

--- a/strr-examiner-web/app/pages/registration/[registrationId].vue
+++ b/strr-examiner-web/app/pages/registration/[registrationId].vue
@@ -29,11 +29,11 @@ const { data: registration, status, error, refresh } = await useLazyAsyncData<
 
 const handleRegistrationAction = (
   id: number,
-  action: 'CANCEL' | 'SUSPEND',
+  action: 'CANCEL',
   buttonPosition: 'left' | 'right',
   buttonIndex: number
 ) => {
-  const status = action === 'CANCEL' ? RegistrationStatus.CANCELLED : RegistrationStatus.SUSPENDED
+  const status = RegistrationStatus.CANCELLED
   return manageAction(
     { id },
     action,
@@ -52,12 +52,8 @@ watch(
 
     updateRouteAndButtons(RoutesE.REGISTRATION, {
       cancel: {
-        action: (id: number) => handleRegistrationAction(id, 'CANCEL', 'right', 1),
+        action: (id: number) => handleRegistrationAction(id, 'CANCEL', 'right', 0),
         label: t('btn.cancel')
-      },
-      suspend: {
-        action: (id: number) => handleRegistrationAction(id, 'SUSPEND', 'right', 0),
-        label: t('btn.suspend')
       }
     })
   }

--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -23,20 +23,10 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
     content: ''
   })
   const showNocModal = ref(true)
-  const nocFormRef = ref()
-
+  const nocFormRef = ref<Form<any>>()
   const sendNocSchema = computed(() => z.object({
     content: z.string().min(1, { message: t('validation.nocContent') })
   }))
-
-  const validateNocContent = async (): Promise<boolean> => {
-    try {
-      await nocFormRef.value.validate()
-      return true
-    } catch (error) {
-      return false
-    }
-  }
 
   const tableFilters = reactive({
     searchText: '',
@@ -122,7 +112,6 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
       method: 'POST',
       body: { content }
     })
-    nocContent.content = ''
   }
 
   /**
@@ -200,7 +189,6 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
     activeReg,
     activeHeader,
     sendNocSchema,
-    validateNocContent,
     nocContent,
     nocFormRef,
     showNocModal,

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/26241

*Description of changes:*
- Examiner NOC UI changes
- Removed suspend action for registrations (per feedback from Andy)
- RegistrationInfoHeader - fixed `Submitted`, added missing | between registration & expiry date
- RegistrationInfoHeader & ApplicationInfoHeader - lowercase am and pm
- Deviation from design
  - Width of NOC component to be same as section above (checked with Andy)
  - Refuse/reject is an acceptable examiner action for `FULL_REVIEW` status (discussed with Lekshmi)
    <img width="839" alt="image" src="https://github.com/user-attachments/assets/41423470-31ff-4e12-bbf1-69d8eb584b6f" />

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/64b8e383-86b5-40da-acc7-3b46a1598c31" />
<img width="1379" alt="image" src="https://github.com/user-attachments/assets/85169754-1e14-496f-9171-d109abdd42fd" />
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/7d8ac926-a82f-41ab-9a85-351822244155" />
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/26b93ef0-f804-428b-909b-50eb5d50206d" />
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/23c707c6-2eb1-49d4-9baf-a9e87c523877" />
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/3b78a087-d699-4b02-8e29-86c03d793b56" />
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/8264717d-bd71-44e6-bace-c85d6f8e2b21" />
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/14d585ba-b723-4651-9547-fca9a548c110" />
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/528a9dfd-6b04-4f70-91af-1e4cb6f74743" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
