### PR TITLE
Examiner UI - Fixed 12:01 not being shown in NOC Expiry (not PST)

### DIFF
--- a/strr-base-web/app/utils/date.ts
+++ b/strr-base-web/app/utils/date.ts
@@ -25,7 +25,7 @@ export function dateStringToDate (dateString: string): Date | null {
 export function dateToString (date: Date | string, format = 'y-MM-dd', toPacific = false) {
   const luxonFormat = format.replace('a', 't')
   const jsDate = typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)
-    ? DateTime.fromISO(date).plus({ minutes: 1 })
+    ? DateTime.fromISO(date, { zone: 'America/Vancouver' }).plus({ minutes: 1 })
     : DateTime.fromJSDate(new Date(date))
   let formattedDate
   if (toPacific) {

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-examiner-web/app/locales/en-CA.ts
+++ b/strr-examiner-web/app/locales/en-CA.ts
@@ -520,6 +520,8 @@ export default {
     EXPIRED: 'Registration expired.',
     NON_COMPLIANCE_SUSPENDED: 'Registration suspended due to non compliance.',
     APPLICATION_REVIEWER_ASSIGNED: 'Application reviewer assigned.',
-    APPLICATION_REVIEWER_UNASSIGNED: 'Application reviewer unassigned.'
+    APPLICATION_REVIEWER_UNASSIGNED: 'Application reviewer unassigned.',
+    NOC_SENT: 'Notice of Consideration sent.',
+    NOC_EXPIRED: 'Notice of Consideration expired.'
   }
 }

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/26841

*Description of changes:*
(Verified that time being shown is in Pacific even though system time is in EST)
<img width="1381" alt="image" src="https://github.com/user-attachments/assets/8f4948e0-4c9c-4a54-bf78-b394e0621906" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
