### PR TITLE
Make CRA Tax Number Optional

### DIFF
--- a/strr-examiner-web/app/components/Host/Expansion/Owners.vue
+++ b/strr-examiner-web/app/components/Host/Expansion/Owners.vue
@@ -91,6 +91,13 @@ const hostOwners = computed<HostOwner[]>(() => {
             <ConnectInfoBox v-if="row.preferredName" :title="$t('label.preferredName')" :content="row.preferredName" />
             <ConnectInfoBox v-if="row.dateOfBirth" :title="$t('label.born')" :content="row.dateOfBirth" />
             <ConnectInfoBox v-if="row.taxNumber" :title="$t('label.craTaxNumber')" :content="row.taxNumber" />
+            <ConnectInfoBox
+              v-else
+              data-testid="no-cra-tax-numner"
+              class="sm:!pr-0"
+              :title="$t('label.craTaxNumber')"
+              :content="$t('label.noCraTaxNumber')"
+            />
           </div>
           <div v-else>
             <p>{{ row.businessLegalName }}</p>

--- a/strr-examiner-web/app/components/Host/Expansion/Owners.vue
+++ b/strr-examiner-web/app/components/Host/Expansion/Owners.vue
@@ -72,7 +72,10 @@ const hostOwners = computed<HostOwner[]>(() => {
       // @ts-expect-error, class is valid attr
       class: 'hidden'
     }"
-    :ui="{ td: { padding: 'first:p-0' } }"
+    :ui="{ td: {
+      base: 'align-text-top',
+      padding: 'first:p-0'
+    }}"
   >
     <template #actions-header>
       <UButton

--- a/strr-examiner-web/app/locales/en-CA.ts
+++ b/strr-examiner-web/app/locales/en-CA.ts
@@ -307,7 +307,8 @@ export default {
     applicationListSectionAria: 'Application list, {count} results',
     clearAllFilters: 'Clear All Filters',
     findInApplication: 'Find in application...',
-    tableLimitDisplay: 'Display:'
+    tableLimitDisplay: 'Display:',
+    noCraTaxNumber: 'No CRA Tax Number'
   },
   link: {
     learnMore: 'Learn More'

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-host-pm-web/app/components/form/AddOwners/Index.vue
+++ b/strr-host-pm-web/app/components/form/AddOwners/Index.vue
@@ -10,7 +10,8 @@ const {
   hasHost,
   hasCoHost,
   hasCompParty,
-  hasPropertyManager
+  hasPropertyManager,
+  isCraNumberOptional
 } = storeToRefs(contactStore)
 
 const editingIndex = ref<number | undefined>(undefined)
@@ -104,7 +105,7 @@ const checklistItems = computed<ConnectValidatedChecklistItem[]>(() => [
         :set-owner="activeOwner"
         :owner-type="addingNewType"
         :is-complete="isComplete"
-        @cancel="addingNewType = undefined, activeOwner = undefined"
+        @cancel="addingNewType = undefined, activeOwner = undefined, isCraNumberOptional = false"
         @done="contactStore.addHostOwner($event), addingNewType = undefined, activeOwner = undefined"
       />
       <SummaryOwners

--- a/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
+++ b/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
@@ -76,7 +76,7 @@ watch(
       :title="$t('strr.section.subTitle.individualName')"
       :error="showErrors && hasFormErrors(ownerFormRef, ['firstName', 'middleName', 'lastName'])"
     >
-      <div class="flex max-w-bcGovInput flex-col gap-3 sm:flex-row">
+      <div class="max-w-bcGovInput flex flex-col gap-3 sm:flex-row">
         <ConnectFormFieldGroup
           id="host-owner-first-name"
           v-model="owner.firstName"
@@ -162,7 +162,7 @@ watch(
           :help="$t('strr.hint.craTaxNumber')"
           mask="### ### ###"
         />
-        <UFormGroup name="test">
+        <UFormGroup name="optionalCraTaxNumber">
           <UCheckbox
             v-model="isCraNumberOptional"
             label="This individual does not have a CRA Tax Number"

--- a/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
+++ b/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
@@ -76,7 +76,7 @@ watch(
       :title="$t('strr.section.subTitle.individualName')"
       :error="showErrors && hasFormErrors(ownerFormRef, ['firstName', 'middleName', 'lastName'])"
     >
-      <div class="max-w-bcGovInput flex flex-col gap-3 sm:flex-row">
+      <div class="flex max-w-bcGovInput flex-col gap-3 sm:flex-row">
         <ConnectFormFieldGroup
           id="host-owner-first-name"
           v-model="owner.firstName"

--- a/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
+++ b/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
@@ -24,6 +24,23 @@ watch(isCompParty, (val) => {
   ownerStore.SetOwnerNameWithUserCreds(owner)
   ownerFormRef.value?.clear('firstName')
 })
+
+const { isCraNumberOptional } = storeToRefs(ownerStore)
+
+watch(
+  () => isCraNumberOptional.value,
+  (val) => {
+    if (val) { owner.value.taxNumber = '' }
+  }
+)
+
+watch(
+  () => owner.value.taxNumber,
+  (val) => {
+    if (val) { isCraNumberOptional.value = false }
+  }
+)
+
 </script>
 
 <template>
@@ -59,7 +76,7 @@ watch(isCompParty, (val) => {
       :title="$t('strr.section.subTitle.individualName')"
       :error="showErrors && hasFormErrors(ownerFormRef, ['firstName', 'middleName', 'lastName'])"
     >
-      <div class="flex max-w-bcGovInput flex-col gap-3 sm:flex-row">
+      <div class="max-w-bcGovInput flex flex-col gap-3 sm:flex-row">
         <ConnectFormFieldGroup
           id="host-owner-first-name"
           v-model="owner.firstName"
@@ -145,6 +162,13 @@ watch(isCompParty, (val) => {
           :help="$t('strr.hint.craTaxNumber')"
           mask="### ### ###"
         />
+        <UFormGroup name="test">
+          <UCheckbox
+            v-model="isCraNumberOptional"
+            label="This individual does not have a CRA Tax Number"
+            class="mt-6"
+          />
+        </UFormGroup>
       </ConnectFormSection>
       <ConnectFormSection
         v-if="owner.role !== OwnerRole.PROPERTY_MANAGER || owner.ownerType !== OwnerType.BUSINESS"

--- a/strr-host-pm-web/app/components/summary/Owners.vue
+++ b/strr-host-pm-web/app/components/summary/Owners.vue
@@ -77,6 +77,13 @@ const getPhoneNumber = (phone: ConnectPhone) => {
             <ConnectInfoBox v-if="row.preferredName" :title="$t('label.preferredName')" :content="row.preferredName" />
             <ConnectInfoBox v-if="row.dateOfBirth" :title="$t('label.born')" :content="row.dateOfBirth" />
             <ConnectInfoBox v-if="row.taxNumber" :title="$t('label.craTaxNumber')" :content="row.taxNumber" />
+            <ConnectInfoBox
+              v-else
+              data-testid="no-cra-tax-numner"
+              class="sm:!pr-0"
+              :title="$t('label.craTaxNumber')"
+              :content="$t('label.noCraTaxNumber')"
+            />
           </div>
           <div v-else>
             <p>{{ row.businessLegalName }}</p>

--- a/strr-host-pm-web/app/locales/en-CA.ts
+++ b/strr-host-pm-web/app/locales/en-CA.ts
@@ -311,7 +311,8 @@ export default {
     unnamed: 'Unnamed',
     completingParty: 'Person completing form',
     individualOrBusiness: 'Individual or Business',
-    contactDetails: 'Contact Details'
+    contactDetails: 'Contact Details',
+    noCraTaxNumber: 'No CRA Tax Number'
   },
   link: {
     hostAccomodationsAct: 'Short-Term Rental Accommodations Act',

--- a/strr-host-pm-web/app/stores/hostOwner.ts
+++ b/strr-host-pm-web/app/stores/hostOwner.ts
@@ -32,7 +32,7 @@ export const useHostOwnerStore = defineStore('host/owner', () => {
       dateOfBirth: type === OwnerType.INDIVIDUAL && role === OwnerRole.HOST
         ? getRequiredNonEmptyString(t('validation.dateOfBirth'))
         : optionalOrEmptyString,
-      taxNumber: type === OwnerType.INDIVIDUAL && role === OwnerRole.HOST
+      taxNumber: (type === OwnerType.INDIVIDUAL && role === OwnerRole.HOST) && !isCraNumberOptional.value
         ? getRequiredSin(t('validation.sin'))
         : optionalOrEmptyString
     })
@@ -62,6 +62,7 @@ export const useHostOwnerStore = defineStore('host/owner', () => {
   const activeOwner = ref<HostOwner | undefined>(undefined)
   const activeOwnerEditIndex = ref(-1)
   const hostOwners = ref<HostOwner[]>([])
+  const isCraNumberOptional = ref<boolean>(false)
 
   const findByRole = (ownerRole: OwnerRole) => hostOwners.value.find(val => val.role === ownerRole)
   const findCompPartyIndex = () => hostOwners.value.findIndex(val => val.isCompParty)
@@ -133,6 +134,7 @@ export const useHostOwnerStore = defineStore('host/owner', () => {
     activeOwner,
     activeOwnerEditIndex,
     hostOwners,
+    isCraNumberOptional,
     hasHost,
     hasCoHost,
     hasPropertyManager,

--- a/strr-host-pm-web/app/utils/host-permit-dash-helpers.ts
+++ b/strr-host-pm-web/app/utils/host-permit-dash-helpers.ts
@@ -20,7 +20,7 @@ export const getHostPermitDashOwners = (): ConnectAccordionItem[] => {
         ),
         ...(owner.taxNumber
           ? [{ label: t('label.craTaxNumber'), text: owner.taxNumber }]
-          : []
+          : [{ label: t('label.craTaxNumber'), text: t('label.noCraTaxNumber') }]
         ),
         {
           icon: owner.role === OwnerRole.HOST ? 'i-mdi-map-marker-outline' : 'i-mdi-email-outline',

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-host-pm-web/tests/mocks/mockedData.ts
+++ b/strr-host-pm-web/tests/mocks/mockedData.ts
@@ -13,7 +13,7 @@ const mockDocuments: ApiDocument[] = [
   }
 ]
 
-const primaryContactPerson: ApiHostContactPerson = {
+const mockPrimaryContactPerson: ApiHostContactPerson = {
   contactType: OwnerType.INDIVIDUAL,
   dateOfBirth: '1985-05-15',
   emailAddress: 'alice.smith@example.com',
@@ -55,7 +55,7 @@ export const mockApplication: HostApplicationResp = {
   registration: {
     documents: mockDocuments,
     listingDetails: [],
-    primaryContact: primaryContactPerson,
+    primaryContact: mockPrimaryContactPerson,
     registrationType: ApplicationType.HOST,
     strRequirements: {
       isBusinessLicenceRequired: true,
@@ -87,5 +87,38 @@ export const mockApplication: HostApplicationResp = {
       businessLicense: '123123123',
       strataHotelCategory: StrataHotelCategory.FULL_SERVICE
     }
+  }
+}
+
+const mockMailingAddress: ConnectAddress = {
+  street: '456 Elm St',
+  streetAdditional: 'Suite 200',
+  city: 'Victoria',
+  region: 'BC',
+  postalCode: 'V1V2B2',
+  country: 'CA',
+  locationDescription: 'Next to the library',
+  streetName: 'Elm St',
+  streetNumber: '456',
+  unitNumber: '200'
+}
+
+export const mockHostOwner: HostOwner = {
+  ownerType: OwnerType.INDIVIDUAL,
+  preferredName: 'Jane Smith',
+  mailingAddress: mockMailingAddress,
+  businessLegalName: 'Jane Smith Consulting',
+  businessNumber: '987654321',
+  dateOfBirth: '1990-05-15',
+  role: OwnerRole.HOST,
+  isCompParty: true,
+  taxNumber: '123456789',
+  firstName: 'Jane',
+  middleName: 'A.',
+  lastName: 'Smith',
+  faxNumber: '555-987-6543',
+  emailAddress: 'jane.smith@example.com',
+  phone: {
+    number: '555-123-4567'
   }
 }

--- a/strr-host-pm-web/tests/unit/application-dashboard.spec.ts
+++ b/strr-host-pm-web/tests/unit/application-dashboard.spec.ts
@@ -175,7 +175,7 @@ describe('Dashboard Application Page', () => {
     expect(documentsList.findAllComponents(UBadge).length).toBe(1) // should show date badge for NOC doc
   })
 
-  it('renders dashboard with No CRA Tax Number', async () => {
+  it('renders dashboard with No CRA Tax Number', () => {
     vi.mock('@/stores/hostOwner', () => ({
       useHostOwnerStore: () => ({
         validateOwners: () => true,

--- a/strr-host-pm-web/tests/unit/application-dashboard.spec.ts
+++ b/strr-host-pm-web/tests/unit/application-dashboard.spec.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, it, expect, vi, beforeAll } from 'vitest'
 import { baseEnI18n } from '../mocks/i18n'
-import { mockApplication } from '../mocks/mockedData'
+import { mockApplication, mockHostOwner } from '../mocks/mockedData'
 import ApplicationDashboard from '~/pages/dashboard/[applicationId].vue'
 import {
   ConnectDashboardSection, Todo, TodoEmpty, SummaryProperty,
@@ -173,5 +173,24 @@ describe('Dashboard Application Page', () => {
 
     expect(documentsList.findAll('[data-test-id="stored-document"]').length).toBe(3) // should show additional doc
     expect(documentsList.findAllComponents(UBadge).length).toBe(1) // should show date badge for NOC doc
+  })
+
+  it('renders dashboard with No CRA Tax Number', async () => {
+    vi.mock('@/stores/hostOwner', () => ({
+      useHostOwnerStore: () => ({
+        validateOwners: () => true,
+        hostOwners: [{
+          ...mockHostOwner,
+          taxNumber: '' // no tax number owner
+        }]
+      })
+    }))
+
+    const individualAndBusinessInfo = wrapper.find('[data-test-id="individuals-business-section"]')
+    expect(individualAndBusinessInfo.exists()).toBe(true)
+    expect(individualAndBusinessInfo.text()).toContain(mockHostOwner.dateOfBirth)
+    expect(individualAndBusinessInfo.text()).toContain(mockHostOwner.emailAddress)
+    // have to assert against the content as there is no other means to unit test it
+    expect(individualAndBusinessInfo.text()).toContain('No CRA Tax Number')
   })
 })


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/26232

*Description of changes:*
- Make CRA Tax Number Optional for Hosts
- Add unit test

![Screenshot 2025-03-24 at 14 37 09](https://github.com/user-attachments/assets/3d048877-dbc0-48fa-b1f4-da44be8e0323)

![Screenshot 2025-03-24 at 14 38 13](https://github.com/user-attachments/assets/4a7c54d8-d03f-47d7-bf77-b5ffa181ba7e)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
