### PR TITLE
feat(ui): update rental setup text in examiner details page

### DIFF
--- a/strr-examiner-web/i18n/locales/en-CA.ts
+++ b/strr-examiner-web/i18n/locales/en-CA.ts
@@ -630,9 +630,9 @@ export default {
     ANOTHER_UNIT: 'Not same property as host’s principal residence'
   },
   rentalUnitSetupOption: {
-    DIFFERENT_PROPERTY: 'Short-term renting a unit on a property you don\'t live at',
-    SEPARATE_UNIT_SAME_PROPERTY: 'Short-term renting a separate unit on the property where you live',
-    PRIMARY_RESIDENCE_OR_SHARED_SPACE: 'Short-term renting or sharing the space you live in'
+    DIFFERENT_PROPERTY: 'Option 1: Renting a unit on a property you don\'t live at',
+    SEPARATE_UNIT_SAME_PROPERTY: 'Option 2: Renting a separate unit on the property where you live',
+    PRIMARY_RESIDENCE_OR_SHARED_SPACE: 'Option 3: Renting or sharing the space you live in'
   },
   rentalUnitSetupType: {
     WHOLE_PRINCIPAL_RESIDENCE: "This unit is the host's principal residence", // The whole Host Principal Residence

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/32360

*Description of changes:*
- update rental setup text in examiner details page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
