### PR TITLE
Allow Image Upload for Hosts

### DIFF
--- a/strr-base-web/app/locales/en-CA.ts
+++ b/strr-base-web/app/locales/en-CA.ts
@@ -125,7 +125,7 @@ export default {
       },
       fileType: {
         title: 'Invalid File Type',
-        description: 'Only PDF files are supported. Please upload a PDF document.'
+        description: 'Only PDF, jpeg, or jpg files are supported. Please upload a PDF, jpeg, or jpg.'
       },
       generic: {
         title: 'Error Uploading Document',

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-host-pm-web/app/components/form/AddDocuments/index.vue
+++ b/strr-host-pm-web/app/components/form/AddDocuments/index.vue
@@ -117,7 +117,7 @@ onMounted(async () => {
                       :error="isComplete && hasFormErrors(docFormRef, ['documentUpload'])"
                       :is-required="docStore.requiredDocs.length > 0"
                       :help-id="docUploadHelpId"
-                      accept="application/pdf"
+                      accept="application/pdf,image/jpeg"
                       @change="docStore.addStoredDocument"
                       @cancel="docStore.selectedDocType = undefined"
                       @error="e => strrModal.openErrorModal(

--- a/strr-host-pm-web/app/locales/en-CA.ts
+++ b/strr-host-pm-web/app/locales/en-CA.ts
@@ -387,7 +387,7 @@ export default {
   },
   hint: {
     strataRefCode: 'This is a unique code for each registered strata hotel. Ask the strata hotel management for this code.',
-    docUpload: 'File must be a PDF. Maximum 10 MB.',
+    docUpload: 'File must be a PDF, jpeg, or jpg. Maximum 10 MB.',
     autocomplete: 'For example: 123 - 456 Street Name Victoria BC  V8V 2V2'
   },
   page: {

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-strata-web/app/components/form/StrataDetails.vue
+++ b/strr-strata-web/app/components/form/StrataDetails.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Form } from '#ui/types'
 import { z } from 'zod'
+import type { Form } from '#ui/types'
 
 const rtc = useRuntimeConfig().public
 const strataModal = useStrataModals()
@@ -268,7 +268,7 @@ onMounted(async () => {
                 <DocumentUploadButton
                   id="supporting-documents"
                   :label="$t('label.chooseDocsOpt')"
-                  accept="application/pdf"
+                  accept="application/pdf,image/jpeg"
                   :is-required="false"
                   :is-invalid="isComplete && hasFormErrors(documentFormRef, ['documents'])"
                   help-id="supporting-documents-help"

--- a/strr-strata-web/app/locales/en-CA.ts
+++ b/strr-strata-web/app/locales/en-CA.ts
@@ -183,7 +183,7 @@ export default {
     STRATA_HOTEL_DOCUMENTATION: 'Supporting strata-titled hotel or motel documentation'
   },
   hint: {
-    docUpload: 'File must be a PDF. Maximum 10 MB.'
+    docUpload: 'File must be a PDF, jpeg, or jpg. Maximum 10 MB.'
   },
   ConnectFeeWidget: {
     feeSummary: {

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/27134

*Description of changes:*
- Allow Hosts to upload images (jpeg, jpg) when adding documents in Step 3 of the Host and Strata applications
- Update text

#### Mobile view

![IMG_4821](https://github.com/user-attachments/assets/ec69879b-fbd7-4a9b-abba-1b14490d45e3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
