### PR TITLE
26715 - Fix Hosts system preventing to add property manager

### DIFF
--- a/strr-host-pm-web/app/components/form/AddOwners/Index.vue
+++ b/strr-host-pm-web/app/components/form/AddOwners/Index.vue
@@ -86,7 +86,7 @@ const checklistItems = computed<ConnectValidatedChecklistItem[]>(() => [
         color="primary"
         icon="i-mdi-account-plus"
         variant="outline"
-        :disabled="disableButtons || (hasHost && hasCoHost)"
+        :disabled="disableButtons || (hasHost && hasCoHost && hasPropertyManager)"
         data-testid="add-person-owner-btn"
         @click="addingNewType = OwnerType.INDIVIDUAL"
       />

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.2.55",
+  "version": "1.2.56",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/26715

*Description of changes:*
Fixed, now:
User is on step 2 of host application
User adds themself as the property host
User adds a co-host
User is able to add another individual for property manager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
