### PR TITLE
Fix Step 3 validation with BL Exemption

### DIFF
--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -175,10 +175,13 @@ const steps = ref<Step[]>([
     icon: 'i-mdi-file-upload-outline',
     complete: false,
     isValid: false,
-    validationFn: () => (
-      propertyStore.validateBusinessLicense(true) as boolean &&
-      documentsStore.validateRequiredDocuments().length === 0 &&
-      showUnitDetailsForm.value)
+    validationFn: (): boolean => {
+      // if BL Exemption selected, do not validate business lic
+      const blValid = propertyReqStore.blRequirements.isBusinessLicenceExempt ||
+        propertyStore.validateBusinessLicense(true)
+      const docsValid = documentsStore.validateRequiredDocuments().length === 0
+      return blValid && docsValid && showUnitDetailsForm.value
+    }
   },
   {
     i18nPrefix: 'strr.step',

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.51",
+  "version": "1.2.52",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31564

*Description of changes:*
- Fix: Do not validate Business Lic if BL Exemption is selected. Otherwise the Step 3 will be showing invalid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
