### PR TITLE
API - Assign & Unassign - Allow on all statuses

### DIFF
--- a/strr-api/src/strr_api/services/application_service.py
+++ b/strr-api/src/strr_api/services/application_service.py
@@ -62,7 +62,20 @@ APPLICATION_STATES_STAFF_ACTION = [
     Application.Status.ADDITIONAL_INFO_REQUESTED,
 ]
 APPLICATION_UNPAID_STATES = [Application.Status.DRAFT, Application.Status.PAYMENT_DUE]
-APPLICATION_ASSIGN_STATES = [Application.Status.FULL_REVIEW, Application.Status.PROVISIONAL_REVIEW]
+APPLICATION_ASSIGN_STATES = [
+    Application.Status.FULL_REVIEW,
+    Application.Status.PROVISIONAL_REVIEW,
+    Application.Status.PROVISIONAL,
+    Application.Status.NOC_PENDING,
+    Application.Status.NOC_EXPIRED,
+    Application.Status.ADDITIONAL_INFO_REQUESTED,
+    Application.Status.PAYMENT_DUE,
+    Application.Status.PAID,
+    Application.Status.FULL_REVIEW_APPROVED,
+    Application.Status.PROVISIONALLY_APPROVED,
+    Application.Status.AUTO_APPROVED,
+    Application.Status.DECLINED,
+]
 
 
 class ApplicationService:

--- a/strr-api/src/strr_api/services/application_service.py
+++ b/strr-api/src/strr_api/services/application_service.py
@@ -69,8 +69,6 @@ APPLICATION_ASSIGN_STATES = [
     Application.Status.NOC_PENDING,
     Application.Status.NOC_EXPIRED,
     Application.Status.ADDITIONAL_INFO_REQUESTED,
-    Application.Status.PAYMENT_DUE,
-    Application.Status.PAID,
     Application.Status.FULL_REVIEW_APPROVED,
     Application.Status.PROVISIONALLY_APPROVED,
     Application.Status.AUTO_APPROVED,

--- a/strr-api/tests/unit/resources/test_registration_applications.py
+++ b/strr-api/tests/unit/resources/test_registration_applications.py
@@ -855,7 +855,7 @@ def test_assign_and_unassign_application(session, client, jwt):
         assert HTTPStatus.OK == rv.status_code
         application_number = rv.json.get("header").get("applicationNumber")
         application = Application.find_by_application_number(application_number=application_number)
-        application.status = Application.Status.DRAFT
+        application.status = Application.Status.PAYMENT_DUE
         application.save()
 
         staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")

--- a/strr-api/tests/unit/resources/test_registration_applications.py
+++ b/strr-api/tests/unit/resources/test_registration_applications.py
@@ -854,6 +854,9 @@ def test_assign_and_unassign_application(session, client, jwt):
         rv = client.post("/applications", json=json_data, headers=headers)
         assert HTTPStatus.OK == rv.status_code
         application_number = rv.json.get("header").get("applicationNumber")
+        application = Application.find_by_application_number(application_number=application_number)
+        application.status = Application.Status.DRAFT
+        application.save()
 
         staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
         rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/26347

*Description of changes:*
Based on clarified requirement from @andyyanggov. Assign and Unassign need to allowed for other application statuses and not just `FULL_REVIEW & PROVISIONAL_REVIEW`.
https://github.com/bcgov/STRR/pull/669#issuecomment-2787723952

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
