### PR TITLE
chore(strr-examiner-web): bump version to 0.2.34

### DIFF
--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -666,22 +666,6 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
 
-    it('returns false when the latest renewal is in PROVISIONALLY_APPROVED (badge hidden)', () => {
-      const reg = {
-        ...mockHostRegistration,
-        header: {
-          ...mockHostRegistration.header,
-          applications: [
-            {
-              applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
-            }
-          ]
-        }
-      }
-      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
-    })
-
     it('returns false when renewal has no application status', () => {
       const reg = {
         ...mockHostRegistration,


### PR DESCRIPTION
*Issue:*

- https://github.com/bcgov/STRR/issues/1120

*Description of changes:*

- **Release:** Bump `strr-examiner-web` package version to **0.2.34** for this change. This was missed in the previous PR.

Related PR: https://github.com/bcgov/STRR/pull/1472

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
