### PR TITLE
fix(host-pm-web): clear CRA tax number field error when exempt is checked

### DIFF
--- a/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
+++ b/strr-host-pm-web/app/components/form/AddOwners/input/Person.vue
@@ -37,7 +37,10 @@ const isRenewalEditActive = computed((): boolean => (activeOwnerEditIndex.value 
 watch(
   () => isCraNumberOptional.value,
   (val) => {
-    if (val) { owner.value.taxNumber = '' }
+    if (val) {
+      owner.value.taxNumber = ''
+      ownerFormRef.value?.clear('taxNumber')
+    }
   }
 )
 

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/strr#1095

*Description of changes:*

- When "This individual does not have a CRA Tax Number" is checked, clear the owner form's `taxNumber` field error state via `ownerFormRef.clear('taxNumber')`, so the CRA input no longer stays in error state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
