### PR TITLE
fix: updated deprecated calls to the current supported replacements.

### DIFF
--- a/strr-api/src/strr_api/resources/meta.py
+++ b/strr-api/src/strr_api/resources/meta.py
@@ -35,9 +35,9 @@
 """Meta information about the service.
 Currently this only provides API versioning information
 """
-from flask import Blueprint
-from flask import __version__ as framework_version
-from flask import jsonify
+from importlib.metadata import version as meta_version
+
+from flask import Blueprint, jsonify
 
 from strr_api.common.run_version import get_run_version
 
@@ -56,5 +56,6 @@ def info():
       200:
         description:
     """
+    framework_version = meta_version("flask")
     version = get_run_version()
     return jsonify(API=f"{__name__[: __name__.find('.')]}/{version}", FrameWork=f"{framework_version}")

--- a/strr-api/src/strr_api/responses/LTSAResponse.py
+++ b/strr-api/src/strr_api/responses/LTSAResponse.py
@@ -3,7 +3,7 @@ LTSA response objects.
 """
 from typing import List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class TitleSummary(BaseModel):
@@ -100,6 +100,7 @@ class DescriptionOfLand(BaseModel):
     parcelStatus: str
 
 
+# @dataclass(config=ConfigDict(extra="ignore"))
 class LtsaResponse(BaseModel):
     """LTSA Reference endpoint response object."""
 
@@ -110,7 +111,4 @@ class LtsaResponse(BaseModel):
     ownershipGroups: List[OwnershipGroup]
     descriptionsOfLand: List[DescriptionOfLand]
 
-    class Config:
-        """Pydantic configuration"""
-
-        extra = "ignore"
+    __pydantic_config__ = ConfigDict(extra="ignore")


### PR DESCRIPTION
*Issue:* n/a

*Description of changes:*
- updated meta and replaced deprecated version info
- updated pydantic call to use the dict as the current calls were deprecated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
