### PR TITLE
Refactor Supporting Documents for Host and Strata

### DIFF
--- a/strr-examiner-web/app/components/Host/SubHeader.vue
+++ b/strr-examiner-web/app/components/Host/SubHeader.vue
@@ -98,7 +98,9 @@ const hostExp = useHostExpansion()
             data-testid="flag-host-address-not-same"
           />
         </div>
-        <div><strong>{{ t('strr.label.pid') }}</strong> {{ activeReg.unitDetails?.parcelIdentifier }}</div>
+        <div v-if="activeReg.unitDetails?.parcelIdentifier">
+          <strong>{{ t('strr.label.pid') }}</strong> {{ activeReg.unitDetails?.parcelIdentifier }}
+        </div>
         <div v-if="isApplication" class="flex gap-x-1">
           <strong>{{ t('strr.label.registeredRentals') }}</strong>
           {{ (activeHeader as ApplicationHeader)?.existingHostRegistrations }}

--- a/strr-examiner-web/app/components/Strata/SupportingInfo.vue
+++ b/strr-examiner-web/app/components/Strata/SupportingInfo.vue
@@ -5,12 +5,31 @@ const exStore = useExaminerStore()
 const { activeReg } = storeToRefs(exStore)
 
 const { t } = useI18n()
+
+// show all documents except those uploaded during NOC
+const applicationDocumentsConfig: SupportingDocumentsConfig = {
+  excludeUploadStep: [DocumentUploadStep.NOC]
+}
+
+// show documents uploaded during NOC only, with their date badges
+const nocDocumentsConfig: SupportingDocumentsConfig = {
+  includeUploadStep: [DocumentUploadStep.NOC],
+  includeDateBadge: [DocumentUploadStep.NOC]
+}
+
 </script>
 <template>
   <ConnectPageSection v-if="activeReg?.documents?.length">
     <div class="divide-y px-10 py-6">
       <ApplicationDetailsSection :label="t('strr.label.supportingInfo')">
-        <SupportingDocuments />
+        <SupportingDocuments
+          class="mb-1 flex gap-y-1"
+          :config="applicationDocumentsConfig"
+        />
+        <SupportingDocuments
+          class="mb-1 flex gap-y-1"
+          :config="nocDocumentsConfig"
+        />
       </ApplicationDetailsSection>
     </div>
   </ConnectPageSection>

--- a/strr-examiner-web/app/interfaces/supporting-documents.ts
+++ b/strr-examiner-web/app/interfaces/supporting-documents.ts
@@ -1,0 +1,13 @@
+/**
+ * Configuration interface for supporting documents.
+ *
+ * Allows filtering of the Supporting Documents, with options to include or exclude specific upload types and steps,
+ * and to show or hide upload date badges.
+ */
+export interface SupportingDocumentsConfig {
+    includeTypes?: DocumentUploadType[],
+    excludeTypes?: DocumentUploadType[],
+    includeUploadStep?: DocumentUploadStep[],
+    excludeUploadStep?: DocumentUploadStep[],
+    includeDateBadge?: DocumentUploadStep[] // Upload Steps for which to show the date badges
+}

--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -186,7 +186,7 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
         requirements: [],
         applicantName: '',
         propertyAddress: '',
-        status: [ApplicationStatus.FULL_REVIEW],
+        status: [],
         submissionDate: { start: null, end: null },
         lastModified: { start: null, end: null },
         adjudicator: []

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",
@@ -47,5 +47,6 @@
     "nuxt": "^3.15.0",
     "uuid": "^11.0.3",
     "v-calendar": "^3.1.2"
-  }
+  },
+  "packageManager": "pnpm@9.13.2+sha1.969cc200a41db98449afee1bfa7578b3ce6ff330"
 }

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -47,6 +47,5 @@
     "nuxt": "^3.15.0",
     "uuid": "^11.0.3",
     "v-calendar": "^3.1.2"
-  },
-  "packageManager": "pnpm@9.13.2+sha1.969cc200a41db98449afee1bfa7578b3ce6ff330"
+  }
 }

--- a/strr-examiner-web/tests/unit/components.spec.ts
+++ b/strr-examiner-web/tests/unit/components.spec.ts
@@ -1,0 +1,125 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, it, vi, expect } from 'vitest'
+import filter from 'lodash/filter'
+import { enI18n } from '../mocks/i18n'
+import { mockDocuments, mockDocumentsNOC, mockHostApplication } from '../mocks/mockedData'
+import SupportingDocuments from '~/components/SupportingDocuments.vue'
+import { UBadge, UButton } from '#components'
+
+describe('SupportingDocuments Component', () => {
+  // setup documents for tests
+  const allMocDocuments = [...mockDocuments, ...mockDocumentsNOC]
+  mockHostApplication.registration.documents = allMocDocuments
+
+  vi.mock('@/stores/examiner', () => ({
+    useExaminerStore: () => ({
+      activeReg: ref(mockHostApplication.registration),
+      activeHeader: ref(mockHostApplication.header),
+      activeRecord: ref(mockHostApplication)
+    })
+  }))
+
+  // create SupportingDocuments component with a specified config
+  const mountComponent = async (config: SupportingDocumentsConfig) => {
+    return await mountSuspended(SupportingDocuments, {
+      global: { plugins: [enI18n] },
+      props: { config }
+    })
+  }
+
+  // Supporting Documents Configs to help with testing
+
+  const NO_CONFIG = {} // show all documents, exclude badges
+
+  const ALL_DOCS_NOC_BADGES: SupportingDocumentsConfig = { // all documents with all date badges for NOC upload step
+    includeDateBadge: [DocumentUploadStep.NOC]
+  }
+
+  const BUSINESS_LIC_DOCS: SupportingDocumentsConfig = { // only BL docs during initial application submission
+    includeTypes: [DocumentUploadType.LOCAL_GOVT_BUSINESS_LICENSE],
+    excludeUploadStep: [DocumentUploadStep.NOC]
+  }
+
+  const BUSINESS_LIC_NOC_DOCS: SupportingDocumentsConfig = { // only BL docs during NOC Pending
+    includeTypes: [DocumentUploadType.LOCAL_GOVT_BUSINESS_LICENSE],
+    includeUploadStep: [DocumentUploadStep.NOC]
+  }
+
+  const INITIAL_APP_DOCS: SupportingDocumentsConfig = { // only docs during initial application submission, exclude NOC
+    excludeUploadStep: [DocumentUploadStep.NOC]
+  }
+
+  const NOC_APP_DOCS: SupportingDocumentsConfig = { // only docs during initial application submission, exclude NOC
+    includeUploadStep: [DocumentUploadStep.NOC],
+    includeDateBadge: [DocumentUploadStep.NOC]
+  }
+
+  it('should display all documents without date badges', async () => {
+    const supportingDocuments = await mountComponent(NO_CONFIG)
+
+    expect(supportingDocuments.exists()).toBe(true)
+    expect(supportingDocuments.findAllComponents(UButton).length).toBe(allMocDocuments.length)
+    expect(supportingDocuments.findAllComponents(UBadge).length).toBe(0) // no badges because of empty config
+  })
+
+  it('should display all documents with date badges for NOC documents', async () => {
+    const supportingDocuments = await mountComponent(ALL_DOCS_NOC_BADGES)
+
+    const filteredDocsCount = filter(allMocDocuments, {
+      uploadStep: DocumentUploadStep.NOC
+    }).length
+
+    expect(supportingDocuments.exists()).toBe(true)
+    expect(supportingDocuments.findAllComponents(UButton).length).toBe(allMocDocuments.length)
+    expect(supportingDocuments.findAllComponents(UBadge).length).toBe(filteredDocsCount)
+  })
+
+  it('should display only Business Lic documents', async () => {
+    const supportingDocuments = await mountComponent(BUSINESS_LIC_DOCS)
+
+    const filteredDocsCount = filter(allMocDocuments, {
+      documentType: DocumentUploadType.LOCAL_GOVT_BUSINESS_LICENSE
+    }).length
+
+    expect(supportingDocuments.exists()).toBe(true)
+    expect(supportingDocuments.findAllComponents(UButton).length).toBe(filteredDocsCount)
+    expect(supportingDocuments.findAllComponents(UBadge).length).toBe(0)
+  })
+
+  it('should display only Business Lic documents during NOC', async () => {
+    const supportingDocuments = await mountComponent(BUSINESS_LIC_NOC_DOCS)
+
+    const filteredDocsCount = filter(allMocDocuments, {
+      documentType: DocumentUploadType.LOCAL_GOVT_BUSINESS_LICENSE,
+      uploadStep: DocumentUploadStep.NOC
+    }).length
+
+    expect(supportingDocuments.exists()).toBe(true)
+    expect(supportingDocuments.findAllComponents(UButton).length).toBe(filteredDocsCount)
+    expect(supportingDocuments.findAllComponents(UBadge).length).toBe(0)
+  })
+
+  it('should display all documents during initial application submission (exclude NOC)', async () => {
+    const supportingDocuments = await mountComponent(INITIAL_APP_DOCS)
+
+    const filteredDocsCount = allMocDocuments.length - filter(allMocDocuments, {
+      uploadStep: DocumentUploadStep.NOC
+    }).length
+
+    expect(supportingDocuments.exists()).toBe(true)
+    expect(supportingDocuments.findAllComponents(UButton).length).toBe(filteredDocsCount)
+    expect(supportingDocuments.findAllComponents(UBadge).length).toBe(0)
+  })
+
+  it('should display all docs uploaded during NOC Pending status', async () => {
+    const supportingDocuments = await mountComponent(NOC_APP_DOCS)
+
+    const filteredDocsCount = filter(allMocDocuments, {
+      uploadStep: DocumentUploadStep.NOC
+    }).length
+
+    expect(supportingDocuments.exists()).toBe(true)
+    expect(supportingDocuments.findAllComponents(UButton).length).toBe(filteredDocsCount)
+    expect(supportingDocuments.findAllComponents(UBadge).length).toBe(3)
+  })
+})

--- a/strr-examiner-web/tests/unit/host-application-details.spec.ts
+++ b/strr-examiner-web/tests/unit/host-application-details.spec.ts
@@ -13,7 +13,7 @@ import ApplicationDetails from '~/pages/examine/[applicationId].vue'
 import {
   ApplicationInfoHeader, HostSubHeader, HostSupportingInfo,
   StrataSubHeader, PlatformSubHeader, UBadge, UButton,
-  StrataSupportingInfo
+  StrataSupportingInfo, SupportingDocuments
 } from '#components'
 
 let currentMockData = mockHostApplication
@@ -24,7 +24,13 @@ vi.mock('@/stores/examiner', () => ({
     activeReg: ref(currentMockData.registration),
     activeHeader: ref(currentMockData.header),
     activeRecord: ref(currentMockData),
-    isApplication: ref(true)
+    isApplication: ref(true),
+    openDocInNewTab: vi.fn().mockImplementation(() => {
+      const url = URL.createObjectURL(new Blob(['test']))
+      window.open(url, '_blank')
+      URL.revokeObjectURL(url)
+      setTimeout(() => URL.revokeObjectURL(url), 100)
+    })
   })
 }))
 
@@ -54,6 +60,7 @@ describe('Examiner - Host Application Details Page', () => {
     expect(wrapper.findComponent(ApplicationInfoHeader).exists()).toBe(true)
     expect(wrapper.findComponent(HostSubHeader).exists()).toBe(true)
     expect(wrapper.findComponent(HostSupportingInfo).exists()).toBe(true)
+    expect(wrapper.findComponent(SupportingDocuments).exists()).toBe(true)
     expect(wrapper.findComponent(StrataSubHeader).exists()).toBe(false)
     expect(wrapper.findComponent(StrataSupportingInfo).exists()).toBe(false)
     expect(wrapper.findComponent(PlatformSubHeader).exists()).toBe(false)
@@ -91,7 +98,8 @@ describe('Examiner - Host Application Details Page', () => {
     expect(hostSupportingInfo.exists()).toBe(true)
     expect(hostSupportingInfo.findTestId('str-prohibited-section').exists()).toBe(false)
     expect(hostSupportingInfo.findTestId('business-lic-section').exists()).toBe(true)
-    expect(hostSupportingInfo.findTestId('open-business-lic-btn').exists()).toBe(true)
+    expect(hostSupportingInfo.findTestId('bl-documents').exists()).toBe(true)
+    expect(hostSupportingInfo.findTestId('open-business-lic-btn-0').exists()).toBe(true)
     expect(hostSupportingInfo.findTestId('business-lic-section').text())
       .toContain(mockHostApplication.registration.unitDetails!.businessLicense)
     expect(hostSupportingInfo.findTestId('business-lic-section').findAllComponents(UButton).length).toBe(1)
@@ -102,7 +110,9 @@ describe('Examiner - Host Application Details Page', () => {
 
   it('opens document in new tab when business license button is clicked', async () => {
     const hostSupportingInfo = wrapper.findComponent(HostSupportingInfo)
-    const businessLicBtn = hostSupportingInfo.findTestId('open-business-lic-btn')
+    expect(hostSupportingInfo.findTestId('bl-documents').exists()).toBe(true)
+    expect(hostSupportingInfo.findTestId('open-business-lic-btn-0').exists()).toBe(true)
+    const businessLicBtn = hostSupportingInfo.findTestId('open-business-lic-btn-0')
     await businessLicBtn.trigger('click')
     expect(mockOpen).toHaveBeenCalledWith('blob:url', '_blank')
   })


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/26234

*Description of changes:*
- Refactor SupportingDocuments component to support existing and NOC documents, for Host and Strata
- Main requirement: Show NOC documents (with badges) separately on the new line below the initial application documents
- Use a config to display different documents based on requirements
- Add unit tests


#### Host

![Screenshot 2025-03-18 at 12 08 07](https://github.com/user-attachments/assets/fdd1e4c5-aa66-4b63-b7b8-08c55500340f)

![Screenshot 2025-03-18 at 11 41 49](https://github.com/user-attachments/assets/2a14b7d7-b447-4d8e-9960-45bf6981da0a)


#### Strata
![Screenshot 2025-03-19 at 16 25 19](https://github.com/user-attachments/assets/35d152e6-c49a-4a35-adf5-e9568f7fa395)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
