### PR TITLE
Prevent Examiner actions from showing up in certain cases

### DIFF
--- a/strr-examiner-web/app/composables/useExaminerRoute.ts
+++ b/strr-examiner-web/app/composables/useExaminerRoute.ts
@@ -112,7 +112,7 @@ export const useExaminerRoute = () => {
       const currentLabels = currentButtons.rightButtons.map(btn => btn.label)
       const commonLabels = configLabels.filter(label => currentLabels.includes(label))
       const processedLabels = new Set<string>()
-      const uniqueRightButtons = currentButtons.rightButtons.filter((btn) => {
+      const uniqueRightButtons = examinerActions?.length > 0 && currentButtons.rightButtons.filter((btn) => {
         if (processedLabels.has(btn.label) || commonLabels.includes(btn.label)) {
           return false
         }

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/28966

*Description of changes:*
- Prevent Examiner actions from showing up in certain cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
