### PR TITLE
Host Application view with Provisional NOC

### DIFF
--- a/strr-base-web/app/composables/useStrrBasePermit.ts
+++ b/strr-base-web/app/composables/useStrrBasePermit.ts
@@ -39,7 +39,8 @@ export const useStrrBasePermit = <R extends ApiRegistrationResp, A extends ApiAp
       // there is a lag in the payment Q, trigger the strr api to grab the most current pay details
       application.value = await updatePaymentDetails<A>(application.value.header.applicationNumber)
     }
-    if (application.value?.header.registrationId) {
+    if (application.value?.header.registrationId &&
+      application.value?.header.status !== ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING) { // do not load registration for Provisional Pending NOC
       // Get linked registration if applicable
       registration.value = await getAccountRegistrations<R>(
         application.value.header.registrationId) as R

--- a/strr-base-web/app/locales/en-CA.ts
+++ b/strr-base-web/app/locales/en-CA.ts
@@ -411,6 +411,12 @@ export default {
       general: "You have received a Notice of Consideration {boldStart}email{boldEnd} about issues with your application. Please review it carefully and {linkStart}add any required documents{linkEnd} below by selecting {boldStart}'Add new document'{boldEnd}.", // used for Host and Strata
       host: "{newLine}{newLine}Make sure to select the correct document category when uploading. If submitting a {boldStart}Statement Document{boldEnd}, upload it under {boldStart}'Other Proof Document'{boldEnd}." // Host only specific addition
     },
+    provisionalNoc: { // Notice of Consideration
+      title1: 'Notice of Consideration - Due:',
+      title2: 'at 12:01 am PT',
+      general: "You have received a Notice of Consideration {boldStart}email{boldEnd} about issues with your provisionally approved registration number. Please review it carefully and {linkStart}add any required documents{linkEnd} below by selecting {boldStart}'Add new document'{boldEnd}.", // used for Host and Strata
+      host: "{newLine}{newLine}Make sure to select the correct document category when uploading. If submitting a {boldStart}Statement Document{boldEnd}, upload it under {boldStart}'Other Proof Document'{boldEnd}." // Host only specific addition
+    },
     renewal: {
       title1: 'Registration Renewal - Due:',
       title2: 'at 11:59 pm PT'

--- a/strr-base-web/app/utils/accountDashHelpers.ts
+++ b/strr-base-web/app/utils/accountDashHelpers.ts
@@ -32,3 +32,12 @@ export function getDaysToExpiryColumn (heading: ApplicationHeader): { label: str
 
   return { label: t('label.dayCount', daysTillExpiry), value: daysTillExpiry }
 }
+
+// return the application status based on the header
+export function getApplicationStatus (header: ApplicationHeader): string {
+  // for Provisional Pending NOC we should display application host status instead of registration
+  if (header.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING) {
+    return header.hostStatus
+  }
+  return header.registrationStatus || header.hostStatus
+}

--- a/strr-base-web/app/utils/todoItems.ts
+++ b/strr-base-web/app/utils/todoItems.ts
@@ -59,9 +59,12 @@ export const getTodoApplication = (
     })
   }
 
-  if (applicationInfo?.status === ApplicationStatus.NOC_PENDING) {
+  if (applicationInfo?.status === ApplicationStatus.NOC_PENDING ||
+    applicationInfo?.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING
+  ) {
     const nocEndDate = dateToString(applicationInfo!.nocEndDate as Date, 'DDD')
     const isHost = applicationType === ApplicationType.HOST
+    const isProvisional = applicationInfo?.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING
 
     const translationProps = {
       newLine: '<br/>',
@@ -79,7 +82,14 @@ export const getTodoApplication = (
       subtitle: `${t('todos.noc.general', translationProps)}${isHost ? t('todos.noc.host', translationProps) : ''}`
     }
 
-    todos.push(nocTodo)
+    const provisionalNocTodo: Todo = {
+      id: 'todo-provisional-noc-add-docs',
+      title: `${t('todos.provisionalNoc.title1')} ${nocEndDate} ${t('todos.provisionalNoc.title2')}`,
+      subtitle: `${t('todos.provisionalNoc.general',
+        translationProps)}${isHost ? t('todos.provisionalNoc.host', translationProps) : ''}`
+    }
+
+    todos.push(isProvisional ? provisionalNocTodo : nocTodo)
   }
 
   return todos

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-examiner-web/app/locales/en-CA.ts
+++ b/strr-examiner-web/app/locales/en-CA.ts
@@ -592,7 +592,7 @@ export default {
     APPLICATION_REVIEWER_UNASSIGNED: 'Application reviewer unassigned',
     NOC_SENT: 'Notice of Consideration sent',
     NOC_EXPIRED: 'Notice of Consideration expired',
-    HOST_REGISTRATION_UNIT_ADDRESS_UPDATED: 'Host STR Address Updated'
+    HOST_REGISTRATION_UNIT_ADDRESS_UPDATED: 'Registration: Host address updated',
+    HOST_APPLICATION_UNIT_ADDRESS_UPDATED: 'Application: Host address updated'
   }
-
 }

--- a/strr-host-pm-web/app/components/summary/SupportingInfo.vue
+++ b/strr-host-pm-web/app/components/summary/SupportingInfo.vue
@@ -11,6 +11,12 @@ const isFileUploadOpen = ref(false)
 const docStore = useDocumentStore()
 const { application } = storeToRefs(useHostPermitStore())
 
+// used to display Add New Document button
+const isNocPending = computed(() =>
+  application.value?.header.status === ApplicationStatus.NOC_PENDING ||
+  application.value?.header.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING
+)
+
 // step 3 items
 const supportingInfo = computed(() => {
   const items = [
@@ -91,7 +97,7 @@ const supportingInfo = computed(() => {
         </div>
 
         <div
-          v-if="application?.header.status === ApplicationStatus.NOC_PENDING"
+          v-if="isNocPending"
           class="mt-4 md:mt-0"
         >
           <UButton

--- a/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
+++ b/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
@@ -89,7 +89,8 @@ onMounted(async () => {
     title.value = permitDetails.value.unitAddress.nickname || t('strr.label.unnamed')
     subtitles.value = [{ text: getAddressDisplayParts(unitAddress.value.address, true).join(', ') }]
 
-    if (!registration.value) {
+    // for Provisional Pending NOC the header details should be based on the application
+    if (!registration.value || application.value?.header.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING) {
       setHeaderDetails(
         application.value?.header.hostStatus,
         undefined,

--- a/strr-host-pm-web/app/pages/dashboard/index.vue
+++ b/strr-host-pm-web/app/pages/dashboard/index.vue
@@ -83,7 +83,7 @@ const mapApplicationsList = () => {
     number: app.header.registrationNumber || app.header.applicationNumber,
     lastStatusChange: getLastStatusChangeColumn(app.header),
     daysToExpiry: getDaysToExpiryColumn(app.header),
-    status: app.header.registrationStatus || app.header.hostStatus,
+    status: getApplicationStatus(app.header),
     applicationNumber: app.header.applicationNumber // always used for view action
   }))
 }

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/28432

*Description of changes:*
- Host Dashboard should show and Application and not Registration
- Host should be able to upload additional documents (as per usual NOC flow)
- To Do item for Hosts

![Screenshot 2025-05-16 at 11 34 31](https://github.com/user-attachments/assets/8d057736-04d8-4289-b5e2-0565279e76a7)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
