### PR TITLE
31091 - Locked hotel address fields for strata hotels

### DIFF
--- a/strr-strata-web/app/components/form/StrataDetails.vue
+++ b/strr-strata-web/app/components/form/StrataDetails.vue
@@ -6,10 +6,36 @@ const rtc = useRuntimeConfig().public
 const strataModal = useStrataModals()
 const { addNewEmptyBuilding, removeBuildingAtIndex, strataDetailsSchema } = useStrrStrataDetailsStore()
 const { strataDetails } = storeToRefs(useStrrStrataDetailsStore())
+const { isRegistrationRenewal } = storeToRefs(useStrrStrataStore())
 const docStore = useDocumentStore()
 const { getDocumentSchema } = docStore
 
 const props = defineProps<{ isComplete: boolean }>()
+
+// Type for address field keys, derived from ConnectAddress interface
+type AddressField = keyof ConnectAddress
+
+// For new applications: only country and region are locked
+const editableAddressDisabledFields: AddressField[] = ['country', 'region']
+
+// For renewals: hotel address fields are locked (pre-filled from original registration)
+const lockedAddressFields: AddressField[] = [
+  'country',
+  'street',
+  'streetName',
+  'streetNumber',
+  'unitNumber',
+  'streetAdditional',
+  'city',
+  'region',
+  'postalCode',
+  'locationDescription'
+]
+
+// Dynamically determine which fields to disable based on renewal status
+const addressDisabledFields = computed<AddressField[]>(() => (
+  isRegistrationRenewal.value ? lockedAddressFields : editableAddressDisabledFields
+))
 
 const strataDetailsFormRef = ref<Form<z.output<typeof strataDetailsSchema>>>()
 const documentFormRef = ref<Form<any>>()
@@ -169,7 +195,7 @@ onMounted(async () => {
                 v-model:postal-code="strataDetails.location.postalCode"
                 :schema-prefix="'location.'"
                 :form-ref="strataDetailsFormRef"
-                :disabled-fields="['country', 'region']"
+                :disabled-fields="addressDisabledFields"
                 :excluded-fields="['streetName', 'streetNumber', 'unitNumber']"
                 :use-location-desc-label="true"
               />
@@ -232,7 +258,7 @@ onMounted(async () => {
                       v-model:postal-code="building.postalCode"
                       :schema-prefix="`buildings.${i}`"
                       :form-ref="strataDetailsFormRef"
-                      :disabled-fields="['country', 'region']"
+                      :disabled-fields="addressDisabledFields"
                       :excluded-fields="['streetName', 'streetNumber', 'unitNumber']"
                     />
                   </div>

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31091

*Description of changes:*
After speaking with Arlen, I confirmed that we only need to lock the address fields of hotel (step 3) for strata hotel renewals

<img width="1271" height="712" alt="image" src="https://github.com/user-attachments/assets/fe953cd6-0915-4ce5-aa08-89e433e47d66" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
