### PR TITLE
API Hotfix - Update NOC Status Labels - Changed Requirements

### DIFF
--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -422,8 +422,8 @@ class ApplicationSerializer:
         Application.Status.PROVISIONAL_REVIEW: "Approved – Provisional",
         Application.Status.FULL_REVIEW: "Pending Approval",
         Application.Status.DECLINED: "Declined",
-        Application.Status.NOC_PENDING: "Notice of Consideration - Submissions Open",
-        Application.Status.NOC_EXPIRED: "Notice of Consideration - Submissions Closed",
+        Application.Status.NOC_PENDING: "Notice of Consideration",
+        Application.Status.NOC_EXPIRED: "Pending Review",
     }
 
     HOST_ACTIONS = {Application.Status.PAYMENT_DUE: ["SUBMIT_PAYMENT"]}
@@ -438,8 +438,8 @@ class ApplicationSerializer:
         Application.Status.PROVISIONAL_REVIEW: "Provisional Examination",
         Application.Status.FULL_REVIEW: "Full Examination",
         Application.Status.DECLINED: "Declined",
-        Application.Status.NOC_PENDING: "NOC - Open",
-        Application.Status.NOC_EXPIRED: "NOC - Closed",
+        Application.Status.NOC_PENDING: "NOC - Pending",
+        Application.Status.NOC_EXPIRED: "NOC - Expired",
     }
 
     EXAMINER_ACTIONS = {


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/27356

*Description of changes:*
```
Application.Status.PROVISIONAL_REVIEW_NOC_PENDING: "Notice of Consideration",
Application.Status.PROVISIONAL_REVIEW_NOC_EXPIRED: "Pending Review",

Application.Status.PROVISIONAL_REVIEW_NOC_PENDING: "NOC - Pending",
Application.Status.PROVISIONAL_REVIEW_NOC_EXPIRED: "NOC - Expired",
```

Will be added when this is merged with main

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
