### PR TITLE
feat: adding send a final day reminder for renewals.

### DIFF
--- a/jobs/renewal-reminders/src/renewal_reminders/job.py
+++ b/jobs/renewal-reminders/src/renewal_reminders/job.py
@@ -225,6 +225,9 @@ def run():
             send_fourteen_days_reminder(
                 app, registration_type=Registration.RegistrationType.HOST
             )
+            send_final_day_reminder(
+                app, registration_type=Registration.RegistrationType.HOST
+            )
             send_forty_days_reminder(
                 app, registration_type=Registration.RegistrationType.PLATFORM
             )


### PR DESCRIPTION
*Issue:*
- /bcgov/entity#31994

*Description of changes:*
- Adding the selection and sending of a final day reminder for registrations that are expiring and have no paid renewal on file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
