### PR TITLE
fix(ui): add text for missing filing history events for examiner

### DIFF
--- a/strr-examiner-web/i18n/locales/en-CA.ts
+++ b/strr-examiner-web/i18n/locales/en-CA.ts
@@ -719,6 +719,7 @@ export default {
     MANUALLY_DENIED: 'Application rejected by staff',
     MORE_INFORMATION_REQUESTED: 'Additional information requested from the applicant',
     REGISTRATION_CREATED: 'Registration created',
+    REGISTRATION_RENEWED: 'Registration renewed',
     REGISTRATION_CANCELLED: 'Registration cancelled',
     CERTIFICATE_ISSUED: 'Certificate issued for the registration',
     REGISTRATION_EXPIRED: 'Registration expired',
@@ -736,7 +737,8 @@ export default {
     REGISTRATION_REINSTATED: 'Registration reinstated',
     REGISTRATION_APPROVED: 'Registration approved',
     CONDITIONS_OF_APPROVAL_UPDATED: 'Registration - Updated conditions of approval',
-    REGISTRATION_DOCUMENT_UPLOADED: 'Registration document uploaded'
+    REGISTRATION_DOCUMENT_UPLOADED: 'Registration document uploaded',
+    RENEWAL_REMINDER_SENT: 'Renewal reminder sent'
   },
   approvalConditions: {
     principalResidence: 'Principal Residence',

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "scripts": {
     "build-check": "nuxt build",
     "build": "nuxt generate",


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1137

*Description of changes:*
- Added text for two missing events 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
