### PR TITLE
fix: add missing filing history event name

### DIFF
--- a/strr-examiner-web/i18n/locales/en-CA.ts
+++ b/strr-examiner-web/i18n/locales/en-CA.ts
@@ -682,7 +682,7 @@ export default {
     REGISTRATION_CREATED: 'Registration created',
     REGISTRATION_CANCELLED: 'Registration cancelled',
     CERTIFICATE_ISSUED: 'Certificate issued for the registration',
-    EXPIRED: 'Registration expired',
+    REGISTRATION_EXPIRED: 'Registration expired',
     NON_COMPLIANCE_SUSPENDED: 'Registration suspended due to non compliance',
     APPLICATION_REVIEWER_ASSIGNED: 'Application reviewer assigned',
     APPLICATION_REVIEWER_UNASSIGNED: 'Application reviewer unassigned',

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/29614

*Description of changes:*
- One of the Filing History Events was missing content

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
