### PR TITLE
31091 - Fixes to the locking of fields in strata hotel renewals

### DIFF
--- a/strr-strata-web/app/locales/en-CA.ts
+++ b/strr-strata-web/app/locales/en-CA.ts
@@ -80,7 +80,8 @@ export default {
     hint: {
       brandName: 'The name of the strata-titled hotel or motel.',
       brandSite: 'e.g., https://www.your-strata-hotel.ca/',
-      numberOfUnits: 'The total number of units within the strata-titled hotel or motel that are offered as short-term rental accommodation.'
+      numberOfUnits: 'The total number of units within the strata-titled hotel or motel that are offered as short-term rental accommodation.',
+      adjacentProperties: 'Additional buildings must be on adjacent properties.'
     },
     review: {
       brand: {

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31091

*Description of changes:*
Felipe's comment: https://github.com/bcgov/entity/issues/31091#issuecomment-3598681540
<img width="1012" height="657" alt="image" src="https://github.com/user-attachments/assets/8dd09a9c-c2c2-47c1-af7a-7fe04c011de9" />

This fixes that. 

Also, I noticed this in the source of truth excel sheet:
<img width="1878" height="115" alt="image" src="https://github.com/user-attachments/assets/eb210c7f-213d-4ddb-b457-a9231102f1a5" />

So I added a toolbar to the button only when renewal:
<img width="480" height="152" alt="image" src="https://github.com/user-attachments/assets/112dd42b-70ef-41c3-9b5c-2210b8a7910e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
