### PR TITLE
Disable Edit Address for Registrations

### DIFF
--- a/strr-examiner-web/app/components/Host/SubHeader.vue
+++ b/strr-examiner-web/app/components/Host/SubHeader.vue
@@ -15,7 +15,7 @@ const { isFeatureEnabled } = useFeatureFlags()
 const canEditApplicationAddress = isFeatureEnabled('enable-examiner-edit-address-application')
 const { checkAndPerformAction, openHostOwners } = useHostExpansion()
 
-const isEditDisabled = computed((): boolean => activeReg.value.status === RegistrationStatus.CANCELLED)
+const isEditAddressDisabled = computed((): boolean => activeReg.value.status === RegistrationStatus.CANCELLED)
 
 </script>
 <template>
@@ -35,7 +35,7 @@ const isEditDisabled = computed((): boolean => activeReg.value.status === Regist
             variant="link"
             size="xs"
             color="blue"
-            :disabled="isEditingRentalUnit || !isAssignedToUser || isEditDisabled"
+            :disabled="isEditingRentalUnit || !isAssignedToUser || isEditAddressDisabled"
             data-testid="edit-rental-unit-button"
             :aria-label="t('strr.label.editRentalUnit')"
             class="flex items-center gap-1"

--- a/strr-examiner-web/app/components/Host/SubHeader.vue
+++ b/strr-examiner-web/app/components/Host/SubHeader.vue
@@ -15,6 +15,8 @@ const { isFeatureEnabled } = useFeatureFlags()
 const canEditApplicationAddress = isFeatureEnabled('enable-examiner-edit-address-application')
 const { checkAndPerformAction, openHostOwners } = useHostExpansion()
 
+const isEditDisabled = computed((): boolean => activeReg.value.status === RegistrationStatus.CANCELLED)
+
 </script>
 <template>
   <div
@@ -33,7 +35,7 @@ const { checkAndPerformAction, openHostOwners } = useHostExpansion()
             variant="link"
             size="xs"
             color="blue"
-            :disabled="isEditingRentalUnit || !isAssignedToUser"
+            :disabled="isEditingRentalUnit || !isAssignedToUser || isEditDisabled"
             data-testid="edit-rental-unit-button"
             :aria-label="t('strr.label.editRentalUnit')"
             class="flex items-center gap-1"

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/28965

*Description of changes:*
- Disable Edit Address for Cancelled Registrations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
