### PR TITLE
fix(ui): fixed strata hotel unit type not auto filled in hosts

### DIFF
--- a/strr-host-pm-web/app/components/form/DefineYourRental/UnitDetails.vue
+++ b/strr-host-pm-web/app/components/form/DefineYourRental/UnitDetails.vue
@@ -63,7 +63,7 @@ watch(() => reqStore.prRequirements.prExemptionReason, async (val) => {
     propStore.unitDetails.propertyType = PropertyType.STRATA_HOTEL
     await validateForm(unitDetailsFormRef.value, props.isComplete) // validate the form to clear the unit type errors
   }
-})
+}, { immediate: true })
 
 // watch and clear unit setup radio if one of the disabled options selected
 watch(() => propStore.unitDetails.hostType, (val) => {

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/STRR#1145

*Description of changes:*
When completing a renewal in hosts that has a strata hotel exemption, the dropdown is disabled and users can't proceed anymore. This fixes so that the watcher is actually fired on initial load and not only on change which is the case for renewals. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
