### PR TITLE
fix(examiner-web): gate renewal badge on latest renewal status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,7 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .pnpm-store/**
-
+**/.pnpm-store/**
 
 # Distribution / packaging
 .eggs/

--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -294,30 +294,11 @@ const getRequirementsColumn = (app: HousApplicationResponse) => {
   return result
 }
 
-/** Application statuses that mean a renewal was completed (registration was renewed) */
-const RENEWAL_APPROVED_STATUSES = new Set<ApplicationStatus>([
-  ApplicationStatus.FULL_REVIEW_APPROVED,
-  ApplicationStatus.PROVISIONALLY_APPROVED,
-  ApplicationStatus.PROVISIONAL_REVIEW,
-  ApplicationStatus.AUTO_APPROVED
-])
-
 const REVIEW_RENEW_STATUSES = new Set<ApplicationStatus>([
   ApplicationStatus.FULL_REVIEW,
   ApplicationStatus.PROVISIONALLY_APPROVED,
   ApplicationStatus.PROVISIONAL_REVIEW
 ])
-
-/** Check if a registration has been renewed. Draft renewals are ignored (Renewals in progress). */
-const hasBeenRenewed = (reg: HousRegistrationResponse): boolean => {
-  const applications = reg.header?.applications ?? []
-  return applications.some(
-    app =>
-      app.applicationType === 'renewal' &&
-      app.applicationStatus &&
-      RENEWAL_APPROVED_STATUSES.has(app.applicationStatus as ApplicationStatus)
-  )
-}
 
 const isReviewRenew = (reg: HousRegistrationResponse): boolean => {
   const applications = reg.header?.applications ?? []
@@ -327,6 +308,31 @@ const isReviewRenew = (reg: HousRegistrationResponse): boolean => {
       app.applicationStatus &&
       REVIEW_RENEW_STATUSES.has(app.applicationStatus as ApplicationStatus)
   )
+}
+
+/**
+ * Statuses where the renewal no longer needs examiner action (badge hidden).
+ */
+const RENEWAL_BADGE_HIDDEN_STATUSES = new Set<ApplicationStatus>([
+  ApplicationStatus.FULL_REVIEW_APPROVED,
+  ApplicationStatus.DECLINED,
+  ApplicationStatus.PROVISIONALLY_DECLINED,
+  ApplicationStatus.AUTO_APPROVED
+])
+
+/**
+ * Show the "Renewal" badge when any renewal on this registration still needs examiner action.
+ */
+function shouldShowRenewalBadge (reg: HousRegistrationResponse): boolean {
+  const apps = reg.header?.applications ?? []
+  const renewals = apps.filter(a => a.applicationType === 'renewal')
+  return renewals.some((r) => {
+    const status = r.applicationStatus as ApplicationStatus | undefined
+    if (!status) {
+      return false
+    }
+    return !RENEWAL_BADGE_HIDDEN_STATUSES.has(status)
+  })
 }
 
 const getRegistrationSubStatus = (reg: HousRegistrationResponse): string => {
@@ -497,7 +503,7 @@ const { data: registrationListResp, status: regStatus } = await useAsyncData(
         propertyAddress: getPropertyAddressColumnForRegistration(reg),
         localGov: getLocalGovColumnForRegistration(reg),
         adjudicator: getAdjudicatorColumn(reg.header),
-        hasRenewed: hasBeenRenewed(reg),
+        showRenewalBadge: shouldShowRenewalBadge(reg),
         hasRecentDocumentUpload: hasRecentDocumentUpload(getDocumentsFromRegistration(reg))
       }))
 
@@ -1131,7 +1137,7 @@ const tabLinks = computed(() => [
                 <span>{{ row.registrationNumber }}</span>
               </div>
               <UBadge
-                v-if="row.hasRenewed"
+                v-if="row.showRenewalBadge"
                 :label="t('label.renewal')"
                 color="primary"
                 variant="solid"

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -9,7 +9,12 @@ import {
 } from '../mocks/mockedData'
 import { enI18n } from '../mocks/i18n'
 import Dashboard from '~/pages/dashboard.vue'
-import { ApplicationStatus, ApplicationType, PrExemptionReason, StrataHotelCategory } from '#imports'
+import {
+  ApplicationStatus,
+  ApplicationType,
+  PrExemptionReason,
+  StrataHotelCategory
+} from '#imports'
 
 const mockedResp: ApiApplicationsListResp = {
   applications: mockApplications,
@@ -23,7 +28,7 @@ const createMockStore = (initialFilters = {}) => {
   const tableFilters = reactive({
     searchText: '',
     registrationNumber: '',
-    registrationType: [],
+    registrationType: [] as ApplicationType[],
     requirements: [],
     applicantName: '',
     propertyAddress: '',
@@ -61,7 +66,7 @@ const createMockStore = (initialFilters = {}) => {
       Object.assign(tableFilters, {
         searchText: '',
         registrationNumber: '',
-        registrationType: [],
+        registrationType: [] as ApplicationType[],
         requirements: [],
         applicantName: '',
         propertyAddress: '',
@@ -573,6 +578,124 @@ describe('Examiner Dashboard Page', () => {
 
       const result = wrapper.vm.getConditionsColumnForRegistration(registration)
       expect(result).toBe('-')
+    })
+  })
+
+  describe('shouldShowRenewalBadge', () => {
+    it('returns false when there is no renewal application on the registration', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: []
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it('returns true when any renewal still needs examiner action', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(true)
+    })
+
+    it('returns true when an older renewal still needs action even if a newer renewal is decided', () => {
+      // Newest-first order matches RegistrationSerializer._populate_applications
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
+            },
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(true)
+    })
+
+    it('returns false when every renewal is in a terminal state that hides the badge', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
+            },
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.AUTO_APPROVED
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it('returns false when a renewal is in a terminal state that hides the badge', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it('returns false when the latest renewal is in PROVISIONALLY_APPROVED (badge hidden)', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it('returns false when renewal has no application status', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: undefined
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
   })
 


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/STRR/issues/1120

*Description of changes:*

- Replace the registrations table `hasRenewed` / `hasBeenRenewed` logic with `showRenewalBadge` driven by `shouldShowRenewalBadge`.
- The Renewal badge now reflects the **latest** renewal application: it shows when that renewal still needs examiner action, and is hidden for terminal outcomes (for example full review approved, declined, provisionally declined, auto approved).

#### Testing on examiner dashboard:
    1. Go to http://localhost:3000/en-CA/dashboard?tab=registrations
    2. select a registration with renewal badge on examiner dashboard.
    3. on registration page make sure all applications are approved.
    4. go back to dashboard on registrations tab. the same registration should no longer have the renewal badge.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
