### PR TITLE
fix(ui): make tax number validation optional for Reg renewals

### DIFF
--- a/strr-host-pm-web/app/stores/hostOwner.ts
+++ b/strr-host-pm-web/app/stores/hostOwner.ts
@@ -4,6 +4,7 @@ export const useHostOwnerStore = defineStore('host/owner', () => {
   // TODO: pull common pieces of this and useStrrContactStore into base composable
   const { t } = useNuxtApp().$i18n
   const { getNewContact } = useStrrContactStore()
+  const { isRegistrationRenewal } = storeToRefs(useHostPermitStore())
 
   const getHostOwnerSchema = (type: OwnerType, role?: OwnerRole) => {
     return z.object({
@@ -32,7 +33,8 @@ export const useHostOwnerStore = defineStore('host/owner', () => {
       dateOfBirth: type === OwnerType.INDIVIDUAL && role === OwnerRole.HOST
         ? getRequiredNonEmptyString(t('validation.dateOfBirth'))
         : optionalOrEmptyString,
-      taxNumber: (type === OwnerType.INDIVIDUAL && role === OwnerRole.HOST) && !isCraNumberOptional.value
+      taxNumber: (type === OwnerType.INDIVIDUAL && role === OwnerRole.HOST) && !isCraNumberOptional.value &&
+        !isRegistrationRenewal.value // taxNumber is non-editable in renewals, so need to make validation optional in case it's empty
         ? getRequiredSin(t('validation.sin'))
         : optionalOrEmptyString
     })

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31790

*Description of changes:*
- make tax number validation optional for Reg renewals



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
