### PR TITLE
fix: pr only registrations not asked for new documents for renewals

### DIFF
--- a/strr-host-pm-web/app/stores/hostPermit.ts
+++ b/strr-host-pm-web/app/stores/hostPermit.ts
@@ -100,8 +100,10 @@ export const useHostPermitStore = defineStore('host/permit', () => {
     blInfo.value = formatHostUnitDetailsBlInfoUI(permitDetails.value.unitDetails)
     unitAddress.value = { address: formatHostUnitAddressUI(permitDetails.value.unitAddress) }
     showUnitDetailsForm.value = !!unitAddress.value.address.street || !!unitAddress.value.address.streetAdditional
-    prRequirements.value.isPropertyPrExempt = !!permitDetails.value.unitDetails.prExemptReason
-    prRequirements.value.prExemptionReason = permitDetails.value.unitDetails.prExemptReason
+    // Normalize null/empty exemption reason so PR docs are required when not exempt
+    const prExemptReason = permitDetails.value.unitDetails.prExemptReason || undefined
+    prRequirements.value.isPropertyPrExempt = !!prExemptReason
+    prRequirements.value.prExemptionReason = prExemptReason
     blRequirements.value.isBusinessLicenceExempt = !!permitDetails.value.unitDetails.blExemptReason
 
     // populate BL Exempt radio buttons selection and reason

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",
@@ -50,5 +50,6 @@
     "nuxt": "3.15.4",
     "uuid": "^11.1.0",
     "vue-country-flag-next": "^2.3.2"
-  }
+  },
+  "packageManager": "pnpm@10.21.0+sha1.a2cb35d3f07a58fecfe050af9277c5dc43a1b2e7"
 }


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/31993

*Description of changes:*
This was one of those bugs that was really annoying to pinpoint what was causing the issue haha
Now, on PR only registration renewal, we can see the document list required:
<img width="1020" height="892" alt="image" src="https://github.com/user-attachments/assets/6eecf773-b5c0-4d77-94ea-e3e82f20da29" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
