### PR TITLE
feat(ui+api): logic changes to substatus filters & renewal badge

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.13"
+version = "0.3.14"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/dataclass.py
+++ b/strr-api/src/strr_api/models/dataclass.py
@@ -73,6 +73,7 @@ class RegistrationSearch:
     requirements: list[str] | None = None
     account_id: int | None = None
     approval_methods: List[str] | None = None
+    examiner_reviewed: bool | None = None
     noc_statuses: List[str] | None = None
     is_set_aside: bool | None = None
     local_gov: str | None = None

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -167,7 +167,12 @@ class Registration(Versioned, BaseModel):
         """Collect OR conditions for registration sub-status filters."""
         sub_status_conditions = []
         if filter_criteria.approval_methods:
-            sub_status_conditions.append(cls._approval_method_condition(filter_criteria.approval_methods))
+            sub_status_conditions.append(
+                cls._approval_method_condition(
+                    filter_criteria.approval_methods,
+                    filter_criteria.examiner_reviewed,
+                )
+            )
         if filter_criteria.noc_statuses:
             sub_status_conditions.append(Registration.noc_status.in_(filter_criteria.noc_statuses))
         if filter_criteria.is_set_aside is True:
@@ -451,14 +456,16 @@ class Registration(Versioned, BaseModel):
         return query
 
     @classmethod
-    def _approval_method_condition(cls, approval_methods: list[str]):
-        """Build SQL condition for filtering by latest application status."""
+    def _approval_method_condition(cls, approval_methods: list[str], examiner_reviewed: bool | None = None):
+        """Build SQL condition for filtering by latest application status and review state."""
         # pylint: disable=import-outside-toplevel
         from sqlalchemy import select
 
         from strr_api.models.application import Application
 
-        # for each registration, get the status of the most recent application
+        # For each registration, evaluate only the latest application (same ordering
+        # used by the dashboard payload). This keeps filtering aligned with what users
+        # see in the Sub-Status column.
         latest_app_status_subq = (
             select(Application.status)
             .where(Application.registration_id == Registration.id)
@@ -466,12 +473,43 @@ class Registration(Versioned, BaseModel):
             .limit(1)
             .scalar_subquery()
         )
-        return latest_app_status_subq.in_(approval_methods)
+        approval_status_condition = latest_app_status_subq.in_(approval_methods)
+        if examiner_reviewed is None:
+            # Backward-compatible behavior: only filter by approval method/status.
+            return approval_status_condition
+
+        latest_app_decider_subq = (
+            select(Application.decider_id)
+            .where(Application.registration_id == Registration.id)
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        reviewed_condition = db.or_(
+            # latest application was decided by an examiner.
+            latest_app_decider_subq.isnot(None),
+            # fallback for older data paths where registration level decider is set.
+            Registration.decider_id.isnot(None),
+        )
+
+        # examinerReviewed=false -> "review queue" (not yet examiner decided)
+        # examinerReviewed=true  -> already reviewed by an examiner
+        return (
+            db.and_(approval_status_condition, reviewed_condition)
+            if examiner_reviewed
+            else db.and_(approval_status_condition, db.not_(reviewed_condition))
+        )
 
     @classmethod
     def _review_renew_condition(cls):
-        """Build SQL condition for registrations requiring renewal review."""
+        """Build SQL condition for renewals requiring human review.
+
+        A registration matches only when its latest renewal is in review/provisional
+        statuses and that latest renewal has no decider yet.
+        """
         # pylint: disable=import-outside-toplevel
+        from sqlalchemy import select
+
         from strr_api.enums.enum import ApplicationType
         from strr_api.models.application import Application
 
@@ -480,14 +518,36 @@ class Registration(Versioned, BaseModel):
             Application.Status.PROVISIONALLY_APPROVED.value,
             Application.Status.PROVISIONAL_REVIEW.value,
         ]
-        renewal_exists = db.exists().where(
-            db.and_(
+
+        # Latest renewal status for this registration.
+        latest_renewal_status_subq = (
+            select(Application.status)
+            .where(
                 Application.registration_id == Registration.id,
                 Application.type == ApplicationType.RENEWAL.value,
-                Application.status.in_(renewal_not_fully_approved_statuses),
             )
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
         )
-        return renewal_exists
+        # Latest renewal decider for this registration.
+        # Using the renewal application's decider (not registration level decider)
+        latest_renewal_decider_subq = (
+            select(Application.decider_id)
+            .where(
+                Application.registration_id == Registration.id,
+                Application.type == ApplicationType.RENEWAL.value,
+            )
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        return db.and_(
+            # "Review Renew" means latest renewal is still in review/provisional state
+            latest_renewal_status_subq.in_(renewal_not_fully_approved_statuses),
+            # and has not been examiner reviewed yet.
+            latest_renewal_decider_subq.is_(None),
+        )
 
 
 class RentalProperty(Versioned, BaseModel):

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -478,75 +478,62 @@ class Registration(Versioned, BaseModel):
             # Backward-compatible behavior: only filter by approval method/status.
             return approval_status_condition
 
-        latest_app_decider_subq = (
-            select(Application.decider_id)
-            .where(Application.registration_id == Registration.id)
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
-        reviewed_condition = db.or_(
-            # latest application was decided by an examiner.
-            latest_app_decider_subq.isnot(None),
-            # fallback for older data paths where registration level decider is set.
-            Registration.decider_id.isnot(None),
-        )
+        # Per examiner workflow, review state for registrations is represented by
+        # the registration level decider.
+        reviewed_condition = Registration.decider_id.isnot(None)
 
-        # examinerReviewed=false -> "review queue" (not yet examiner decided)
+        # examinerReviewed=false -> "review queue" (not yet examiner decided, no renewal filed)
         # examinerReviewed=true  -> already reviewed by an examiner
         return (
             db.and_(approval_status_condition, reviewed_condition)
             if examiner_reviewed
-            else db.and_(approval_status_condition, db.not_(reviewed_condition))
+            else db.and_(
+                approval_status_condition,
+                db.not_(reviewed_condition),
+                db.not_(cls._has_renewal_filed_condition()),
+            )
         )
 
     @classmethod
     def _review_renew_condition(cls):
         """Build SQL condition for renewals requiring human review.
 
-        A registration matches only when its latest renewal is in review/provisional
-        statuses and that latest renewal has no decider yet.
+        A registration matches when all are true:
+        - a renewal is filed
+        - no registration-level decision exists yet
+        - latest application is still in provisional review queue
         """
         # pylint: disable=import-outside-toplevel
-        from sqlalchemy import select
-
-        from strr_api.enums.enum import ApplicationType
         from strr_api.models.application import Application
 
-        renewal_not_fully_approved_statuses = [
-            Application.Status.FULL_REVIEW.value,
+        provisional_statuses = [
             Application.Status.PROVISIONALLY_APPROVED.value,
             Application.Status.PROVISIONAL_REVIEW.value,
         ]
-
-        # Latest renewal status for this registration.
-        latest_renewal_status_subq = (
-            select(Application.status)
-            .where(
-                Application.registration_id == Registration.id,
-                Application.type == ApplicationType.RENEWAL.value,
-            )
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
-        # Latest renewal decider for this registration.
-        # Using the renewal application's decider (not registration level decider)
-        latest_renewal_decider_subq = (
-            select(Application.decider_id)
-            .where(
-                Application.registration_id == Registration.id,
-                Application.type == ApplicationType.RENEWAL.value,
-            )
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
         return db.and_(
-            # "Review Renew" means latest renewal is still in review/provisional state
-            latest_renewal_status_subq.in_(renewal_not_fully_approved_statuses),
-            # and has not been examiner reviewed yet.
-            latest_renewal_decider_subq.is_(None),
+            cls._has_renewal_filed_condition(),
+            Registration.decider_id.is_(None),
+            cls._approval_method_condition(provisional_statuses),
+        )
+
+    @classmethod
+    def _has_renewal_filed_condition(cls):
+        """Return SQL condition indicating the registration has a filed renewal."""
+        # pylint: disable=import-outside-toplevel
+        from strr_api.enums.enum import ApplicationType
+        from strr_api.models.application import Application
+
+        return db.exists().where(
+            db.and_(
+                Application.registration_id == Registration.id,
+                Application.type == ApplicationType.RENEWAL.value,
+                Application.status.notin_(
+                    [
+                        Application.Status.DRAFT.value,
+                        Application.Status.PAYMENT_DUE.value,
+                    ]
+                ),
+            )
         )
 
 

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -1025,7 +1025,7 @@ def search_registrations():
       - in: query
         name: examinerReviewed
         type: boolean
-        description: When provided with approvalMethod, filter provisional approval records by whether an examiner has reviewed the latest application.
+        description: When provided with approvalMethod, filter provisional records by whether an examiner decision exists at the registration level.
       - in: query
         name: nocStatus
         type: array
@@ -1044,7 +1044,7 @@ def search_registrations():
       - in: query
         name: reviewRenew
         type: boolean
-        description: When true, only return registrations where the latest renewal application is in review/provisional status (FULL_REVIEW, PROVISIONAL_REVIEW, PROVISIONALLY_APPROVED) and has no decider.
+        description: When true, only return registrations with a filed renewal, no registration-level decider, and latest application status in PROVISIONALLY_APPROVED/PROVISIONAL_REVIEW.
     responses:
       200:
         description:

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -1023,6 +1023,10 @@ def search_registrations():
           enum: [FULL_REVIEW_APPROVED, AUTO_APPROVED, PROVISIONALLY_APPROVED]
         description: Approval method filter. Can provide multiple values.
       - in: query
+        name: examinerReviewed
+        type: boolean
+        description: When provided with approvalMethod, filter provisional approval records by whether an examiner has reviewed the latest application.
+      - in: query
         name: nocStatus
         type: array
         items:
@@ -1040,7 +1044,7 @@ def search_registrations():
       - in: query
         name: reviewRenew
         type: boolean
-        description: When true, only return registrations that have a renewal application that is not fully approved (FULL_REVIEW, PROVISIONAL_REVIEW, PROVISIONALLY_APPROVED).
+        description: When true, only return registrations where the latest renewal application is in review/provisional status (FULL_REVIEW, PROVISIONAL_REVIEW, PROVISIONALLY_APPROVED) and has no decider.
     responses:
       200:
         description:
@@ -1061,6 +1065,8 @@ def search_registrations():
         assignee = request.args.get("assignee", None)
         requirements = request.args.getlist("requirement") or None
         approval_methods = request.args.getlist("approvalMethod") or None
+        examiner_reviewed_param = request.args.get("examinerReviewed", None)
+        examiner_reviewed = examiner_reviewed_param.lower() == "true" if examiner_reviewed_param else None
         noc_statuses = request.args.getlist("nocStatus") or None
         is_set_aside_param = request.args.get("isSetAside", None)
         is_set_aside = is_set_aside_param.lower() == "true" if is_set_aside_param else None
@@ -1086,6 +1092,7 @@ def search_registrations():
             assignee=assignee,
             requirements=requirements,
             approval_methods=approval_methods,
+            examiner_reviewed=examiner_reviewed,
             noc_statuses=noc_statuses,
             is_set_aside=is_set_aside,
             local_gov=local_gov,

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2576,7 +2576,8 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
             found
         ), "Registration with most recent app PROVISIONALLY_APPROVED should match PROVISIONALLY_APPROVED filter"
 
-        # examinerReviewed=false should include this registration because latest app has no decider
+        # examinerReviewed=false should NOT include this registration because the
+        # registration level decider fallback marks it as reviewed.
         rv = client.get(
             (
                 f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
@@ -2587,9 +2588,10 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         assert rv.status_code == HTTPStatus.OK
         registrations = rv.json
         found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
-        assert found, "Provisional record without decider should match examinerReviewed=false filter"
+        assert not found, "Record should not match examinerReviewed=false when registration decider fallback is present"
 
-        # examinerReviewed=true should exclude this registration (latest app has no decider)
+        # examinerReviewed=true should include this registration due registration
+        # decider fallback even though latest app decider is null.
         rv = client.get(
             (
                 f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
@@ -2600,9 +2602,7 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         assert rv.status_code == HTTPStatus.OK
         registrations = rv.json
         found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
-        assert (
-            not found
-        ), "Provisional record without decider should not match examinerReviewed=true filter"
+        assert found, "Record should match examinerReviewed=true due registration level decider fallback"
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2577,7 +2577,7 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         ), "Registration with most recent app PROVISIONALLY_APPROVED should match PROVISIONALLY_APPROVED filter"
 
         # examinerReviewed=false should NOT include this registration because the
-        # registration level decider fallback marks it as reviewed.
+        # registration-level decider marks it as reviewed.
         rv = client.get(
             (
                 f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
@@ -2588,10 +2588,10 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         assert rv.status_code == HTTPStatus.OK
         registrations = rv.json
         found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
-        assert not found, "Record should not match examinerReviewed=false when registration decider fallback is present"
+        assert not found, "Record should not match examinerReviewed=false when registration decider is present"
 
         # examinerReviewed=true should include this registration due registration
-        # decider fallback even though latest app decider is null.
+        # decider, even though latest app decider is null.
         rv = client.get(
             (
                 f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
@@ -2602,14 +2602,14 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         assert rv.status_code == HTTPStatus.OK
         registrations = rv.json
         found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
-        assert found, "Record should match examinerReviewed=true due registration level decider fallback"
+        assert found, "Record should match examinerReviewed=true due registration decider"
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
-def test_search_registrations_review_renew_includes_registration_with_renewal_not_fully_approved(
+def test_search_registrations_review_renew_includes_registration_with_filed_renewal_and_no_registration_decider(
     mock_create_invoice, session, client, jwt
 ):
-    """Test that reviewRenew=true returns registrations that have a renewal that is not fully approved."""
+    """Test that reviewRenew=true returns registrations with a filed renewal and no decider."""
     from nanoid import generate
 
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
@@ -2636,21 +2636,25 @@ def test_search_registrations_review_renew_includes_registration_with_renewal_no
         registration_number = response_json.get("header").get("registrationNumber")
         registration = Registration.query.filter_by(registration_number=registration_number).one_or_none()
 
-        # Add a renewal application that is not fully approved (FULL_REVIEW, PROVISIONAL_REVIEW, PROVISIONALLY_APPROVED)
+        # Clear registration-level decider to simulate backlog requiring examiner review.
+        registration.decider_id = None
+        registration.save()
+
+        # Add a filed renewal application.
         session.refresh(application)
         renewal_app = Application(
             application_json=application.application_json,
             application_number=generate(alphabet="0123456789", size=14),
             type=ApplicationType.RENEWAL.value,
             registration_type=application.registration_type,
-            status=Application.Status.FULL_REVIEW.value,
+            status=Application.Status.PROVISIONALLY_APPROVED.value,
             registration_id=registration.id,
             application_date=application.application_date + timedelta(seconds=1),
         )
         session.add(renewal_app)
         session.commit()
 
-        # reviewRenew=true should return this registration (has renewal that is not fully approved)
+        # reviewRenew=true should return this registration (filed renewal + no decider)
         rv = client.get(
             f"/registrations/search?reviewRenew=true&recordNumber={registration_number}&status={RegistrationStatus.ACTIVE.value}",
             headers=staff_headers,
@@ -2660,7 +2664,7 @@ def test_search_registrations_review_renew_includes_registration_with_renewal_no
         assert len(registrations.get("registrations")) == 1
         assert registrations.get("registrations")[0].get("registrationNumber") == registration_number
 
-        # reviewRenew=false should still return it (no filter)
+        # reviewRenew=false behaves as no extra filter (same as omitting reviewRenew).
         rv = client.get(
             f"/registrations/search?reviewRenew=false&recordNumber={registration_number}",
             headers=staff_headers,
@@ -2718,10 +2722,22 @@ def test_search_registrations_review_renew_excludes_registration_without_renewal
         assert len(registrations.get("registrations")) == 1
         assert registrations.get("registrations")[0].get("registrationNumber") == registration_number
 
+        # reviewRenew=false behaves as no extra filter (same as omitting reviewRenew)
+        rv = client.get(
+            f"/registrations/search?reviewRenew=false&recordNumber={registration_number}",
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        assert len(registrations.get("registrations")) == 1
+        assert registrations.get("registrations")[0].get("registrationNumber") == registration_number
+
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
-def test_search_registrations_review_renew_excludes_renewal_fully_approved(mock_create_invoice, session, client, jwt):
-    """Test that reviewRenew=true excludes registrations whose only renewal is fully approved (e.g. FULL_REVIEW_APPROVED)."""
+def test_search_registrations_review_renew_excludes_when_latest_status_not_provisional_queue(
+    mock_create_invoice, session, client, jwt
+):
+    """Test that reviewRenew=true excludes registrations when latest status is not provisional queue."""
     from nanoid import generate
 
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
@@ -2748,7 +2764,11 @@ def test_search_registrations_review_renew_excludes_renewal_fully_approved(mock_
         registration_number = response_json.get("header").get("registrationNumber")
         registration = Registration.query.filter_by(registration_number=registration_number).one_or_none()
 
-        # Add a renewal application that is fully approved (FULL_REVIEW_APPROVED)
+        # Registration is not yet examiner-decided.
+        registration.decider_id = None
+        registration.save()
+
+        # Add a filed renewal application that is fully approved.
         session.refresh(application)
         renewal_app = Application(
             application_json=application.application_json,
@@ -2762,7 +2782,7 @@ def test_search_registrations_review_renew_excludes_renewal_fully_approved(mock_
         session.add(renewal_app)
         session.commit()
 
-        # reviewRenew=true should NOT return this registration (renewal is fully approved)
+        # reviewRenew=true should NOT return this registration because latest status is not provisional queue.
         rv = client.get(
             f"/registrations/search?reviewRenew=true&recordNumber={registration_number}&status={RegistrationStatus.ACTIVE.value}",
             headers=staff_headers,
@@ -2773,8 +2793,8 @@ def test_search_registrations_review_renew_excludes_renewal_fully_approved(mock_
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
-def test_search_registrations_review_renew_excludes_latest_reviewed_renewal(mock_create_invoice, session, client, jwt):
-    """Test that reviewRenew=true excludes registrations when latest renewal already has a decider."""
+def test_search_registrations_review_renew_excludes_registration_with_decider(mock_create_invoice, session, client, jwt):
+    """Test that reviewRenew=true excludes registrations with a registration-level decider."""
     from nanoid import generate
 
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
@@ -2809,7 +2829,7 @@ def test_search_registrations_review_renew_excludes_latest_reviewed_renewal(mock
             registration_type=application.registration_type,
             status=Application.Status.PROVISIONALLY_APPROVED.value,
             registration_id=registration.id,
-            decider_id=application.decider_id,
+            decider_id=None,
             application_date=application.application_date + timedelta(seconds=1),
         )
         session.add(renewal_app)

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2544,6 +2544,8 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
             registration_type=application.registration_type,
             status=Application.Status.PROVISIONALLY_APPROVED,
             registration_id=registration.id,
+            reviewer_id=application.reviewer_id,
+            decider_id=None,
             application_date=application.application_date + timedelta(seconds=1),
         )
         session.add(renewal_app)
@@ -2573,6 +2575,34 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         assert (
             found
         ), "Registration with most recent app PROVISIONALLY_APPROVED should match PROVISIONALLY_APPROVED filter"
+
+        # examinerReviewed=false should include this registration because latest app has no decider
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
+                f"&examinerReviewed=false&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert found, "Provisional record without decider should match examinerReviewed=false filter"
+
+        # examinerReviewed=true should exclude this registration (latest app has no decider)
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
+                f"&examinerReviewed=true&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert (
+            not found
+        ), "Provisional record without decider should not match examinerReviewed=true filter"
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
@@ -2733,6 +2763,58 @@ def test_search_registrations_review_renew_excludes_renewal_fully_approved(mock_
         session.commit()
 
         # reviewRenew=true should NOT return this registration (renewal is fully approved)
+        rv = client.get(
+            f"/registrations/search?reviewRenew=true&recordNumber={registration_number}&status={RegistrationStatus.ACTIVE.value}",
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        assert len(registrations.get("registrations")) == 0
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_search_registrations_review_renew_excludes_latest_reviewed_renewal(mock_create_invoice, session, client, jwt):
+    """Test that reviewRenew=true excludes registrations when latest renewal already has a decider."""
+    from nanoid import generate
+
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        json_data = json.load(f)
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        rv = client.post("/applications", json=json_data, headers=headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        application_number = response_json.get("header").get("applicationNumber")
+
+        application = Application.find_by_application_number(application_number=application_number)
+        application.payment_status = PaymentStatus.COMPLETED.value
+        application.status = Application.Status.FULL_REVIEW
+        application.save()
+
+        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
+        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        registration_number = response_json.get("header").get("registrationNumber")
+        registration = Registration.query.filter_by(registration_number=registration_number).one_or_none()
+
+        session.refresh(application)
+        renewal_app = Application(
+            application_json=application.application_json,
+            application_number=generate(alphabet="0123456789", size=14),
+            type=ApplicationType.RENEWAL.value,
+            registration_type=application.registration_type,
+            status=Application.Status.PROVISIONALLY_APPROVED.value,
+            registration_id=registration.id,
+            decider_id=application.decider_id,
+            application_date=application.application_date + timedelta(seconds=1),
+        )
+        session.add(renewal_app)
+        session.commit()
+
         rv = client.get(
             f"/registrations/search?reviewRenew=true&recordNumber={registration_number}&status={RegistrationStatus.ACTIVE.value}",
             headers=staff_headers,

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2793,7 +2793,9 @@ def test_search_registrations_review_renew_excludes_when_latest_status_not_provi
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
-def test_search_registrations_review_renew_excludes_registration_with_decider(mock_create_invoice, session, client, jwt):
+def test_search_registrations_review_renew_excludes_registration_with_decider(
+    mock_create_invoice, session, client, jwt
+):
     """Test that reviewRenew=true excludes registrations with a registration-level decider."""
     from nanoid import generate
 

--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -273,9 +273,12 @@ const getLatestRegistrationApplicationStatus = (reg: HousRegistrationResponse): 
   return getLatestRegistrationApplication(reg)?.applicationStatus as ApplicationStatus | undefined
 }
 
+const isProvisionalReviewQueueStatus = (status: ApplicationStatus | undefined): boolean => {
+  return status === ApplicationStatus.PROVISIONALLY_APPROVED || status === ApplicationStatus.PROVISIONAL_REVIEW
+}
+
 const hasExaminerReview = (reg: HousRegistrationResponse): boolean => {
-  const latestApplication = reg.header?.applications?.[0]
-  const decider = latestApplication?.decider ?? reg.header?.decider
+  const decider = reg.header?.decider
   return Boolean(decider?.username || decider?.displayName)
 }
 
@@ -302,40 +305,21 @@ const getRequirementsColumn = (app: HousApplicationResponse) => {
   return result
 }
 
-const REVIEW_RENEW_STATUSES = new Set<ApplicationStatus>([
-  ApplicationStatus.FULL_REVIEW,
-  ApplicationStatus.PROVISIONALLY_APPROVED,
-  ApplicationStatus.PROVISIONAL_REVIEW
-])
-
-const getLatestRenewalApplication = (reg: HousRegistrationResponse) => {
+const hasRenewalApplication = (reg: HousRegistrationResponse): boolean => {
   const applications = reg.header?.applications ?? []
-  return applications.find(app => app.applicationType === 'renewal')
+  return applications.some(app => app.applicationType === 'renewal')
 }
 
 const isReviewRenew = (reg: HousRegistrationResponse): boolean => {
-  const latestRenewal = getLatestRenewalApplication(reg)
-  if (!latestRenewal?.applicationStatus) {
-    return false
-  }
-
-  const hasRenewalDecider = Boolean(latestRenewal.decider?.username || latestRenewal.decider?.displayName)
-  return REVIEW_RENEW_STATUSES.has(latestRenewal.applicationStatus as ApplicationStatus) && !hasRenewalDecider
+  const latestAppStatus = getLatestRegistrationApplicationStatus(reg)
+  return hasRenewalApplication(reg) && !hasExaminerReview(reg) && isProvisionalReviewQueueStatus(latestAppStatus)
 }
 
 /**
- * Show the "Renewal" badge when the latest application is a provisionally approved renewal
- * and no registration-level decision has been recorded yet.
+ * Show the "Renewal" badge with the exact same predicate used by "Review Renew".
  */
 const shouldShowRenewalBadge = (reg: HousRegistrationResponse): boolean => {
-  const latest = getLatestRegistrationApplication(reg)
-  if (!latest || latest.applicationType !== 'renewal') {
-    return false
-  }
-  if (latest.applicationStatus !== ApplicationStatus.PROVISIONALLY_APPROVED) {
-    return false
-  }
-  return !reg.header?.decider?.username
+  return isReviewRenew(reg)
 }
 
 const getRegistrationSubStatus = (reg: HousRegistrationResponse): string => {
@@ -359,10 +343,7 @@ const getRegistrationSubStatus = (reg: HousRegistrationResponse): string => {
   }
 
   const latestAppStatus = getLatestRegistrationApplicationStatus(reg)
-  if (
-    latestAppStatus === ApplicationStatus.PROVISIONALLY_APPROVED ||
-    latestAppStatus === ApplicationStatus.PROVISIONAL_REVIEW
-  ) {
+  if (isProvisionalReviewQueueStatus(latestAppStatus)) {
     return hasExaminerReview(reg) ? 'Approved' : 'Review'
   }
   if (

--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -273,6 +273,12 @@ const getLatestRegistrationApplicationStatus = (reg: HousRegistrationResponse): 
   return getLatestRegistrationApplication(reg)?.applicationStatus as ApplicationStatus | undefined
 }
 
+const hasExaminerReview = (reg: HousRegistrationResponse): boolean => {
+  const latestApplication = reg.header?.applications?.[0]
+  const decider = latestApplication?.decider ?? reg.header?.decider
+  return Boolean(decider?.username || decider?.displayName)
+}
+
 const getRequirementsColumn = (app: HousApplicationResponse) => {
   let result = ''
   let listingSize = ''
@@ -302,14 +308,19 @@ const REVIEW_RENEW_STATUSES = new Set<ApplicationStatus>([
   ApplicationStatus.PROVISIONAL_REVIEW
 ])
 
-const isReviewRenew = (reg: HousRegistrationResponse): boolean => {
+const getLatestRenewalApplication = (reg: HousRegistrationResponse) => {
   const applications = reg.header?.applications ?? []
-  return applications.some(
-    app =>
-      app.applicationType === 'renewal' &&
-      app.applicationStatus &&
-      REVIEW_RENEW_STATUSES.has(app.applicationStatus as ApplicationStatus)
-  )
+  return applications.find(app => app.applicationType === 'renewal')
+}
+
+const isReviewRenew = (reg: HousRegistrationResponse): boolean => {
+  const latestRenewal = getLatestRenewalApplication(reg)
+  if (!latestRenewal?.applicationStatus) {
+    return false
+  }
+
+  const hasRenewalDecider = Boolean(latestRenewal.decider?.username || latestRenewal.decider?.displayName)
+  return REVIEW_RENEW_STATUSES.has(latestRenewal.applicationStatus as ApplicationStatus) && !hasRenewalDecider
 }
 
 /**
@@ -337,6 +348,12 @@ const getRegistrationSubStatus = (reg: HousRegistrationResponse): string => {
   if (reg.nocStatus === RegistrationNocStatus.NOC_EXPIRED) {
     return 'NOC - Expired'
   }
+  if (reg.status === RegistrationStatus.CANCELLED) {
+    return 'Cancelled'
+  }
+  if (reg.status === RegistrationStatus.SUSPENDED) {
+    return 'Suspended'
+  }
   if (isReviewRenew(reg)) {
     return 'Review Renew'
   }
@@ -346,7 +363,7 @@ const getRegistrationSubStatus = (reg: HousRegistrationResponse): string => {
     latestAppStatus === ApplicationStatus.PROVISIONALLY_APPROVED ||
     latestAppStatus === ApplicationStatus.PROVISIONAL_REVIEW
   ) {
-    return 'Review'
+    return hasExaminerReview(reg) ? 'Approved' : 'Review'
   }
   if (
     latestAppStatus === ApplicationStatus.AUTO_APPROVED ||

--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -257,6 +257,7 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
 
   type RegistrationSubStatusFilters = {
     approvalMethods: string[]
+    examinerReviewed?: boolean
     nocStatuses: string[]
     isSetAside: boolean
     reviewRenew: boolean
@@ -267,12 +268,16 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
     const nocStatuses = new Set<string>()
     let isSetAside = false
     let reviewRenew = false
+    let hasReviewSubStatus = false
+    let hasApprovedSubStatus = false
 
     for (const subStatus of subStatuses) {
       if (subStatus === REVIEW_SUB_STATUS) {
+        hasReviewSubStatus = true
         approvalMethods.add(ApplicationStatus.PROVISIONALLY_APPROVED)
         approvalMethods.add(ApplicationStatus.PROVISIONAL_REVIEW)
       } else if (subStatus === APPROVED_SUB_STATUS) {
+        hasApprovedSubStatus = true
         approvalMethods.add(ApplicationStatus.AUTO_APPROVED)
         approvalMethods.add(ApplicationStatus.FULL_REVIEW_APPROVED)
       } else if (NOC_ATTR.has(subStatus)) {
@@ -284,8 +289,11 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
       }
     }
 
+    const examinerReviewed = (hasReviewSubStatus && !hasApprovedSubStatus) ? false : undefined
+
     return {
       approvalMethods: [...approvalMethods],
+      examinerReviewed,
       nocStatuses: [...nocStatuses],
       isSetAside,
       reviewRenew
@@ -309,6 +317,9 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
 
     if (mappedSubStatuses.approvalMethods.length > 0) {
       queryParams.approvalMethod = mappedSubStatuses.approvalMethods
+    }
+    if (mappedSubStatuses.examinerReviewed !== undefined) {
+      queryParams.examinerReviewed = mappedSubStatuses.examinerReviewed
     }
     if (mappedSubStatuses.nocStatuses.length > 0) {
       queryParams.nocStatus = mappedSubStatuses.nocStatuses

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -600,7 +600,7 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
 
-    it('returns false when the latest application is not a renewal', () => {
+    it('returns false when there is no renewal application', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
@@ -609,10 +609,6 @@ describe('Examiner Dashboard Page', () => {
             {
               applicationType: 'host',
               applicationStatus: ApplicationStatus.FULL_REVIEW
-            },
-            {
-              applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
             }
           ]
         }
@@ -622,9 +618,10 @@ describe('Examiner Dashboard Page', () => {
 
     it.each([
       { status: ApplicationStatus.FULL_REVIEW, label: 'full review' },
-      { status: ApplicationStatus.PROVISIONAL_REVIEW, label: 'provisional review' },
+      { status: ApplicationStatus.FULL_REVIEW_APPROVED, label: 'full review approved' },
+      { status: ApplicationStatus.AUTO_APPROVED, label: 'auto approved' },
       { status: undefined, label: 'missing status' }
-    ])('returns false when latest renewal is not provisionally approved ($label)', ({ status }) => {
+    ])('returns false when latest status is not provisional review queue status ($label)', ({ status }) => {
       const reg = {
         ...mockHostRegistration,
         header: {
@@ -640,7 +637,7 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
 
-    it('returns false when provisionally approved renewal but registration has a decider', () => {
+    it('returns false when review-renew conditions are met except registration has a decider', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
@@ -657,7 +654,7 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
 
-    it('returns true when latest is provisionally approved renewal and no registration decider', () => {
+    it('returns true when it matches Review Renew predicate', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
@@ -673,16 +670,15 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(true)
     })
 
-    it('returns false when an older renewal is provisionally approved but latest app is decided renewal', () => {
-      // Newest-first order matches RegistrationSerializer._populate_applications
+    it('returns true when an older renewal exists and latest provisional application is registration', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
           ...headerBase,
           applications: [
             {
-              applicationType: 'renewal',
-              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
+              applicationType: 'registration',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
             },
             {
               applicationType: 'renewal',
@@ -691,7 +687,7 @@ describe('Examiner Dashboard Page', () => {
           ]
         }
       }
-      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(true)
     })
   })
 
@@ -790,16 +786,35 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Suspended')
     })
 
-    it('shows Approved instead of Review Renew when latest renewal has a decider', () => {
+    it('shows Approved instead of Review Renew when registration has a decider', () => {
       const reg = {
         ...mockHostRegistration,
         header: {
           ...mockHostRegistration.header,
+          decider: { username: 'examiner1' },
           applications: [
             {
               applicationType: 'renewal',
               applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED,
-              decider: { username: 'examiner1' }
+              decider: {}
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Approved')
+    })
+
+    it('does not show Review Renew when latest status is not provisional queue status', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          decider: {},
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW_APPROVED
             }
           ]
         }

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -693,7 +693,6 @@ describe('Examiner Dashboard Page', () => {
       }
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
-
   })
 
   describe('getRegistrationSubStatus', () => {

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -12,6 +12,7 @@ import Dashboard from '~/pages/dashboard.vue'
 import {
   ApplicationStatus,
   ApplicationType,
+  RegistrationStatus,
   PrExemptionReason,
   StrataHotelCategory
 } from '#imports'
@@ -691,6 +692,121 @@ describe('Examiner Dashboard Page', () => {
         }
       }
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
+  })
+
+  describe('getRegistrationSubStatus', () => {
+    it('shows Review for provisional status when there is no examiner review', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          assignee: {},
+          decider: {},
+          applications: [
+            {
+              applicationType: 'registration',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Review')
+    })
+
+    it('shows Review for provisional status when only assignee exists', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          assignee: { username: 'examiner1' },
+          decider: {},
+          applications: [
+            {
+              applicationType: 'registration',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED,
+              assignee: { username: 'examiner1' },
+              decider: {}
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Review')
+    })
+
+    it('shows Approved for provisional status when an examiner reviewed the file', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          decider: { username: 'examiner1' },
+          applications: [
+            {
+              applicationType: 'registration',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Approved')
+    })
+
+    it('shows Cancelled when registration is cancelled, even if latest application is review', () => {
+      const reg = {
+        ...mockHostRegistration,
+        status: RegistrationStatus.CANCELLED,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'registration',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Cancelled')
+    })
+
+    it('shows Suspended when registration is suspended, even if renewal review exists', () => {
+      const reg = {
+        ...mockHostRegistration,
+        status: RegistrationStatus.SUSPENDED,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.FULL_REVIEW
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Suspended')
+    })
+
+    it('shows Approved instead of Review Renew when latest renewal has a decider', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED,
+              decider: { username: 'examiner1' }
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Approved')
     })
   })
 

--- a/strr-examiner-web/tests/unit/store-examiner.spec.ts
+++ b/strr-examiner-web/tests/unit/store-examiner.spec.ts
@@ -306,6 +306,23 @@ describe('Store - Examiner', () => {
     }))
   })
 
+  it('should include examinerReviewed=false when filtering by Review sub-status', async () => {
+    const store = useExaminerStore()
+
+    store.tableFilters.subStatus = ['REVIEW'] as any
+    await store.fetchRegistrations()
+
+    expect(mockStrrApi).toHaveBeenCalledWith('/registrations/search', expect.objectContaining({
+      query: expect.objectContaining({
+        approvalMethod: [
+          ApplicationStatus.PROVISIONALLY_APPROVED,
+          ApplicationStatus.PROVISIONAL_REVIEW
+        ],
+        examinerReviewed: false
+      })
+    }))
+  })
+
   it('should include all active table filters in the search query', async () => {
     const store = useExaminerStore()
 


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1118

*Description of changes:*
Here are a list of changes of what this PR does:
- Review now only shows registrations that are provisionally reviewed or provisionally approved that DO NOT have the decider block filled in. Meaning, they were approved but no examiner actually have looked at them yet and made a decision.
- Review Renew, follows a similar path. Renewals that have been provisionally approved but no examiner have looked and made a decision on that renewal.
- If a registration now is Suspended or Cancelled, we actually show it in the sub-status column as well. Examiners want to see that

I tested my changes in both old and new dashboard. They both look good from my perspective. Old dashboard works the exact same way as before. New one has that updated logic.

Here's an example of stuff that won't show anymore in Review:
Previously, something like this used to show:
<img width="2546" height="725" alt="image" src="https://github.com/user-attachments/assets/218c6fb6-cb90-4212-afb6-f1a9d4118b5b" />
Now, it doesn't. Reason is because it was provisionally approved and there is a decider.


For review renew, something like this won't show anymore:
<img width="2537" height="1063" alt="image" src="https://github.com/user-attachments/assets/ce4fe883-c935-432e-a094-18ea82f29349" />
Reason being, it's a provisionally approved renewal with a decider. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
