### PR TITLE
Fix to prevent confirm modal on session timeout

### DIFF
--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -396,7 +396,10 @@ definePageMeta({
 })
 
 // save application before session expires
-setOnBeforeSessionExpired(() => submitApplication(true, applicationId.value))
+setOnBeforeSessionExpired(() => {
+  shouldSkipConfirmModal = true
+  submitApplication(true, applicationId.value)
+})
 </script>
 <template>
   <ConnectSpinner v-if="loading" overlay />

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31002

*Description of changes:*
- Prevent confirm modal from showing up on session timeout

### Before fix 
![Screenshot 2025-10-29 at 16 03 32](https://github.com/user-attachments/assets/f2196146-5234-4d3a-92da-eac8d80a69ac)


### After the Fix
![Screenshot 2025-10-29 at 16 09 37](https://github.com/user-attachments/assets/69a32a46-73a9-435e-ac9c-9e48f01ccc68)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
