### PR TITLE
fix(ui): fix broken status filters in the old dashboard

### DIFF
--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -219,15 +219,15 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
         regStatus.push(status)
         return false
       }
-      if (approvalMethodStatuses.has(status)) {
-        approvalMethods.push(status)
-        return false
+      if (isSplitDashboardTableEnabled.value) {
+        if (approvalMethodStatuses.has(status)) {
+          approvalMethods.push(status)
+        }
+        if (NOC_ATTR.has(status)) {
+          nocStatuses.push(status)
+        }
       }
-      if (NOC_ATTR.has(status)) {
-        nocStatuses.push(status)
-        return false
-      }
-      if (status === SET_ASIDE_ATTR) {
+      if (isSplitDashboardTableEnabled.value && status === SET_ASIDE_ATTR) {
         isSetAside = true
         return false
       }

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",

--- a/strr-examiner-web/tests/unit/store-examiner.spec.ts
+++ b/strr-examiner-web/tests/unit/store-examiner.spec.ts
@@ -12,6 +12,16 @@ import {
 } from '../mocks/mockedData'
 import { ApplicationStatus, RegistrationStatus } from '#imports'
 
+const { getSplitDashboardEnabled, setSplitDashboardEnabled } = vi.hoisted(() => {
+  let splitDashboardEnabled = false
+  return {
+    getSplitDashboardEnabled: () => splitDashboardEnabled,
+    setSplitDashboardEnabled: (value: boolean) => {
+      splitDashboardEnabled = value
+    }
+  }
+})
+
 // mock $strrApi accessed through useNuxtApp()
 const mockStrrApi = vi.fn().mockResolvedValue({})
 
@@ -33,11 +43,12 @@ mockNuxtImport('useStrrModals', () => () => ({
 }))
 
 vi.mock('@/composables/useExaminerFeatureFlags', () => ({
-  useExaminerFeatureFlags: () => ({ isSplitDashboardTableEnabled: ref(false) })
+  useExaminerFeatureFlags: () => ({ isSplitDashboardTableEnabled: ref(getSplitDashboardEnabled()) })
 }))
 
 describe('Store - Examiner', () => {
   beforeEach(() => {
+    setSplitDashboardEnabled(false)
     setActivePinia(createPinia())
     vi.clearAllMocks()
     mockStrrApi.mockResolvedValue({})
@@ -107,6 +118,62 @@ describe('Store - Examiner', () => {
       query: expect.objectContaining({
         status: [ApplicationStatus.FULL_REVIEW],
         registrationStatus: []
+      })
+    }))
+  })
+
+  it('should include approval and NOC statuses in application status query for old dashboard', async () => {
+    const store = useExaminerStore()
+
+    store.tableFilters.status = [
+      ApplicationStatus.PROVISIONALLY_APPROVED,
+      ApplicationStatus.AUTO_APPROVED,
+      ApplicationStatus.FULL_REVIEW_APPROVED,
+      ApplicationStatus.NOC_PENDING,
+      ApplicationStatus.NOC_EXPIRED
+    ] as any
+    await store.fetchApplications()
+
+    expect(mockStrrApi).toHaveBeenCalledWith('/applications', expect.objectContaining({
+      query: expect.objectContaining({
+        status: [
+          ApplicationStatus.PROVISIONALLY_APPROVED,
+          ApplicationStatus.AUTO_APPROVED,
+          ApplicationStatus.FULL_REVIEW_APPROVED,
+          ApplicationStatus.NOC_PENDING,
+          ApplicationStatus.NOC_EXPIRED
+        ],
+        registrationStatus: []
+      })
+    }))
+  })
+
+  it('should include NOC statuses in application status query for split dashboard', async () => {
+    setSplitDashboardEnabled(true)
+    const store = useExaminerStore()
+
+    store.tableFilters.status = [
+      ApplicationStatus.FULL_REVIEW,
+      ApplicationStatus.NOC_PENDING,
+      ApplicationStatus.NOC_EXPIRED,
+      ApplicationStatus.DECLINED,
+      ApplicationStatus.PAYMENT_DUE,
+      ApplicationStatus.DRAFT
+    ] as any
+    await store.fetchApplications()
+
+    expect(mockStrrApi).toHaveBeenCalledWith('/applications', expect.objectContaining({
+      query: expect.objectContaining({
+        status: [
+          ApplicationStatus.FULL_REVIEW,
+          ApplicationStatus.NOC_PENDING,
+          ApplicationStatus.NOC_EXPIRED,
+          ApplicationStatus.DECLINED,
+          ApplicationStatus.PAYMENT_DUE,
+          ApplicationStatus.DRAFT
+        ],
+        registrationStatus: [],
+        applicationsOnly: true
       })
     }))
   })


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1432

*Description of changes:*
In TEST right now:
<img width="1252" height="862" alt="image" src="https://github.com/user-attachments/assets/071cf254-7bc8-4a8a-b529-64291ce7a00b" />

In local:
<img width="1261" height="902" alt="image" src="https://github.com/user-attachments/assets/7e794193-36e0-43af-8618-bcafc47b155c" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
