### PR TITLE
fix: bumping the api version

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.1.13"
+version = "0.1.14"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
*Issue:*
/bcgov/entity#31994

*Description of changes:*
- bumping the API version, to force lock change on job

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
