### PR TITLE
fix: fixed hosts sessionstorage reset on account change

### DIFF
--- a/strr-host-pm-web/app/components/dashboard/ApplicationsTable.vue
+++ b/strr-host-pm-web/app/components/dashboard/ApplicationsTable.vue
@@ -12,21 +12,15 @@ const props = withDefaults(defineProps<{
   applicationsLimit: 6
 })
 
-// Pagination state - persisted in session storage
-// reset when account changes so we don't show page 4 for an account with 1 page for example
-const { page: applicationsPage, resetPage: resetApplicationsPage } = useDashboardTablePagination(
-  'appPage',
-  () => accountStore.currentAccount.id
-)
-
-// Search state - persisted in session storage; reset when account changes
-const { searchText } = useDashboardTableSearch('appSearch', () => accountStore.currentAccount.id)
+// Pagination and search state from composable
+const { page: applicationsPage } = useDashboardTablePagination('appPage')
+const { searchText } = useDashboardTableSearch('appSearch')
 const isSearching = computed(() => searchText.value.length >= 3)
 
 // When starting a new search (or clearing), always return to page 1
 watch(searchText, () => {
   if (applicationsPage.value !== 1) {
-    resetApplicationsPage()
+    applicationsPage.value = 1
   }
 })
 

--- a/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
+++ b/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
@@ -12,21 +12,15 @@ const props = withDefaults(defineProps<{
   registrationsLimit: 6
 })
 
-// Pagination state - persisted in session storage
-// reset when account changes so we don't show page 4 for an account with 1 page for example
-const { page: registrationsPage, resetPage: resetRegistrationsPage } = useDashboardTablePagination(
-  'regPage',
-  () => accountStore.currentAccount.id
-)
-
-// Search state - persisted in session storage; reset when account changes
-const { searchText } = useDashboardTableSearch('regSearch', () => accountStore.currentAccount.id)
+// Pagination and search state from composable
+const { page: registrationsPage } = useDashboardTablePagination('regPage')
+const { searchText } = useDashboardTableSearch('regSearch')
 const isSearching = computed(() => searchText.value.length >= 3)
 
 // When starting a new search (or clearing), always return to page 1
 watch(searchText, () => {
   if (registrationsPage.value !== 1) {
-    resetRegistrationsPage()
+    registrationsPage.value = 1
   }
 })
 

--- a/strr-host-pm-web/app/composables/useDashboardTablePersistence.ts
+++ b/strr-host-pm-web/app/composables/useDashboardTablePersistence.ts
@@ -1,21 +1,13 @@
-// Persist pagination state in session storage.
-// When resetWhen() changes (account id), page is reset to 1 so we don't show an invalid page for the new account.
-export function useDashboardTablePagination (storageKey: string, resetWhen?: () => unknown) {
+// Persist pagination state in session storage
+export function useDashboardTablePagination (storageKey: string) {
   const page = useSessionStorage(storageKey, 1)
   const resetPage = () => { page.value = 1 }
-  if (resetWhen) {
-    watch(resetWhen, () => { page.value = 1 }, { immediate: false })
-  }
   return { page, resetPage }
 }
 
-// Persist search state in session storage.
-// When resetWhen() changes (account id), search is cleared so we don't keep the previous account's search.
-export function useDashboardTableSearch (storageKey: string, resetWhen?: () => unknown) {
+// Persist search state in session storage
+export function useDashboardTableSearch (storageKey: string) {
   const searchText = useSessionStorage(storageKey, '')
   const clearSearch = () => { searchText.value = '' }
-  if (resetWhen) {
-    watch(resetWhen, () => { searchText.value = '' }, { immediate: false })
-  }
   return { searchText, clearSearch }
 }

--- a/strr-host-pm-web/app/pages/dashboard-new/index.vue
+++ b/strr-host-pm-web/app/pages/dashboard-new/index.vue
@@ -1,7 +1,21 @@
 <script setup lang="ts">
 const { t } = useNuxtApp().$i18n
 const localePath = useLocalePath()
+const accountStore = useConnectAccountStore()
 const strrModal = useStrrModals()
+
+// Persist table state in session storage; clear when account changes so we don't show page 4 for an account with 1 page
+const { resetPage: resetRegPage } = useDashboardTablePagination('regPage')
+const { clearSearch: clearRegSearch } = useDashboardTableSearch('regSearch')
+const { resetPage: resetAppPage } = useDashboardTablePagination('appPage')
+const { clearSearch: clearAppSearch } = useDashboardTableSearch('appSearch')
+
+watch(() => accountStore.currentAccount.id, () => {
+  resetRegPage()
+  clearRegSearch()
+  resetAppPage()
+  clearAppSearch()
+}, { immediate: false })
 
 useHead({
   title: t('page.dashboardList.title')


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/32412

*Description of changes:*
Resetting now the page and search fields in hosts on account switch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
