### PR TITLE
Add dash after Unit Number in Examiner Details View

### DIFF
--- a/strr-examiner-web/app/utils/format-helper.ts
+++ b/strr-examiner-web/app/utils/format-helper.ts
@@ -40,8 +40,11 @@ export function displayFullUnitAddress (mailingAddress?: ApiUnitAddress): string
   // add comma only if address & addressLineTwo exists
   // const addressPartTwo = address && addressLineTwo ? `, ${addressLineTwo}` : addressLineTwo || ''
 
+  // add dash '-' after unit number, if exists
+  const displayUnitNumber = unitNumber ? `${unitNumber}-` : ''
+
   return `
-        ${unitNumber} ${streetNumber} ${streetName}, 
+        ${displayUnitNumber}${streetNumber} ${streetName}, 
         ${city || '-'} ${province} ${postalCode || '-'}, 
         ${country || '-'}
       `

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/28813

*Description of changes:*
- Add dash after Unit Number in Examiner Details View

![Screenshot 2025-06-10 at 12 47 21](https://github.com/user-attachments/assets/68cc6714-db07-45ef-a489-2793999eb3ab)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
