### PR TITLE
fix: update missed tests in conftest change. bump version

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.6"
+version = "0.3.7"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2416,7 +2416,7 @@ def test_search_registrations_requirement_with_sorting(app, session, client, jwt
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
-def test_search_registrations_with_approval_method_noc_status_set_aside_filters(session, client, jwt):
+def test_search_registrations_with_approval_method_noc_status_set_aside_filters(app, session, client, jwt):
     """Test search registrations with approvalMethod, nocStatus, and isSetAside filters."""
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
         json_data = json.load(f)


### PR DESCRIPTION
*Issue:* bcgov/entity#32435b

*Description of changes:*
- update failing test to account for conftest changes.
- bump version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
