### PR TITLE
Examiner API - Requirements Filter - Host NO_REQ Criteria Update

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.0.59"
+version = "0.0.60"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -248,13 +248,25 @@ class Application(BaseModel):
             StrrRequirement.BL.value: {"registration": {"strRequirements": {"isBusinessLicenceRequired": True}}},
             StrrRequirement.PR.value: {"registration": {"strRequirements": {"isPrincipalResidenceRequired": True}}},
             StrrRequirement.PROHIBITED.value: {"registration": {"strRequirements": {"isStrProhibited": True}}},
-            StrrRequirement.NO_REQ.value: {"registration": {"strRequirements": {"isStraaExempt": True}}},
         }
         pr_exempt_mapping = {
             StrrRequirement.PR_EXEMPT_STRATA_HOTEL.value: "STRATA_HOTEL",
             StrrRequirement.PR_EXEMPT_FARM_LAND.value: "FARM_LAND",
             StrrRequirement.PR_EXEMPT_FRACTIONAL_OWNERSHIP.value: "FRACTIONAL_OWNERSHIP",
         }
+
+        if req == StrrRequirement.NO_REQ.value:
+            return db.or_(
+                Application.application_json["registration"]["strRequirements"]["isStraaExempt"].astext == "true",
+                db.and_(
+                    Application.application_json["registration"]["strRequirements"]["isBusinessLicenceRequired"].astext
+                    == "false",
+                    Application.application_json["registration"]["strRequirements"][
+                        "isPrincipalResidenceRequired"
+                    ].astext
+                    == "false",
+                ),
+            )
 
         if req in host_req_mapping:
             return Application.application_json.contains(host_req_mapping[req])

--- a/strr-api/tests/unit/resources/test_registration_applications.py
+++ b/strr-api/tests/unit/resources/test_registration_applications.py
@@ -930,7 +930,10 @@ def test_requirements_filter(session, client, jwt):
     response_json = rv.json
     applications = response_json["applications"]
     for application in applications:
-        assert application["registration"]["strRequirements"]["isStraaExempt"] is True
+        assert application["registration"]["strRequirements"]["isStraaExempt"] is True or (
+            application["registration"]["strRequirements"]["isBusinessLicenceRequired"] is False
+            and application["registration"]["strRequirements"]["isPrincipalResidenceRequired"] is False
+        )
 
     rv = client.get("/applications?requirement=PR&requirement=BL", headers=staff_headers)
     assert HTTPStatus.OK == rv.status_code


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/26657

*Description of changes:*
`NO_REQ` (Scenario 6) means not having PR or BL requirements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
