### PR TITLE
feat: feature flag hosts text search fields

### DIFF
--- a/strr-host-pm-web/app/components/dashboard/ApplicationsTable.vue
+++ b/strr-host-pm-web/app/components/dashboard/ApplicationsTable.vue
@@ -4,7 +4,7 @@ const localePath = useLocalePath()
 const accountStore = useConnectAccountStore()
 const strrModal = useStrrModals()
 const { deleteApplication, getAccountApplications, searchApplications } = useStrrApi()
-const { isDashboardTableSortingEnabled } = useHostFeatureFlags()
+const { isDashboardTableSortingEnabled, isHostSearchTextFieldsEnabled } = useHostFeatureFlags()
 
 const props = withDefaults(defineProps<{
   applicationsLimit?: number
@@ -186,6 +186,7 @@ async function handleApplicationSelect (row: any) {
           {{ $t('page.dashboardList.applicationsInProgress') }} ({{ totalFilteredApplications }})
         </h2>
         <UInput
+          v-if="isHostSearchTextFieldsEnabled"
           v-model="searchText"
           icon="i-mdi-magnify"
           :placeholder="$t('strr.label.search')"

--- a/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
+++ b/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
@@ -4,7 +4,7 @@ const localePath = useLocalePath()
 const accountStore = useConnectAccountStore()
 const permitStore = useHostPermitStore()
 const { getAccountRegistrations, searchRegistrations } = useStrrApi()
-const { isDashboardTableSortingEnabled } = useHostFeatureFlags()
+const { isDashboardTableSortingEnabled, isHostSearchTextFieldsEnabled } = useHostFeatureFlags()
 
 const props = withDefaults(defineProps<{
   registrationsLimit?: number
@@ -164,6 +164,7 @@ async function handleRegistrationSelect (row: any) {
           {{ $t('page.dashboardList.myShortTermRentals') }} ({{ registrationsResp?.total || 0 }})
         </h2>
         <UInput
+          v-if="isHostSearchTextFieldsEnabled"
           v-model="searchText"
           icon="i-mdi-magnify"
           :placeholder="$t('strr.label.search')"

--- a/strr-host-pm-web/app/composables/useHostFeatureFlags.ts
+++ b/strr-host-pm-web/app/composables/useHostFeatureFlags.ts
@@ -8,6 +8,7 @@ export const useHostFeatureFlags = () => {
     isNewRentalUnitSetupEnabled: isFeatureEnabled('enable-host-new-rental-unit-setup'),
     isNewPrDocumentsListEnabled: isFeatureEnabled('enable-host-new-pr-documents'),
     isDashboardTableSortingEnabled: isFeatureEnabled('enable-host-dashboard-table-sorting'),
-    isNewDashboardEnabled: isFeatureEnabled('enable-new-host-dashboard')
+    isNewDashboardEnabled: isFeatureEnabled('enable-new-host-dashboard'),
+    isHostSearchTextFieldsEnabled: isFeatureEnabled('enable-host-search-text-fields')
   }
 }

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31960

*Description of changes:*
If feature flag is off:
<img width="1532" height="810" alt="image" src="https://github.com/user-attachments/assets/cbeb944a-9f7b-4b27-820d-fa23f5cf697e" />

This is the flag I created:
<img width="1607" height="192" alt="image" src="https://github.com/user-attachments/assets/27d9df3a-0ddd-4742-8156-db81dfb65bc7" />

I've set it to ON in DEV and TEST so that we can test as we implement a fix. It is OFF in PROD.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
