### PR TITLE
docs(runbooks): add API, queue/jobs, and payments operational guides

### DIFF
--- a/docs/runbooks/payments.md
+++ b/docs/runbooks/payments.md
@@ -1,0 +1,246 @@
+# Runbook: Payments
+
+After checkout, an application reaches `PAID` via synchronous `PUT .../payment-details` and/or async handling in `strr-pay` (Pay CloudEvents). This runbook also covers BC Registries Pay API usage, `strr-db` queries, and **manual** cross-reference with **fin_warehouse** (external to this repo).
+
+**Primary code:** `strr-api/src/strr_api/services/payment_service.py`, `strr-api/src/strr_api/resources/application.py`, `queue_services/strr-pay/src/strr_pay/resources/pay_listener.py`.
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Nuxt UI
+    participant API as strr-api
+    participant Pay as Pay API
+    participant PS as Pub/Sub
+    participant Worker as strr-pay
+
+    UI->>API: Submit application (non-draft)
+    API->>Pay: POST /payment-requests
+    Pay-->>API: invoice id
+    API->>API: application invoice_id, status PAYMENT_DUE, events
+    UI->>Pay: User completes payment (hosted checkout)
+    Note over API,Worker: Path A: UI calls PUT .../payment-details
+    UI->>API: PUT /applications/{id}/payment-details
+    API->>Pay: GET /payment-requests/{id}
+    API->>API: status PAID if COMPLETED/APPROVED
+    Note over PS,Worker: Path B: async CloudEvent
+    Pay->>PS: bc.registry.payment COMPLETED
+    PS->>Worker: deliver event
+    Worker->>API: DB: Application by invoice_id
+    Worker->>API: set PAID if PAYMENT_DUE
+```
+
+## Two paths to PAID
+
+1. **Synchronous refresh:** Client calls `PUT /applications/<application_number>/payment-details`. The API fetches the latest invoice from Pay API and runs `ApplicationService.update_application_payment_details_and_status`.
+2. **Async:** `strr-pay` worker consumes CloudEvents (`ce.type == bc.registry.payment`, `status_code == COMPLETED`), finds `Application` by `invoice_id`, and if status is `PAYMENT_DUE`, sets `PAID` and `payment_completion_date`.
+
+**Worker retry:** If no application row exists yet, worker may return **404** so Pub/Sub can retry (see `pay_listener.py`).
+
+## Pay API usage (API side)
+
+| Action          | HTTP                                                                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Create invoice  | `POST {PAYMENT_SVC_URL}/payment-requests` with `Authorization` (user JWT), `Account-Id`, body includes `businessInfo.corpType: "STRR"` and filing info |
+| Refresh invoice | `GET {PAYMENT_SVC_URL}/payment-requests/{invoice_id}`                                                                                                  |
+| Receipt PDF     | `POST {PAYMENT_SVC_URL}/payment-requests/{invoice_id}/receipts` with `Accept: application/pdf`                                                         |
+
+**Config:** `PAYMENT_SVC_URL` = `PAY_API_URL` + `PAY_API_VERSION` in `strr-api/src/strr_api/config.py`.
+
+## STRR database (payment fields)
+
+Table `**application`** (see `strr-api/src/strr_api/models/application.py`):
+
+| Column                    | Meaning                                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| `invoice_id`              | Pay API payment-request id                                                                      |
+| `payment_status_code`     | String (aligns with pay statuses such as CREATED, COMPLETED; see `PaymentStatus` enum in code) |
+| `payment_completion_date` | When payment completed                                                                          |
+| `payment_account`         | Account id context (string)                                                                     |
+
+**Events:** `INVOICE_GENERATED`, `PAYMENT_COMPLETE`, `APPLICATION_SUBMITTED` in `events` table (`event_name`).
+
+**Note:** There is no separate `invoices` table; reconciliation keys off `**invoice_id`** on `application`.
+
+## Payment states (reference)
+
+Enum `PaymentStatus` in `strr-api/src/strr_api/enums/enum.py` includes e.g. `CREATED`, `COMPLETED`, `PAID`, `APPROVED`, `FAILED`, `REFUNDED`. **Refunds** are not implemented as an automated workflow in STRR. Treat `REFUNDED` as operational/manual via Pay API.
+
+## Receipts
+
+- Route: `GET /applications/<application_number>/payment/receipt` (PDF from Pay API).
+- Blocked if application status is in unpaid states (`APPLICATION_UNPAID_STATES`, including `DRAFT`, `PAYMENT_DUE`).
+
+## GCP Cloud Logging queries
+
+**Note:** Queries below are pinned to **prod** service names (`*-prod`). For other environments, replace `-prod` with the appropriate suffix (for example `-test` or `-dev`).
+
+**Invoice creation failures (strr-api):**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api-prod"
+textPayload=~"(Pay-api integration|Invalid response from pay-api|create invoice)"
+```
+
+**Payment completion (strr-pay):**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-pay-prod"
+jsonPayload.message=~"Processing payment"
+```
+
+**strr-pay 404 (retries):**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-pay-prod"
+httpRequest.status=404
+```
+
+**strr-pay errors:**
+
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-pay-prod"
+severity="ERROR"
+```
+
+**Receipt failures:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api-prod"
+textPayload=~"Failed to get receipt pdf for filing"
+```
+
+**Trace by invoice id (API + worker):**
+
+```text
+resource.type="cloud_run_revision"
+(resource.labels.service_name="strr-api-prod" OR resource.labels.service_name="strr-pay-prod")
+textPayload=~"<INVOICE_ID>" OR jsonPayload.message=~"<INVOICE_ID>"
+```
+
+## SQL: STRR (strr-db)
+
+**Full payment state:**
+
+```sql
+SELECT a.application_number, a.type, a.registration_type, a.status,
+       a.invoice_id, a.payment_status_code, a.payment_completion_date,
+       a.payment_account, a.application_date, a.decision_date
+FROM application a
+WHERE a.application_number = '<APP_NUMBER>';
+```
+
+**By invoice_id (to cross-reference with fin_warehouse):**
+
+```sql
+SELECT a.application_number, a.type, a.registration_type, a.status,
+       a.invoice_id, a.payment_status_code, a.payment_completion_date,
+       a.payment_account, a.application_date
+FROM application a
+WHERE a.invoice_id = <INVOICE_ID>;
+```
+
+**Payment event timeline:**
+
+```sql
+SELECT e.event_name, e.details, e.created_date, u.username
+FROM events e
+LEFT JOIN users u ON e.user_id = u.id
+WHERE e.application_id = (SELECT id FROM application WHERE application_number = '<APP_NUMBER>')
+  AND e.event_name IN ('INVOICE_GENERATED', 'PAYMENT_COMPLETE', 'APPLICATION_SUBMITTED')
+ORDER BY e.created_date;
+```
+
+**PAYMENT_DUE with invoice set:**
+
+```sql
+SELECT application_number, invoice_id, payment_status_code,
+       payment_account, application_date, modified
+FROM application
+WHERE status = 'PAYMENT_DUE'
+  AND invoice_id IS NOT NULL
+ORDER BY application_date DESC;
+```
+
+**PAID but no registration (possible downstream failure):**
+
+```sql
+SELECT a.application_number, a.invoice_id, a.payment_status_code,
+       a.payment_completion_date, a.status, a.registration_id
+FROM application a
+WHERE a.status = 'PAID'
+  AND a.registration_id IS NULL
+  AND a.payment_completion_date < NOW() - INTERVAL '2 hours'
+ORDER BY a.payment_completion_date;
+```
+
+**Summary counts:**
+
+```sql
+SELECT payment_status_code, status, COUNT(*) AS cnt
+FROM application
+WHERE payment_status_code IS NOT NULL
+GROUP BY payment_status_code, status
+ORDER BY cnt DESC;
+```
+
+**By SBC account:**
+
+```sql
+SELECT application_number, type, status, invoice_id,
+       payment_status_code, payment_completion_date, application_date
+FROM application
+WHERE payment_account = '<SBC_ACCOUNT_ID>'
+ORDER BY application_date DESC;
+```
+
+**Cross-reference row for fin_warehouse / Pay API:**
+
+```sql
+SELECT a.application_number, a.invoice_id, a.payment_status_code,
+       a.payment_completion_date, a.payment_account,
+       a.status AS app_status, a.type AS app_type,
+       r.registration_number, r.status AS reg_status
+FROM application a
+LEFT JOIN registrations r ON a.registration_id = r.id
+WHERE a.invoice_id = <INVOICE_ID>;
+```
+
+**To match all invoices in strr with invoices in pay**:
+
+```sql
+SELECT a.application_number, a.invoice_id, i.id, a.payment_status_code,
+       a.payment_completion_date, a.payment_account
+FROM strr.application a
+LEFT JOIN strr.registrations r ON a.registration_id = r.id
+left join pay.invoices i on i.id = a.invoice_id;
+```
+
+**Recent payments to audit (last 7 days):**
+
+```sql
+SELECT a.application_number, a.invoice_id, a.payment_status_code,
+       a.payment_completion_date, a.payment_account, a.status
+FROM application a
+WHERE a.payment_status_code IS NOT NULL
+  AND a.payment_completion_date >= NOW() - INTERVAL '7 days'
+ORDER BY a.payment_completion_date DESC;
+```
+
+## fin_warehouse (external database)
+
+`fin_warehouse` DB is found in `Data Warehouse 'Prod' (mvnjri-prod) project`. Use it for financial reconciliation, audits, and cross-checking Pay API settlement data.
+
+### Reconciliation scenarios
+
+| Scenario                          | STRR                                              | fin_warehouse       | Action                                                                                                                                                                                    |
+| --------------------------------- | ------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Paid in finance but stuck in STRR | `status=PAYMENT_DUE`, `invoice_id` set            | Completed / settled | Worker may have missed event. Confirm Pay API `GET /payment-requests/{id}`. If paid, coordinate **manual** DB update with governance; then ensure auto-approval/job expectations are met. |
+| Duplicate invoices                | Same `application_number`, different `invoice_id` | Multiple rows       | Identify paid invoice in Pay API; void or adjust others per Pay API process                                                                                                               |
+| Refund                            | `payment_status_code` still COMPLETED             | `refund_amount > 0` | No automated refund in STRR; Pay API admin; update STRR payment fields if policy requires                                                                                                 |
+| Missing in warehouse              | `invoice_id` in STRR                              | No row              | Payment may not have completed; verify Pay API first                                                                                                                                      |

--- a/docs/runbooks/queue-services-and-jobs.md
+++ b/docs/runbooks/queue-services-and-jobs.md
@@ -1,0 +1,219 @@
+# Runbook: Queue Services and Jobs
+
+Pub/Sub-backed workers (`strr-pay`, `strr-email`, `batch-permit-validator` listener) and scheduled or batch Cloud Run Jobs under `jobs/`.
+
+## Queue services (Cloud Run + Pub/Sub)
+
+### strr-pay
+
+- **Role:** HTTP worker consuming payment CloudEvents; on `bc.registry.payment` with `status_code == COMPLETED`, loads `Application` by `invoice_id` and if status is `PAYMENT_DUE`, sets `PAID`, `payment_completion_date`, `payment_status_code`.
+- **Retries:** Returns **404** when application not found so the message can be retried (ordering race).
+- **Code:** `queue_services/strr-pay/src/strr_pay/resources/pay_listener.py`
+- **Logging:** JSON structlog via `structured-logging` (sbc-connect-common), with fields such as `message`, `severity`.
+
+### strr-email
+
+- **Role:** Consumes queue messages, posts to Notify API for email delivery.
+- **Config:** `GCP_EMAIL_TOPIC`. If unset, publisher may skip with an info log (`gcp_queue_publisher` pattern in API).
+- **Code:** `queue_services/strr-email/src/strr_email/resources/email_listener.py`
+
+### batch-permit-validator (listener)
+
+- **Role:** Batch / permit validation listener (see `queue_services/batch-permit-validator/README.md`).
+- **Note:** A job variant also exists under `jobs/batch-permit-validator/`. Do not confuse deployables.
+
+## Jobs (repo folders)
+
+Typical jobs in `jobs/`:
+
+| Job (folder) | Purpose (high level) |
+|--------------|---------------------|
+| `auto-approval` | Processes `PAID` applications past delay; calls `ApprovalService.process_auto_approval` |
+| `provisional-approval` | Provisional approval path |
+| `registration_expiry` | Expires registrations |
+| `renewal-reminders` | Sends renewal reminders |
+| `noc_expiry` | NOC expiry processing |
+| `interactions-update` | Customer interaction sync |
+| `strr-backfiller` | Backfill utility |
+| `batch-permit-validator` | Batch permit validation job |
+
+**Deployment:** Cloud Run **Jobs** via `backend-job-cd.yaml` pattern from `bcregistry-sre`.
+
+**Common failures:**
+
+- **DB pool timeouts:** e.g. `interactions-update` (long-running DB work)
+- **Batch timeouts:** e.g. batch-permit-validator Cloud Run Job timeout (check `clouddeploy.yaml` / job template - historically long timeouts like 45 minutes mentioned in design docs)
+
+## Log diving: queue services
+
+strr-pay / strr-email use **JSON** logs (`jsonPayload.message`, `jsonPayload.severity`) when ingested as structured JSON.
+
+**Note:** Queries below are pinned to **prod** service names (`*-prod`). For other environments, replace `-prod` with the appropriate suffix (for example `-test` or `-dev`).
+
+### strr-pay
+
+**Event pipeline:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-pay-prod"
+jsonPayload.message=~"(Incoming raw msg|received ce|Processing payment|completed ce)"
+```
+
+**Errors:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-pay-prod"
+severity="ERROR"
+```
+
+### strr-email
+
+**Notify failures:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-email-prod"
+jsonPayload.message=~"Error posting email to notify-api"
+```
+
+**Activity:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-email-prod"
+jsonPayload.message=~"(completed ce|Error)"
+```
+
+## Log diving: Cloud Run Jobs
+
+**Resource type:** `cloud_run_job` (verify in your project; filters differ from `cloud_run_revision`).
+
+**Auto-approval errors (plain text logger in job):**
+
+```text
+resource.type="cloud_run_job"
+resource.labels.job_name="strr-auto-approval-prod"
+textPayload=~" - ERROR in "
+```
+
+**Auto-approval verbose:**
+
+```text
+resource.type="cloud_run_job"
+resource.labels.job_name="strr-auto-approval-prod"
+severity>="INFO"
+```
+
+**batch-permit-validator (job) errors:**
+
+```text
+resource.type="cloud_run_job"
+resource.labels.job_name="batch-permit-job-prod"
+severity="ERROR"
+```
+
+**registration_expiry:**
+
+```text
+resource.type="cloud_run_job"
+resource.labels.job_name="strr-registration-expiry-prod"
+severity>="INFO"
+```
+
+**noc_expiry:**
+
+```text
+resource.type="cloud_run_job"
+resource.labels.job_name="strr-noc-expiry-prod"
+severity>="INFO"
+```
+
+**Note:** Exact **`job_name`** labels in GCP must match your Cloud Run Job resource names. Adjust filters accordingly.
+
+## SQL: queue / job investigation
+
+**PAID applications (auto-approval backlog):**
+
+```sql
+SELECT a.application_number, a.status, a.payment_completion_date,
+       a.invoice_id, a.type, a.registration_type
+FROM application a
+WHERE a.status = 'PAID'
+  AND a.payment_completion_date < NOW() - INTERVAL '30 minutes'
+ORDER BY a.payment_completion_date;
+```
+
+**Recent auto-approval records:**
+
+```sql
+SELECT a.application_number, a.status, aar.record->>'suggestedAction' AS suggested_action,
+       aar.creation_date AS approval_check_date, a.decision_date
+FROM auto_approval_records aar
+JOIN application a ON aar.application_id = a.id
+WHERE aar.creation_date >= NOW() - INTERVAL '24 hours'
+ORDER BY aar.creation_date DESC;
+```
+
+**Registrations expiring soon (for expiry job validation):**
+
+```sql
+SELECT r.registration_number, r.registration_type, r.status,
+       r.expiry_date, r.start_date, u.username AS owner
+FROM registrations r
+JOIN users u ON r.user_id = u.id
+WHERE r.status = 'ACTIVE'
+  AND r.expiry_date <= NOW() + INTERVAL '30 days'
+ORDER BY r.expiry_date;
+```
+
+**NOC on registration (registration NOC):**
+
+```sql
+SELECT r.registration_number, r.noc_status, noc.start_date, noc.end_date,
+       a.application_number, a.status AS app_status
+FROM registrations r
+JOIN registration_notice_of_consideration noc ON noc.registration_id = r.id
+LEFT JOIN application a ON a.registration_id = r.id
+WHERE r.noc_status = 'NOC_PENDING'
+ORDER BY noc.end_date;
+```
+
+**Application-level NOC:**
+
+```sql
+SELECT a.application_number, a.status, noc.start_date, noc.end_date, noc.content
+FROM application a
+JOIN notice_of_consideration noc ON noc.application_id = a.id
+WHERE a.status IN ('NOC_PENDING', 'PROVISIONAL_REVIEW_NOC_PENDING')
+ORDER BY noc.end_date;
+```
+
+**Interactions (notify/email), last 24h:**
+
+```sql
+SELECT i.interaction_uuid, i.channel, i.status, i.created_at,
+       i.notify_reference, i.provider_reference,
+       a.application_number, r.registration_number
+FROM interactions i
+LEFT JOIN application a ON i.application_id = a.id
+LEFT JOIN registrations r ON i.registration_id = r.id
+WHERE i.created_at >= NOW() - INTERVAL '24 hours'
+ORDER BY i.created_at DESC;
+```
+
+**Failed / non-SENT interactions (7 days):**
+
+```sql
+SELECT i.interaction_uuid, i.channel, i.status, i.created_at,
+       i.meta_data, i.body_content,
+       a.application_number, r.registration_number
+FROM interactions i
+LEFT JOIN application a ON i.application_id = a.id
+LEFT JOIN registrations r ON i.registration_id = r.id
+WHERE i.status != 'SENT'
+  AND i.created_at >= NOW() - INTERVAL '7 days'
+ORDER BY i.created_at DESC;
+```
+

--- a/docs/runbooks/strr-api.md
+++ b/docs/runbooks/strr-api.md
@@ -1,0 +1,166 @@
+# Runbook: strr-api
+
+Flask backend for STRR. Source: `strr-api/`.
+
+## Health checks
+
+| Endpoint | Behavior |
+|----------|----------|
+| `GET /ops/healthz` | Runs `SELECT 1` against the database. Returns **500** if DB is unavailable. |
+| `GET /ops/readyz` | Always **200**; it does **not** verify the database or downstream dependencies. |
+
+**Operational note:** If Kubernetes/Cloud Run readiness uses only `readyz`, pods may be marked ready while the DB is down. Prefer `healthz` for meaningful liveness when troubleshooting.
+
+**Code reference:** `strr-api/src/strr_api/resources/ops.py`
+
+## Configuration
+
+- Primary config: `strr-api/src/strr_api/config.py`
+- **URL pair pattern:** Many services are built from `*_URL` + `*_VERSION` (e.g. `AUTH_SVC_URL`, `PAYMENT_SVC_URL`, `LEGAL_SVC_URL`). Omitting either yields wrong or empty endpoints.
+- Vault mapping (GCP): `strr-api/devops/vaults.gcp.env`
+- Local sample: `strr-api/.env.sample`
+
+### External service timeouts (typical)
+
+| Setting | Notes |
+|---------|--------|
+| `PAY_API_TIMEOUT` | Default 20s |
+| `AUTH_SVC_TIMEOUT` | Default 20s |
+| `LTSA_API_TIMEOUT` | Per config |
+| `GEOCODER_API_TIMEOUT` | Per config |
+| `CONNECT_TIMEOUT` | 60s in `rest_service` |
+
+## Error handling
+
+- Global handlers: `strr-api/src/strr_api/common/error.py`; JSON `{"message": "..."}`.
+- Custom exceptions: `strr-api/src/strr_api/exceptions/exceptions.py` (`ValidationException`, `AuthException`, `ExternalServiceException` → often **502**, etc.).
+- API error text enum: `ErrorMessage` in `strr-api/src/strr_api/enums/enum.py`.
+
+## Database migrations
+
+- Alembic revisions: `strr-api/migrations/versions/`
+- When `POD_NAMESPACE == "migration"`, the app factory registers **only** Flask-Migrate (no normal HTTP routes) (`strr-api/src/strr_api/__init__.py`).
+- **Driver note:** Migrations may use `postgresql+pg8000` while runtime uses `postgresql`/psycopg2. See `config.py` and `migrations/env.py`.
+- Standalone Alembic (no Flask context) uses `DATABASE_URL` with `NullPool` in `migrations/env.py`.
+
+## Scaling (prod)
+
+From `strr-api/devops/gcp/clouddeploy.yaml` (typical): prod may set **`max-scale: "10"`** and **`container-concurrency: "20"`**. Confirm in the current file for your environment.
+
+## Logging
+
+- **Format:** Plain text (`%(asctime)s - %(name)s - %(levelname)s in %(module)s:%(filename)s:%(lineno)d - %(funcName)s: %(message)s`)
+- **Logger names:** `api`, `strr_api` (Flask app logger)
+- **No application correlation/request IDs** in code. Use Cloud Run request logs and timestamps for correlation.
+
+### GCP Cloud Logging: strr-api
+
+**All API errors:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api"
+textPayload=~" - ERROR in "
+```
+
+**500 / uncaught exceptions:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api"
+textPayload=~"Uncaught exception"
+```
+
+**DB connection failures during health check (/ops/healthz):**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api"
+textPayload=~"(DB connection failed|DB connection pool unhealthy)"
+severity="ERROR"
+```
+
+**External service timeouts (Pay API, Auth, LTSA, Geocoder):**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api"
+textPayload=~"(ConnectionError|ConnectTimeout|ReadTimeout|ExternalServiceException)"
+```
+
+**Migration pod logs:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-api"
+textPayload=~"(alembic|migration|upgrade)"
+```
+
+Adjust `resource.labels.service_name` if your Cloud Run service name differs.
+
+## SQL: general investigation (strr-db)
+
+**Application by application number:**
+
+```sql
+SELECT id, application_number, type, registration_type, status,
+       invoice_id, payment_status_code, payment_completion_date, payment_account,
+       registration_id, application_date, decision_date, is_set_aside,
+       submitter_id, reviewer_id, created, modified
+FROM application
+WHERE application_number = '<APP_NUMBER>';
+```
+
+**Recent events for an application:**
+
+```sql
+SELECT e.id, e.event_type, e.event_name, e.details,
+       e.created_date, e.visible_to_applicant,
+       u.username AS event_user
+FROM events e
+LEFT JOIN users u ON e.user_id = u.id
+WHERE e.application_id = (SELECT id FROM application WHERE application_number = '<APP_NUMBER>')
+ORDER BY e.created_date DESC;
+```
+
+**Registration by registration number:**
+
+```sql
+SELECT r.id, r.registration_number, r.registration_type, r.status,
+       r.start_date, r.expiry_date, r.noc_status, r.sbc_account_id,
+       r.cancelled_date, r.provisional_extension_applied,
+       u.username AS owner, rv.username AS reviewer
+FROM registrations r
+LEFT JOIN users u ON r.user_id = u.id
+LEFT JOIN users rv ON r.reviewer_id = rv.id
+WHERE r.registration_number = '<REG_NUMBER>';
+```
+
+**Stuck in PAYMENT_DUE > 24h:**
+
+```sql
+SELECT application_number, invoice_id, payment_status_code,
+       application_date, created, modified
+FROM application
+WHERE status = 'PAYMENT_DUE'
+  AND application_date < NOW() - INTERVAL '24 hours'
+ORDER BY application_date;
+```
+
+**Auto-approval records:**
+
+```sql
+SELECT aar.id, aar.record, aar.creation_date
+FROM auto_approval_records aar
+JOIN application a ON aar.application_id = a.id
+WHERE a.application_number = '<APP_NUMBER>';
+```
+
+**LTSA records:**
+
+```sql
+SELECT l.id, l.record, l.creation_date
+FROM ltsa l
+JOIN application a ON l.application_id = a.id
+WHERE a.application_number = '<APP_NUMBER>';
+```

--- a/strr-examiner-web/.gitignore
+++ b/strr-examiner-web/.gitignore
@@ -133,6 +133,7 @@ out
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+.pnpm-store
 
 .DS_Store
 


### PR DESCRIPTION
*Issue:*

- bcgov/STRR/issues/1442

*Description of changes:*

- Add runbook documentation for `strr-api` operations, including health endpoints, configuration pitfalls, auth/role handling, common startup failures, and production troubleshooting guidance.
- Add runbook documentation for queue services and Cloud Run jobs, covering `strr-pay`, `strr-email`, permit validation listeners, trigger flows, logs, retries, and diagnostics.
- Add a payments runbook describing end-to-end payment flow, API touchpoints, status transitions, reconciliation pointers, and triage steps for failed/missing updates.
- Update ignore rules for examiner web generated artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
