### PR TITLE
Remove GetNext App on action buttons

### DIFF
--- a/strr-examiner-web/app/locales/en-CA.ts
+++ b/strr-examiner-web/app/locales/en-CA.ts
@@ -462,7 +462,8 @@ export default {
     TENANCY_AGREEMENT: 'Tenancy Agreement',
     RENT_RECEIPT_OR_BANK_STATEMENT: 'Rent Receipt or Bank Statement',
     LOCAL_GOVT_BUSINESS_LICENSE: 'Business License',
-    OTHERS: 'Other'
+    OTHERS: 'Other',
+    undefined: 'N/A'
   },
   pr: {
     required: 'Required.',

--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -35,7 +35,7 @@ definePageMeta({
 
 const getHostPrRequirements = (hostApplication: ApiHostApplication): string => {
   const { isBusinessLicenceRequired, isPrincipalResidenceRequired, isStrProhibited } =
-    hostApplication.strRequirements as PropertyRequirements
+    hostApplication?.strRequirements as PropertyRequirements
 
   const { prExemptReason } = hostApplication.unitDetails
   const { strataHotelCategory } = hostApplication.unitDetails

--- a/strr-examiner-web/app/pages/examine/[applicationId].vue
+++ b/strr-examiner-web/app/pages/examine/[applicationId].vue
@@ -33,8 +33,12 @@ const { data: application, status, error, refresh } = await useLazyAsyncData<
     if (initialMount.value && slug && slug !== 'startNew') {
       return await getApplicationById(slug)
     }
-    // if slug is 'startNew' or refresh is executed, fetch next application
-    return await getNextApplication<HousApplicationResponse>()
+    // if slug is 'startNew' (navigated to Examine tab) - get next application
+    if (slug && slug === 'startNew') {
+      return await getNextApplication<HousApplicationResponse>()
+    }
+    // refresh the application with new data
+    return await getApplicationById(route.params.applicationId as string)
   }
 )
 

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -20,6 +20,7 @@ vi.mock('@/stores/examiner', () => ({
     approveApplication: vi.fn(),
     rejectApplication: vi.fn(),
     getNextApplication: vi.fn().mockResolvedValue(mockApplications[0]),
+    getApplicationById: vi.fn().mockResolvedValue(mockApplications[0]),
     getDocument: vi.fn(),
     openDocInNewTab: vi.fn(),
     resetFilters: vi.fn()

--- a/strr-examiner-web/tests/unit/host-application-details.spec.ts
+++ b/strr-examiner-web/tests/unit/host-application-details.spec.ts
@@ -20,6 +20,7 @@ let currentMockData = mockHostApplication
 vi.mock('@/stores/examiner', () => ({
   useExaminerStore: () => ({
     getNextApplication: vi.fn().mockImplementation(() => Promise.resolve(currentMockData)),
+    getApplicationById: vi.fn().mockResolvedValue(currentMockData),
     getDocument: vi.fn().mockResolvedValue(new Blob(['test'], { type: 'application/pdf' })),
     activeReg: ref(currentMockData.registration),
     activeHeader: ref(currentMockData.header),

--- a/strr-examiner-web/tests/unit/host-application-flags.spec.ts
+++ b/strr-examiner-web/tests/unit/host-application-flags.spec.ts
@@ -8,6 +8,7 @@ import { HostSubHeader, HostSupportingInfo } from '#components'
 vi.mock('@/stores/examiner', () => ({
   useExaminerStore: () => ({
     getNextApplication: vi.fn().mockResolvedValue(mockHostApplicationWithFlags),
+    getApplicationById: vi.fn().mockResolvedValue(mockHostApplicationWithFlags),
     activeReg: ref(mockHostApplicationWithFlags.registration),
     activeHeader: ref(mockHostApplicationWithFlags.header),
     activeRecord: ref(mockHostApplicationWithFlags),

--- a/strr-examiner-web/tests/unit/strata-application-details.spec.ts
+++ b/strr-examiner-web/tests/unit/strata-application-details.spec.ts
@@ -11,6 +11,7 @@ import {
 vi.mock('@/stores/examiner', () => ({
   useExaminerStore: () => ({
     getNextApplication: vi.fn().mockResolvedValue(mockStrataApplication),
+    getApplicationById: vi.fn().mockResolvedValue(mockStrataApplication),
     activeReg: ref(mockStrataApplication.registration),
     activeHeader: ref(mockStrataApplication.header),
     activeRecord: ref(mockStrataApplication),


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/26389

*Description of changes:*
- Remove Get Next App on action buttons in Details View
- Covers Host and Strata apps
- Update unit tests

![Screenshot 2025-03-20 at 14 26 45](https://github.com/user-attachments/assets/2f2e97fc-c1e6-4988-aae5-11ddb72152f9)

![Screenshot 2025-03-20 at 14 02 39](https://github.com/user-attachments/assets/afb7769d-b45e-449a-9216-6afb2beb7141)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
