### PR TITLE
Add Province to Address Display Item component

### DIFF
--- a/strr-base-web/app/components/connect/form/address/DisplayItem.vue
+++ b/strr-base-web/app/components/connect/form/address/DisplayItem.vue
@@ -11,34 +11,24 @@ const columns = [
 ]
 
 const addressRows = computed(() => {
-  const rows = []
-
-  if (props.address.unitNumber) {
-    rows.push({ label: t('label.unitNumber'), value: props.address.unitNumber })
+  const addressFields = {
+    unitNumber: 'unitNumber',
+    streetNumber: 'streetNumber',
+    streetName: 'streetName',
+    streetAdditional: 'streetAdditional',
+    city: 'city',
+    region: 'province',
+    postalCode: 'postalCode'
   }
 
-  if (props.address.streetNumber) {
-    rows.push({ label: t('label.streetNumber'), value: props.address.streetNumber })
-  }
-
-  if (props.address.streetName) {
-    rows.push({ label: t('label.streetName'), value: props.address.streetName })
-  }
-
-  if (props.address.streetAdditional) {
-    rows.push({ label: t('label.streetAdditional'), value: props.address.streetAdditional })
-  }
-
-  if (props.address.city) {
-    rows.push({ label: t('label.city'), value: props.address.city })
-  }
-
-  if (props.address.postalCode) {
-    rows.push({ label: t('label.postalCode'), value: props.address.postalCode })
-  }
-
-  return rows
+  return Object.entries(addressFields)
+    .filter(([field]) => props.address[field])
+    .map(([field, label]) => ({
+      label: t(`label.${label}`),
+      value: props.address[field]
+    }))
 })
+
 </script>
 <template>
   <div>

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/29007

*Description of changes:*
- Add Province to Address Display Item component

![Screenshot 2025-06-22 at 11 50 45](https://github.com/user-attachments/assets/d8325cb0-fc6b-40bb-8c73-6396738e89cf)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
