### PR TITLE
Fix scroll in To Do for Pending NOC

### DIFF
--- a/strr-base-web/app/utils/todoItems.ts
+++ b/strr-base-web/app/utils/todoItems.ts
@@ -67,8 +67,10 @@ export const getTodoApplication = (
       newLine: '<br/>',
       boldStart: '<strong>',
       boldEnd: '</strong>',
-      linkStart: "<a href='#summary-supporting-info' class='text-blue-500 underline'>",
-      linkEnd: '</a>'
+      linkStart: "<button type='button'" +
+        "onClick=\"document.getElementById('summary-supporting-info').scrollIntoView({ behavior: 'smooth' })\"" +
+        "class='text-blue-500 underline'>",
+      linkEnd: '</button>'
     }
 
     const nocTodo: Todo = {

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/26622

*Description of changes:*
- Rework scroll to Supporting Info section in To Do for Pending NOC


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
