### PR TITLE
fix(examiner-web): show renewal badge only for latest provisional renewals

### DIFF
--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -265,8 +265,12 @@ const getRegistrationNocStatusDisplay = (nocStatus: RegistrationNocStatus | unde
   return t(`registrationNocStatus.${nocStatus}`)
 }
 
+/** Newest application first (matches API RegistrationSerializer application_date desc). */
+const getLatestRegistrationApplication = (reg: HousRegistrationResponse) =>
+  reg.header?.applications?.[0]
+
 const getLatestRegistrationApplicationStatus = (reg: HousRegistrationResponse): ApplicationStatus | undefined => {
-  return reg.header?.applications?.[0]?.applicationStatus as ApplicationStatus | undefined
+  return getLatestRegistrationApplication(reg)?.applicationStatus as ApplicationStatus | undefined
 }
 
 const getRequirementsColumn = (app: HousApplicationResponse) => {
@@ -309,28 +313,18 @@ const isReviewRenew = (reg: HousRegistrationResponse): boolean => {
 }
 
 /**
- * Statuses where the renewal no longer needs examiner action (badge hidden).
+ * Show the "Renewal" badge when the latest application is a provisionally approved renewal
+ * and no registration-level decision has been recorded yet.
  */
-const RENEWAL_BADGE_HIDDEN_STATUSES = new Set<ApplicationStatus>([
-  ApplicationStatus.FULL_REVIEW_APPROVED,
-  ApplicationStatus.DECLINED,
-  ApplicationStatus.PROVISIONALLY_DECLINED,
-  ApplicationStatus.AUTO_APPROVED
-])
-
-/**
- * Show the "Renewal" badge when any renewal on this registration still needs examiner action.
- */
-function shouldShowRenewalBadge (reg: HousRegistrationResponse): boolean {
-  const apps = reg.header?.applications ?? []
-  const renewals = apps.filter(a => a.applicationType === 'renewal')
-  return renewals.some((r) => {
-    const status = r.applicationStatus as ApplicationStatus | undefined
-    if (!status) {
-      return false
-    }
-    return !RENEWAL_BADGE_HIDDEN_STATUSES.has(status)
-  })
+const shouldShowRenewalBadge = (reg: HousRegistrationResponse): boolean => {
+  const latest = getLatestRegistrationApplication(reg)
+  if (!latest || latest.applicationType !== 'renewal') {
+    return false
+  }
+  if (latest.applicationStatus !== ApplicationStatus.PROVISIONALLY_APPROVED) {
+    return false
+  }
+  return !reg.header?.decider?.username
 }
 
 const getRegistrationSubStatus = (reg: HousRegistrationResponse): string => {

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -582,26 +582,89 @@ describe('Examiner Dashboard Page', () => {
   })
 
   describe('shouldShowRenewalBadge', () => {
-    it('returns false when there is no renewal application on the registration', () => {
+    const headerBase = {
+      ...mockHostRegistration.header,
+      decider: {} as { username?: string },
+      applications: [] as { applicationType?: string, applicationStatus?: ApplicationStatus }[]
+    }
+
+    it('returns false when there are no applications', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
-          ...mockHostRegistration.header,
+          ...headerBase,
           applications: []
         }
       }
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
 
-    it('returns true when any renewal still needs examiner action', () => {
+    it('returns false when the latest application is not a renewal', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
-          ...mockHostRegistration.header,
+          ...headerBase,
+          applications: [
+            {
+              applicationType: 'host',
+              applicationStatus: ApplicationStatus.FULL_REVIEW
+            },
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it.each([
+      { status: ApplicationStatus.FULL_REVIEW, label: 'full review' },
+      { status: ApplicationStatus.PROVISIONAL_REVIEW, label: 'provisional review' },
+      { status: undefined, label: 'missing status' }
+    ])('returns false when latest renewal is not provisionally approved ($label)', ({ status }) => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...headerBase,
           applications: [
             {
               applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.FULL_REVIEW
+              applicationStatus: status
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it('returns false when provisionally approved renewal but registration has a decider', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...headerBase,
+          decider: { username: 'examiner' },
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+    it('returns true when latest is provisionally approved renewal and no registration decider', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...headerBase,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
             }
           ]
         }
@@ -609,12 +672,12 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(true)
     })
 
-    it('returns true when an older renewal still needs action even if a newer renewal is decided', () => {
+    it('returns false when an older renewal is provisionally approved but latest app is decided renewal', () => {
       // Newest-first order matches RegistrationSerializer._populate_applications
       const reg = {
         ...mockHostRegistration,
         header: {
-          ...mockHostRegistration.header,
+          ...headerBase,
           applications: [
             {
               applicationType: 'renewal',
@@ -622,59 +685,7 @@ describe('Examiner Dashboard Page', () => {
             },
             {
               applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.FULL_REVIEW
-            }
-          ]
-        }
-      }
-      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(true)
-    })
-
-    it('returns false when every renewal is in a terminal state that hides the badge', () => {
-      const reg = {
-        ...mockHostRegistration,
-        header: {
-          ...mockHostRegistration.header,
-          applications: [
-            {
-              applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
-            },
-            {
-              applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.AUTO_APPROVED
-            }
-          ]
-        }
-      }
-      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
-    })
-
-    it('returns false when a renewal is in a terminal state that hides the badge', () => {
-      const reg = {
-        ...mockHostRegistration,
-        header: {
-          ...mockHostRegistration.header,
-          applications: [
-            {
-              applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
-            }
-          ]
-        }
-      }
-      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
-    })
-
-    it('returns false when renewal has no application status', () => {
-      const reg = {
-        ...mockHostRegistration,
-        header: {
-          ...mockHostRegistration.header,
-          applications: [
-            {
-              applicationType: 'renewal',
-              applicationStatus: undefined
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
             }
           ]
         }


### PR DESCRIPTION



*Issue:*

- bcgov/STRR/issues/1120

> **Note:** The requirements were revised for this ticket. See [comment](https://github.com/bcgov/STRR/issues/1120#issuecomment-4180868446) for more details.

---
### **Description of changes:**

Display the renewal badge in registrations table on a registration when the newest linked application is a renewal in PROVISIONALLY_APPROVED status and the registration has no decider.

The requirements were revised see comment 


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
