### PR TITLE
31091 - Fix locking of fields in strata hotel renewals bugs

### DIFF
--- a/strr-strata-web/app/components/form/StrataDetails.vue
+++ b/strr-strata-web/app/components/form/StrataDetails.vue
@@ -4,8 +4,9 @@ import type { Form } from '#ui/types'
 
 const rtc = useRuntimeConfig().public
 const strataModal = useStrataModals()
-const { addNewEmptyBuilding, removeBuildingAtIndex, strataDetailsSchema } = useStrrStrataDetailsStore()
-const { strataDetails } = storeToRefs(useStrrStrataDetailsStore())
+const detailsStore = useStrrStrataDetailsStore()
+const { addNewEmptyBuilding, removeBuildingAtIndex, strataDetailsSchema } = detailsStore
+const { strataDetails, originalBuildingCount } = storeToRefs(detailsStore)
 const { isRegistrationRenewal } = storeToRefs(useStrrStrataStore())
 const docStore = useDocumentStore()
 const { getDocumentSchema } = docStore
@@ -31,9 +32,6 @@ const lockedAddressFields: AddressField[] = [
   'postalCode',
   'locationDescription'
 ]
-
-// Track the original number of buildings when loading a renewal
-const originalBuildingCount = ref(0)
 
 // Dynamically determine which fields to disable based on renewal status
 const addressDisabledFields = computed<AddressField[]>(() => (
@@ -61,11 +59,6 @@ watch(() => docStore.storedDocuments,
 )
 
 onMounted(async () => {
-  // Capture the initial building count for renewals to distinguish pre-existing from newly added
-  if (isRegistrationRenewal.value) {
-    originalBuildingCount.value = strataDetails.value.buildings.length
-  }
-
   // validate form if step marked as complete
   if (props.isComplete) {
     await validateForm(strataDetailsFormRef.value, props.isComplete)

--- a/strr-strata-web/app/stores/strata.ts
+++ b/strr-strata-web/app/stores/strata.ts
@@ -70,6 +70,9 @@ export const useStrrStrataStore = defineStore('strr/strata', () => {
 
       strataDetails.value = formatStrataDetailsUI(permitDetails.value.strataHotelDetails)
 
+      // Capture the original building count for renewals to differentiate pre-existing from newly added
+      detailsStore.setOriginalBuildingCount(strataDetails.value.buildings.length)
+
       storedDocuments.value = permitDetails.value.documents?.map<UiDocument>(val => ({
         file: {} as File,
         apiDoc: val,

--- a/strr-strata-web/app/stores/strataDetails.ts
+++ b/strr-strata-web/app/stores/strataDetails.ts
@@ -67,6 +67,14 @@ export const useStrrStrataDetailsStore = defineStore('strr/strataDetails', () =>
 
   const strataDetails = ref<StrataDetails>(getEmptyStrataDetails())
 
+  // Tracks the number of buildings from the original registration (for renewals)
+  // Used to determine which buildings should have locked address fields
+  const originalBuildingCount = ref(0)
+
+  const setOriginalBuildingCount = (count: number) => {
+    originalBuildingCount.value = count
+  }
+
   const addNewEmptyBuilding = () => {
     strataDetails.value.buildings.push({
       country: 'CA',
@@ -101,14 +109,17 @@ export const useStrrStrataDetailsStore = defineStore('strr/strataDetails', () =>
 
   const $reset = () => {
     strataDetails.value = getEmptyStrataDetails()
+    originalBuildingCount.value = 0
   }
 
   return {
     strataDetails,
+    originalBuildingCount,
     getStrataBrandSchema,
     strataDetailsSchema,
     addNewEmptyBuilding,
     removeBuildingAtIndex,
+    setOriginalBuildingCount,
     validateStrataDetails,
     $reset
   }

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31091

*Description of changes:*
Fixing this: https://github.com/bcgov/entity/issues/31091#issuecomment-3628622782

1. Add a new building in Step 3 "Add Strata Hotel Information"
2. Note that fields are editable.
3. Navigate to another step.
4. Return to Step 2.
5. Note that fields for the newly created building are no longer editable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
