### PR TITLE
feat(api): only show applications in applications table

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.10"
+version = "0.3.11"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -224,14 +224,14 @@ class Application(BaseModel):
                 )
             )
         if filter_criteria.applications_only:
-            # Exclude applications that have a completed registration, except renewals
-            # Include: no registration yet or renewal applications
-            query = query.filter(
-                db.or_(
-                    Application.registration_id.is_(None),
-                    Application.type == ApplicationType.RENEWAL.value,
-                )
+            # Exclude all applications that have an associated registration.
+            query = query.filter(Application.registration_id.is_(None))
+            # Also exclude when application_json has a registrationId in header (any non-null, non-empty value)
+            no_reg_in_json = db.or_(
+                Application.application_json["header"]["registrationId"].astext.is_(None),
+                Application.application_json["header"]["registrationId"].astext == "",
             )
+            query = query.filter(no_reg_in_json)
         sort_column = getattr(Application, filter_criteria.sort_by, Application.id)
         if filter_criteria.sort_order and filter_criteria.sort_order.lower() == "asc":
             query = query.order_by(sort_column.asc())

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -268,7 +268,7 @@ def get_applications():
         name: applicationsOnly
         type: boolean
         default: false
-        description: When true, exclude applications that have a completed registration (except renewals). For split dashboard applications table.
+        description: When true, exclude all applications that have an associated registration (including renewals). For split dashboard applications table.
     responses:
       200:
         description:

--- a/strr-api/tests/unit/resources/test_renewal_applications.py
+++ b/strr-api/tests/unit/resources/test_renewal_applications.py
@@ -91,15 +91,14 @@ def test_host_renewal_application_submission(session, client, jwt, request_json,
         assert application.registration_id == registration_id
         assert application.type == "renewal"
 
-        # Test applicationsOnly includes renewal applications (renewals have registration_id but are shown)
+        # Test applicationsOnly excludes renewal applications (renewals have registration_id and are hidden)
         rv = client.get(
             f"/applications?recordNumber={renewal_application_number}&applicationsOnly=true",
             headers=staff_headers,
         )
         response_json = rv.json
         assert rv.status_code == 200
-        assert len(response_json.get("applications")) == 1
-        assert response_json.get("applications")[0]["header"]["applicationNumber"] == renewal_application_number
+        assert len(response_json.get("applications")) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue:*

- bcgov/STRR#1173

*Description of changes:*
Only show applications in the applications table. ALL registrations will now show (doesn't matter if it's renewal or whatnot). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
