### PR TITLE
fix(ui): sub-status column options bug on table switch

### DIFF
--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -912,6 +912,7 @@ const tabLinks = computed(() => [
       </template>
       <UTable
         ref="tableRef"
+        :key="isApplicationTab ? 'applications-table' : 'registrations-table'"
         v-model:sort="sort"
         :columns="columnsTable"
         :rows="isApplicationTab ? applicationListResp.applications : registrationListResp.registrations"

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1089

*Description of changes:*
There was a bug were on table switch, the sub-status column selections were the same as type column selections. This fixes that.
The bug:
<img width="1022" height="441" alt="image" src="https://github.com/user-attachments/assets/1f95b4c6-1563-491f-b351-1652b873b772" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
