### PR TITLE
Fix Fee Widget Recalculation

### DIFF
--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -56,10 +56,10 @@ onMounted(async () => {
     getFee(StrrFeeEntityType.STRR, StrrFeeCode.STR_HOST_2),
     getFee(StrrFeeEntityType.STRR, StrrFeeCode.STR_HOST_3)
   ])
-  hostFee1.value = fee1
-  hostFee2.value = fee2
-  hostFee3.value = fee3
-  hostFee4.value = fee1 // TODO: expecting new fee code for this (hostFee4 - shared accommodation)
+  hostFee1.value = { ...fee1 }
+  hostFee2.value = { ...fee2 }
+  hostFee3.value = { ...fee3 }
+  hostFee4.value = { ...fee1 } // TODO: expecting new fee code for this (hostFee4 - shared accommodation)
   if (hostFee1.value) {
     setPlaceholderServiceFee(hostFee1.value.serviceFees)
   }

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/26265

*Description of changes:*
- Fees weren't reflecting properly in the UI when switching Type of Space and Rental Unit Set-up
- Fix by creating a shallow copy of the fees, instead of copying by reference 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
