### PR TITLE
Show Unsaved Confirm Modal on all Applications flows

### DIFF
--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -42,21 +42,19 @@ const hostFee3 = ref<ConnectFeeItem | undefined>(undefined)
 const hostFee4 = ref<ConnectFeeItem | undefined>(undefined)
 
 const isRegRenewalFlow = computed(() => isRenewal.value && useState('renewalRegId').value)
+let shouldSkipConfirmModal = false
 
 // show default confirm modal when closing or refreshing the tab while in renewal flow
 useEventListener(globalThis, 'beforeunload', (event: BeforeUnloadEvent) => {
-  if (isRegRenewalFlow.value) {
-    event.preventDefault()
-    event.returnValue = ''
-  }
+  event.preventDefault()
+  event.returnValue = ''
 })
 
 // show custom confirm modal when navigating away within the app while in renewal flow
 onBeforeRouteLeave(async () => {
-  if (isRegRenewalFlow.value) {
+  if (!shouldSkipConfirmModal) {
     return await openConfirmUnsavedChanges()
   }
-  return true
 })
 
 onMounted(async () => {
@@ -310,9 +308,8 @@ watch([activeStepIndex, () => permitStore.isRegistrationRenewal], () => {
   leftActionButtons.push(
     {
       action: () => {
-        if (isRegRenewalFlow.value) {
-          useState('renewalRegId', () => undefined)
-        }
+        // save and resume later button
+        shouldSkipConfirmModal = true
         saveApplication(true)
       },
       label: t('btn.saveExit'),

--- a/strr-host-pm-web/app/pages/dashboard/index.vue
+++ b/strr-host-pm-web/app/pages/dashboard/index.vue
@@ -88,7 +88,10 @@ const mapApplicationsList = () => {
     return []
   }
   return (hostPmListResp.value.applications)
-    .filter((app: any) => (app.header.applicationType !== 'renewal' && app.header.status !== ApplicationStatus.DRAFT)) // filter out renewal drafts
+    .filter((app: any) => // filter out renewal drafts
+      !(app.header.applicationType &&
+        app.header.applicationType === 'renewal' && app.header.status === ApplicationStatus.DRAFT)
+    )
     .map((app: any) => {
       const displayAddress = app.header.registrationAddress || app.registration.unitAddress
       return {

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/

*Description of changes:*
- Show Unsaved Confirm Modal on all Applications flows (not only renewals)
- Small fix for filtering out draft renewals

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
