### PR TITLE
Examiner UI - No Completing Party in Registration View

### DIFF
--- a/strr-examiner-web/app/components/Host/Expansion/Owners.vue
+++ b/strr-examiner-web/app/components/Host/Expansion/Owners.vue
@@ -6,7 +6,7 @@ defineEmits<{
   close: [void]
 }>()
 const exStore = useExaminerStore()
-const { activeReg } = storeToRefs(exStore)
+const { activeReg, isApplication } = storeToRefs(exStore)
 
 const { t } = useI18n()
 
@@ -169,7 +169,7 @@ const hostOwners = computed<HostOwner[]>(() => {
     </template>
     <template #role-data="{ row }: { row: HostOwner }">
       <div class="space-y-3">
-        <p v-if="row.isCompParty">
+        <p v-if="isApplication && row.isCompParty">
           {{ $t('label.completingParty') }}
           ({{ getFullName(row) }})
         </p>

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/entity/issues/29923

*Description of changes:*
- [x] Remove the "Completing Party" information from the Registration details view

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
