### PR TITLE
feat(ui): update default filters in examiners dash table

### DIFF
--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -155,13 +155,7 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
   ]
 
   const applicationsOnlyStatuses = [
-    ApplicationStatus.FULL_REVIEW,
-    ApplicationStatus.PAID,
-    ApplicationStatus.ADDITIONAL_INFO_REQUESTED,
-    ApplicationStatus.NOC_PENDING,
-    ApplicationStatus.NOC_EXPIRED,
-    ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING,
-    ApplicationStatus.PROVISIONAL_REVIEW_NOC_EXPIRED
+    ApplicationStatus.FULL_REVIEW
   ]
 
   const tableFilters = reactive({

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -36,13 +36,7 @@ const createMockStore = (initialFilters = {}) => {
   })
 
   const applicationsOnlyStatuses = [
-    ApplicationStatus.FULL_REVIEW,
-    ApplicationStatus.PAID,
-    ApplicationStatus.ADDITIONAL_INFO_REQUESTED,
-    ApplicationStatus.NOC_PENDING,
-    ApplicationStatus.NOC_EXPIRED,
-    ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING,
-    ApplicationStatus.PROVISIONAL_REVIEW_NOC_EXPIRED
+    ApplicationStatus.FULL_REVIEW
   ]
 
   return {


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/32332

*Description of changes:*
- update filters in examiners dashboard application table to only show Full Review (aka new) applications


<img width="2202" height="1808" alt="Screenshot 2026-02-10 at 10 50 12" src="https://github.com/user-attachments/assets/e79e2439-3caa-4ffe-a8e1-039297574a27" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
