### PR TITLE
Host UI Fix - `PROVISIONAL_REVIEW_NOC_PENDING` unable to upload documents

### DIFF
--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/29902

*Description of changes:*
Tested in DEV:
- H307931455 , 36458020593230
- H270872610, 48948108028967

Add document to registration flow will only be triggered if either there is a registration NOC or BL jurisdiction condition is met. For applications with `PROVISIONAL_REVIEW_NOC_PENDING` the documents will be uploaded to application instead of registration (see Arlen comment below).

Because of NOC status flag check in registration document upload endpoint I encountered the following issue:
<img width="855" height="643" alt="image" src="https://github.com/user-attachments/assets/a827564a-8439-40be-9a78-896b7125579b" />

This is what the final requirements from Arlen were:
<img width="1014" height="249" alt="image" src="https://github.com/user-attachments/assets/267de26d-a2ff-4883-b89a-754918252915" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
