### PR TITLE
28765 - Remove "strr-important-deadlines.md" from provisional approval emails #2

### DIFF
--- a/queue_services/strr-email/email-templates/strr-HOST_PROVISIONAL_REVIEW.md
+++ b/queue_services/strr-email/email-templates/strr-HOST_PROVISIONAL_REVIEW.md
@@ -7,10 +7,6 @@ Your application to register the short-term rental described below is **_provisi
 
 ---
 
-[[strr-important-deadlines.md]]
-
----
-
 [[strr-provisional-approval-info.md]]
 
 ---


### PR DESCRIPTION
Removed inclusion of "strr-important-deadlines.md" as the contents are no longer relevant.

*Issue:*

- bcgov/entity/issues/

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
