### PR TITLE
fix(ui): hotfix to show old setup for status filters in old examiner dashboard

### DIFF
--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -577,13 +577,7 @@ function handleColumnSort (column: string) {
   }
 }
 
-// Limit status options to the active table to prevent mixed-status filters.
-const applicationStatusOptions: {
-  label: string,
-  value: any,
-  disabled?: boolean,
-  childStatuses?: any[]
-}[] = [
+const splitDashboardApplicationStatusFilters = [
   {
     label: 'Open',
     value: 'OPEN',
@@ -608,6 +602,35 @@ const applicationStatusOptions: {
   { label: 'Payment Due', value: ApplicationStatus.PAYMENT_DUE },
   { label: 'Draft', value: ApplicationStatus.DRAFT }
 ]
+
+const legacyApplicationStatusFilters = [
+  { label: 'Application Status', value: undefined, disabled: true },
+  { label: 'Full Review', value: ApplicationStatus.FULL_REVIEW },
+  { label: 'Provisional Review', value: ApplicationStatus.PROVISIONAL_REVIEW },
+  { label: 'Payment Due', value: ApplicationStatus.PAYMENT_DUE },
+  { label: 'Provisional', value: ApplicationStatus.PROVISIONAL },
+  { label: 'Paid', value: ApplicationStatus.PAID },
+  { label: 'Additional Info Requested', value: ApplicationStatus.ADDITIONAL_INFO_REQUESTED },
+  { label: 'Provisionally Approved', value: ApplicationStatus.PROVISIONALLY_APPROVED },
+  { label: 'Declined', value: ApplicationStatus.DECLINED },
+  { label: 'Provisionally Declined', value: ApplicationStatus.PROVISIONALLY_DECLINED },
+  { label: 'Auto Approved', value: ApplicationStatus.AUTO_APPROVED },
+  { label: 'Full Review Approved', value: ApplicationStatus.FULL_REVIEW_APPROVED },
+  { label: 'NOC - Pending', value: ApplicationStatus.NOC_PENDING },
+  { label: 'NOC - Expired', value: ApplicationStatus.NOC_EXPIRED },
+  { label: 'NOC - Pending - Provisional', value: ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING },
+  { label: 'NOC - Expired - Provisional', value: ApplicationStatus.PROVISIONAL_REVIEW_NOC_EXPIRED }
+]
+
+// Limit status options to the active table to prevent mixed-status filters.
+const applicationStatusOptions: {
+  label: string,
+  value: any,
+  disabled?: boolean,
+  childStatuses?: any[]
+}[] = isSplitDashboardTableEnabled.value
+  ? splitDashboardApplicationStatusFilters
+  : legacyApplicationStatusFilters
 
 const registrationStatusOptions: { label: string; value: any; disabled?: boolean }[] = [
   { label: 'Status', value: undefined, disabled: true },


### PR DESCRIPTION
*Issue:*

- bcgov/entity/issues/32640

*Description of changes:*
- hotfix to show old setup for status filters in old examiner dashboard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
