### PR TITLE
Examiner UI - Registration Details - Date Badge for NOC & BL Upload Docs

### DIFF
--- a/strr-base-web/app/interfaces/strr-api.ts
+++ b/strr-base-web/app/interfaces/strr-api.ts
@@ -138,6 +138,7 @@ export interface ApiDocument {
   fileType: string
   uploadStep?: DocumentUploadStep
   uploadDate?: string
+  addedOn?: string
 }
 
 export interface ApiRegistrationTodoTaskResp {

--- a/strr-base-web/app/interfaces/strr-api.ts
+++ b/strr-base-web/app/interfaces/strr-api.ts
@@ -137,7 +137,9 @@ export interface ApiDocument {
   fileName: string
   fileType: string
   uploadStep?: DocumentUploadStep
+  /** Date when document was uploaded during application flow (stored in application JSON metadata) */
   uploadDate?: string
+  /** Date when document was added during registration flow (stored in document DB object) */
   addedOn?: string
 }
 

--- a/strr-base-web/app/interfaces/ui-document.ts
+++ b/strr-base-web/app/interfaces/ui-document.ts
@@ -7,5 +7,6 @@ export interface UiDocument {
   loading: boolean
   type: DocumentUploadType,
   uploadStep?: DocumentUploadStep,
+  /** Date when document was uploaded during application flow (stored in application JSON metadata) */
   uploadDate?: string
 }

--- a/strr-examiner-web/app/components/Host/SupportingInfo.vue
+++ b/strr-examiner-web/app/components/Host/SupportingInfo.vue
@@ -102,6 +102,20 @@ const nocDocumentsConfig: SupportingDocumentsConfig = {
   includeDateBadge: [DocumentUploadStep.NOC]
 }
 
+// all documents for registrations with date badges, excluding BL (they are in its own section)
+const registrationDocumentsConfig: SupportingDocumentsConfig = {
+  excludeTypes: [DocumentUploadType.LOCAL_GOVT_BUSINESS_LICENSE],
+  excludeUploadStep: [DocumentUploadStep.NOC],
+  showDateBadgeForAll: true
+}
+
+// BL documents for registrations with date badges
+const businessLicenseRegistrationConfig: SupportingDocumentsConfig = {
+  includeTypes: [DocumentUploadType.LOCAL_GOVT_BUSINESS_LICENSE],
+  excludeUploadStep: [DocumentUploadStep.NOC],
+  showDateBadgeForAll: true
+}
+
 </script>
 <template>
   <ConnectPageSection>
@@ -137,7 +151,7 @@ const nocDocumentsConfig: SupportingDocumentsConfig = {
           <SupportingDocuments
             class="mb-1 flex flex-wrap gap-y-1"
             data-testid="bl-documents"
-            :config="businessLicenseDocumentsConfig"
+            :config="isApplication ? businessLicenseDocumentsConfig : businessLicenseRegistrationConfig"
           />
         </div>
 
@@ -178,7 +192,7 @@ const nocDocumentsConfig: SupportingDocumentsConfig = {
             <SupportingDocuments
               class="mb-1 flex gap-y-1"
               data-testid="initial-app-documents"
-              :config="applicationDocumentsConfig"
+              :config="isApplication ? applicationDocumentsConfig : registrationDocumentsConfig"
             />
             <SupportingDocuments
               class="flex flex-wrap gap-y-1"

--- a/strr-examiner-web/app/components/Strata/SupportingInfo.vue
+++ b/strr-examiner-web/app/components/Strata/SupportingInfo.vue
@@ -2,7 +2,7 @@
 import { ConnectPageSection } from '#components'
 
 const exStore = useExaminerStore()
-const { activeReg } = storeToRefs(exStore)
+const { activeReg, isApplication } = storeToRefs(exStore)
 
 const { t } = useI18n()
 
@@ -17,6 +17,12 @@ const nocDocumentsConfig: SupportingDocumentsConfig = {
   includeDateBadge: [DocumentUploadStep.NOC]
 }
 
+// show all documents for registrations with date badges
+const registrationDocumentsConfig: SupportingDocumentsConfig = {
+  excludeUploadStep: [DocumentUploadStep.NOC],
+  showDateBadgeForAll: true
+}
+
 </script>
 <template>
   <ConnectPageSection v-if="activeReg?.documents?.length">
@@ -24,7 +30,7 @@ const nocDocumentsConfig: SupportingDocumentsConfig = {
       <ApplicationDetailsSection :label="t('strr.label.supportingInfo')">
         <SupportingDocuments
           class="mb-1 flex gap-y-1"
-          :config="applicationDocumentsConfig"
+          :config="isApplication ? applicationDocumentsConfig : registrationDocumentsConfig"
         />
         <SupportingDocuments
           class="mb-1 flex gap-y-1"

--- a/strr-examiner-web/app/components/SupportingDocuments.vue
+++ b/strr-examiner-web/app/components/SupportingDocuments.vue
@@ -52,8 +52,9 @@ const appRegNumber = computed((): string | number =>
         {{ t(`documentLabels.${document.documentType}`) }}
       </UButton>
       <UBadge
-        v-if="document.uploadStep && props.config?.includeDateBadge?.includes(document.uploadStep)"
-        :label="`${ t('strr.label.added')} ` + document.uploadDate"
+        v-if="(document.uploadStep && props.config?.includeDateBadge?.includes(document.uploadStep)) ||
+          (props.config?.showDateBadgeForAll && (document.uploadDate || document.addedOn))"
+        :label="`${ t('strr.label.added')} ` + (document.uploadDate || document.addedOn)"
         size="sm"
         class="ml-2 px-3 py-0 font-bold"
         data-testid="supporting-doc-date-badge"

--- a/strr-examiner-web/app/components/SupportingDocuments.vue
+++ b/strr-examiner-web/app/components/SupportingDocuments.vue
@@ -33,6 +33,11 @@ const filteredDocuments = computed(() => props.config ? filterDocumentsByConfig(
 const appRegNumber = computed((): string | number =>
   isApplication.value ? applicationNumber : activeReg.value.id
 )
+
+const shouldShowDateBadge = (document: ApiDocument): boolean => {
+  return (document.uploadStep && props.config?.includeDateBadge?.includes(document.uploadStep)) ||
+    (props.config?.showDateBadgeForAll && (document.uploadDate || document.addedOn))
+}
 </script>
 
 <template>
@@ -52,8 +57,7 @@ const appRegNumber = computed((): string | number =>
         {{ t(`documentLabels.${document.documentType}`) }}
       </UButton>
       <UBadge
-        v-if="(document.uploadStep && props.config?.includeDateBadge?.includes(document.uploadStep)) ||
-          (props.config?.showDateBadgeForAll && (document.uploadDate || document.addedOn))"
+        v-if="shouldShowDateBadge(document)"
         :label="`${ t('strr.label.added')} ` + (document.uploadDate || document.addedOn)"
         size="sm"
         class="ml-2 px-3 py-0 font-bold"

--- a/strr-examiner-web/app/interfaces/supporting-documents.ts
+++ b/strr-examiner-web/app/interfaces/supporting-documents.ts
@@ -9,5 +9,6 @@ export interface SupportingDocumentsConfig {
     excludeTypes?: DocumentUploadType[],
     includeUploadStep?: DocumentUploadStep[],
     excludeUploadStep?: DocumentUploadStep[],
-    includeDateBadge?: DocumentUploadStep[] // Upload Steps for which to show the date badges
+    includeDateBadge?: DocumentUploadStep[], // Upload Steps for which to show the date badges
+    showDateBadgeForAll?: boolean // Show date badges for all documents regardless of upload step (for registrations)
 }

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/29671

*Description of changes:*
Badges showing for registration NOC & BL
<img width="1435" height="1152" alt="image" src="https://github.com/user-attachments/assets/8a9859f2-6c8a-4617-95d9-769bec5b44f6" />

Application
<img width="1487" height="704" alt="image" src="https://github.com/user-attachments/assets/45c99410-3b49-411a-b7f6-0ca6ab9a3387" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
