### PR TITLE
feat: implemented routing to registrations from registrations table

### DIFF
--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/32202

*Description of changes:*
- Clicking on registration from the registrations table now opens it

While doing some testing, i noticed if i go back while having a registration open gets me back to a state where the applications table is shown. I figured that'll be very annoying for examiners. I added code to fix that. Now, by passing a query param, the UI will know that we were in the registrations table. 

This fix also works when filters are applied. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
