### PR TITLE
fix: fixed newest api code that was causing jobs to fail

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.7"
+version = "0.3.8"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/services/auth_service.py
+++ b/strr-api/src/strr_api/services/auth_service.py
@@ -59,15 +59,12 @@ class AuthService:
     ):
         """Get service account client token for cross api calls."""
 
-        if not [
-            client_id,
-            client_secret,
-            token_url,
-            timeout,
-        ]:
+        # Load from config when any required arg is missing (empty list is falsy; [None, None, ...] is truthy)
+        if not all([client_id, client_secret, token_url]):
             client_id = current_app.config.get("STRR_SERVICE_ACCOUNT_CLIENT_ID")
             client_secret = current_app.config.get("STRR_SERVICE_ACCOUNT_SECRET")
             token_url = current_app.config.get("KEYCLOAK_AUTH_TOKEN_URL")
+        if timeout is None:
             timeout = int(current_app.config.get("AUTH_SVC_TIMEOUT", 20))
 
         data = "grant_type=client_credentials"


### PR DESCRIPTION
*Issue:*

- bcgov/STRR#1154

*Description of changes:*
- This was causing the jobs to fail!

After trying and trying, I managed to run the job locally!
I made my API change, installed locally:
```strr-api = {path = "../../strr-api", develop = true}```

Everything I had to do:
- Made some fixes locally to the devcontainer.json & dockerfile
- Opened a dev container
- Installed everything
- Made fixes to be able to connect to `host.docker.internal`
- Port-forwarded the dev db
- Filled in my .env file and point to dev

Before (which is what we see in the logs in GCP):
<img width="1716" height="266" alt="image" src="https://github.com/user-attachments/assets/817e8ec4-0121-447d-ab72-9bd9c7fecfe2" />

Now 😎 :
<img width="1345" height="493" alt="image" src="https://github.com/user-attachments/assets/5a56c6da-5efe-4a2c-9b06-33a7b71dc59a" />

Job now runs successfully!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
