### PR TITLE
fix: bump the jobs version, missed in the last PR.

### DIFF
--- a/jobs/renewal-reminders/pyproject.toml
+++ b/jobs/renewal-reminders/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "renewal-reminders"
-version = "1.0.2"
+version = "1.0.3"
 description = ""
 authors = []
 packages = [{include = "renewal_reminders", from = "src"}]


### PR DESCRIPTION
*Issue:*
- /bcgov/entity#31994

*Description of changes:*
- bumping the jobs version number, missed in the last PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
