### PR TITLE
fix(strr-api): fix test/uat emails issue

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.14"
+version = "0.3.15"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/interactions.py
+++ b/strr-api/src/strr_api/models/interactions.py
@@ -116,7 +116,7 @@ class CustomerInteraction(Versioned, SimpleBaseModel):
     ) -> CustomerInteraction | None:
         """Return an Interation if it exists."""
         return cls.query.filter(
-            idempotency_key == idempotency_key,
+            cls.idempotency_key == idempotency_key,
             or_(cls.registration_id == registration_id, cls.application_id == application_id),
         ).one_or_none()
 
@@ -126,4 +126,4 @@ class CustomerInteraction(Versioned, SimpleBaseModel):
         interaction_uuid: str,
     ):
         """Return an Interation if it exists."""
-        return cls.query.filter(interaction_uuid == interaction_uuid).one_or_none()
+        return cls.query.filter(cls.interaction_uuid == interaction_uuid).one_or_none()

--- a/strr-api/src/strr_api/services/email_service.py
+++ b/strr-api/src/strr_api/services/email_service.py
@@ -72,9 +72,11 @@ class EmailService:
         Assumes the application.status has been changed."""
         if application.status in APPLICATION_EMAIL_STATES.get(application.registration_type, []):
             try:
+                registration_type = getattr(application.registration_type, "value", application.registration_type)
+                application_status = getattr(application.status, "name", application.status)
                 payload_data = {
                     "applicationNumber": application.application_number,
-                    "emailType": f"{application.registration_type.value}_{application.status.name}",
+                    "emailType": f"{registration_type}_{application_status}",
                 }
                 if custom_content and application.status in [
                     Application.Status.PROVISIONALLY_DECLINED,

--- a/strr-api/src/strr_api/services/email_service.py
+++ b/strr-api/src/strr_api/services/email_service.py
@@ -176,14 +176,25 @@ class EmailService:
             logger.error("Failed to publish email notification: %s", err.with_traceback(None))
 
     @staticmethod
-    def send_renewal_reminder_for_registration(registration: Registration):
+    def send_renewal_reminder_for_registration(registration: Registration, interaction: str | None = None):
         """Send renewal reminder for the registration."""
         # TODO: fix circular import issue
         from strr_api.services import InteractionService
+        from strr_api.services.interaction import EmailInfo
 
-        email_type = "RENEWAL_REMINDER"
-        email_type = f"{registration.registration_type}_{email_type}"
-        interaction_uuid = InteractionService.queued(channel_type=ChannelType.EMAIL, registration_id=registration.id)
+        registration_type = getattr(registration.registration_type, "value", registration.registration_type)
+        email_type = f"{registration_type}_RENEWAL_REMINDER"
+        email_info = EmailInfo(
+            email_type=email_type,
+            registration_number=registration.registration_number,
+            interaction=interaction,
+        )
+        interaction_uuid = InteractionService.queued(
+            channel_type=ChannelType.EMAIL,
+            payload=email_info,
+            registration_id=registration.id,
+            idempotency_key=interaction,
+        )
         try:
             gcp_queue_publisher.publish_to_queue(
                 gcp_queue_publisher.QueueMessage(
@@ -192,6 +203,7 @@ class EmailService:
                     payload={
                         "registrationNumber": registration.registration_number,
                         "emailType": email_type,
+                        "interaction": interaction,
                         "interaction_uuid": interaction_uuid,
                     },
                     topic=current_app.config.get("GCP_EMAIL_TOPIC"),

--- a/strr-api/src/strr_api/services/email_service.py
+++ b/strr-api/src/strr_api/services/email_service.py
@@ -74,7 +74,7 @@ class EmailService:
             try:
                 payload_data = {
                     "applicationNumber": application.application_number,
-                    "emailType": f"{application.registration_type.value}_{application.status}",
+                    "emailType": f"{application.registration_type.value}_{application.status.name}",
                 }
                 if custom_content and application.status in [
                     Application.Status.PROVISIONALLY_DECLINED,

--- a/strr-api/tests/unit/models/test_interactions.py
+++ b/strr-api/tests/unit/models/test_interactions.py
@@ -94,6 +94,30 @@ def test_create_interaction_with_application(session, setup_parents):
     assert interaction.application_id == setup_parents["app_id"]
 
 
+def test_find_by_uuid_returns_requested_interaction(session, setup_parents):
+    """Test that UUID lookup does not match unrelated interaction rows."""
+    interaction_one = generate_interaction_data(customer_id=setup_parents["customer_id"])
+    interaction_two = generate_interaction_data(application_id=setup_parents["app_id"])
+    session.add_all([interaction_one, interaction_two])
+    session.commit()
+
+    stored = CustomerInteraction.find_by_uuid(interaction_two.interaction_uuid)
+
+    assert stored.id == interaction_two.id
+
+
+def test_find_by_id_idempotency_key_respects_key(session, setup_parents):
+    """Test that idempotency lookup filters by the requested key."""
+    interaction_one = generate_interaction_data(registration_id=setup_parents["reg_id"], idempotency_key="job-key-one")
+    interaction_two = generate_interaction_data(registration_id=setup_parents["reg_id"], idempotency_key="job-key-two")
+    session.add_all([interaction_one, interaction_two])
+    session.commit()
+
+    stored = CustomerInteraction.find_by_id_idempotency_key("job-key-two", registration_id=setup_parents["reg_id"])
+
+    assert stored.id == interaction_two.id
+
+
 def test_jsonb_metadata_storage(session, setup_parents):
     """Test that the JSONB column correctly stores and retrieves dictionaries."""
     meta = {"campaign_id": 123, "tags": ["urgent", "promo"]}

--- a/strr-api/tests/unit/services/conftest.py
+++ b/strr-api/tests/unit/services/conftest.py
@@ -32,7 +32,6 @@ def setup_parents(session: Session, random_string, random_integer):
     session.flush()
 
     app = Application(
-        id=random_integer(),
         application_json={},
         registration_id=reg.id,
         application_number=random_string(10),

--- a/strr-api/tests/unit/services/test_email_service.py
+++ b/strr-api/tests/unit/services/test_email_service.py
@@ -43,9 +43,11 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from dotenv import load_dotenv
 from gcp_queue.gcp_queue import GcpQueue
+from sqlalchemy import select
 
 from strr_api import create_app
-from strr_api.models import Application, Registration, User
+from strr_api.enums.enum import InteractionStatus
+from strr_api.models import Application, CustomerInteraction, Registration, User
 from strr_api.services import ApplicationService
 from strr_api.services.email_service import EmailService
 
@@ -150,3 +152,31 @@ def test_email_queue_publish(app, mock_publisher_client, mock_credentials, regis
 
     # set back to original topic
     app.config["GCP_EMAIL_TOPIC"] = orig_topic
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_renewal_reminder_queues_interaction_and_publishes_payload(session, setup_parents, inject_config):
+    """Test that renewal reminders preserve the queued interaction key in the event."""
+    registration = session.get(Registration, setup_parents["registration_id"])
+    job_key = "2026:RENEWAL_REMINDER:40"
+
+    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+        EmailService.send_renewal_reminder_for_registration(registration=registration, interaction=job_key)
+
+    mock_publish.assert_called_once()
+    queue_message = mock_publish.call_args.args[0]
+    payload = queue_message.payload
+
+    assert queue_message.topic == "test"
+    assert payload["registrationNumber"] == registration.registration_number
+    assert payload["emailType"] == "HOST_RENEWAL_REMINDER"
+    assert payload["interaction"] == job_key
+    assert payload["interaction_uuid"]
+
+    stored = session.scalar(
+        select(CustomerInteraction).where(CustomerInteraction.interaction_uuid == payload["interaction_uuid"])
+    )
+
+    assert stored.registration_id == registration.id
+    assert stored.idempotency_key == job_key
+    assert stored.status == InteractionStatus.QUEUED

--- a/strr-api/tests/unit/services/test_email_service.py
+++ b/strr-api/tests/unit/services/test_email_service.py
@@ -180,3 +180,27 @@ def test_send_renewal_reminder_queues_interaction_and_publishes_payload(session,
     assert stored.registration_id == registration.id
     assert stored.idempotency_key == job_key
     assert stored.status == InteractionStatus.QUEUED
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_renewal_reminder_logs_publish_failure(session, setup_parents, inject_config):
+    """Test that renewal reminder publish failures are logged without changing queued tracking."""
+    registration = session.get(Registration, setup_parents["registration_id"])
+    job_key = "2026:RENEWAL_REMINDER:41"
+
+    with (
+        patch(
+            "strr_api.services.email_service.gcp_queue_publisher.publish_to_queue",
+            side_effect=RuntimeError("publish failed"),
+        ),
+        patch("strr_api.services.email_service.logger.error") as mock_logger,
+    ):
+        EmailService.send_renewal_reminder_for_registration(registration=registration, interaction=job_key)
+
+    stored = session.scalar(select(CustomerInteraction).where(CustomerInteraction.idempotency_key == job_key))
+
+    assert stored.registration_id == registration.id
+    assert stored.status == InteractionStatus.QUEUED
+    mock_logger.assert_called_once()
+    assert mock_logger.call_args.args[0] == "Failed to publish email notification: %s"
+    assert str(mock_logger.call_args.args[1]) == "publish failed"

--- a/strr-api/tests/unit/services/test_email_service.py
+++ b/strr-api/tests/unit/services/test_email_service.py
@@ -222,8 +222,9 @@ def test_send_notice_of_consideration_for_application_publishes_payload(
     application.application_number = "A-123456"
     application.status = status
 
-    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
-        EmailService.send_notice_of_consideration_for_application(application)
+    with app.app_context():
+        with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+            EmailService.send_notice_of_consideration_for_application(application)
 
     mock_publish.assert_called_once()
     queue_message = mock_publish.call_args.args[0]
@@ -236,13 +237,110 @@ def test_send_notice_of_consideration_for_application_publishes_payload(
 
 
 @pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_registration_status_update_email_publishes_payload(session, setup_parents, inject_config):
+    """Test that registration status emails publish the expected payload."""
+    registration = session.get(Registration, setup_parents["registration_id"])
+    interaction = "2026:REGISTRATION_STATUS:41"
+
+    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+        EmailService.send_registration_status_update_email(
+            registration=registration,
+            email_content="message body",
+            interaction=interaction,
+        )
+
+    mock_publish.assert_called_once()
+    queue_message = mock_publish.call_args.args[0]
+
+    assert queue_message.topic == "test"
+    assert queue_message.payload == {
+        "registrationNumber": registration.registration_number,
+        "emailType": "HOST_REGISTRATION_ACTIVE",
+        "customContent": "message body",
+        "interaction": interaction,
+    }
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_registration_status_update_email_skips_non_notifiable_status(session, setup_parents, inject_config):
+    """Test that non-notifiable registration statuses do not publish emails."""
+    registration = session.get(Registration, setup_parents["registration_id"])
+    registration.status = "EXPIRED"
+
+    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+        EmailService.send_registration_status_update_email(registration=registration)
+
+    mock_publish.assert_not_called()
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_notice_of_consideration_for_registration_publishes_payload(session, setup_parents, inject_config):
+    """Test that registration NOC emails publish the expected payload."""
+    registration = session.get(Registration, setup_parents["registration_id"])
+
+    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+        EmailService.send_notice_of_consideration_for_registration(registration=registration)
+
+    mock_publish.assert_called_once()
+    queue_message = mock_publish.call_args.args[0]
+
+    assert queue_message.topic == "test"
+    assert queue_message.payload == {
+        "registrationNumber": registration.registration_number,
+        "emailType": "REGISTRATION_NOC",
+    }
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_notice_of_consideration_for_application_logs_publish_failure(app, inject_config):
+    """Test that application NOC publish failures are logged."""
+    application = Application()
+    application.application_number = "A-999991"
+    application.status = Application.Status.AUTO_APPROVED
+
+    with app.app_context():
+        with (
+            patch(
+                "strr_api.services.email_service.gcp_queue_publisher.publish_to_queue",
+                side_effect=RuntimeError("publish failed"),
+            ),
+            patch("strr_api.services.email_service.logger.error") as mock_logger,
+        ):
+            EmailService.send_notice_of_consideration_for_application(application)
+
+    mock_logger.assert_called_once()
+    assert mock_logger.call_args.args[0] == "Failed to publish email notification: %s"
+    assert str(mock_logger.call_args.args[1]) == "publish failed"
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_notice_of_consideration_for_registration_logs_publish_failure(session, setup_parents, inject_config):
+    """Test that registration NOC publish failures are logged."""
+    registration = session.get(Registration, setup_parents["registration_id"])
+
+    with (
+        patch(
+            "strr_api.services.email_service.gcp_queue_publisher.publish_to_queue",
+            side_effect=RuntimeError("publish failed"),
+        ),
+        patch("strr_api.services.email_service.logger.error") as mock_logger,
+    ):
+        EmailService.send_notice_of_consideration_for_registration(registration=registration)
+
+    mock_logger.assert_called_once()
+    assert mock_logger.call_args.args[0] == "Failed to publish email notification: %s"
+    assert str(mock_logger.call_args.args[1]) == "publish failed"
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
 def test_send_set_aside_email_publishes_payload(app, inject_config):
     """Test that set-aside emails publish the expected payload."""
     application = Application()
     application.application_number = "A-654321"
 
-    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
-        EmailService.send_set_aside_email(application, email_content="set aside body")
+    with app.app_context():
+        with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+            EmailService.send_set_aside_email(application, email_content="set aside body")
 
     mock_publish.assert_called_once()
     queue_message = mock_publish.call_args.args[0]
@@ -253,3 +351,70 @@ def test_send_set_aside_email_publishes_payload(app, inject_config):
         "emailType": "SET_ASIDE",
         "message": "set aside body",
     }
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_set_aside_email_logs_publish_failure(app, inject_config):
+    """Test that set-aside publish failures are logged."""
+    application = Application()
+    application.application_number = "A-999992"
+
+    with app.app_context():
+        with (
+            patch(
+                "strr_api.services.email_service.gcp_queue_publisher.publish_to_queue",
+                side_effect=RuntimeError("publish failed"),
+            ),
+            patch("strr_api.services.email_service.logger.error") as mock_logger,
+        ):
+            EmailService.send_set_aside_email(application, email_content="set aside body")
+
+    mock_logger.assert_called_once()
+    assert mock_logger.call_args.args[0] == "Failed to publish email notification: %s"
+    assert str(mock_logger.call_args.args[1]) == "publish failed"
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_application_status_update_email_includes_custom_content(app, inject_config):
+    """Test that declined application status emails include custom content."""
+    application = Application()
+    application.registration_type = Registration.RegistrationType.HOST
+    application.status = Application.Status.DECLINED
+    application.application_number = "A-777777"
+
+    with app.app_context():
+        with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+            EmailService.send_application_status_update_email(application, custom_content="decline details")
+
+    mock_publish.assert_called_once()
+    queue_message = mock_publish.call_args.args[0]
+
+    assert queue_message.topic == "test"
+    assert queue_message.payload == {
+        "applicationNumber": "A-777777",
+        "emailType": "HOST_DECLINED",
+        "customContent": "decline details",
+    }
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_application_status_update_email_logs_publish_failure(app, inject_config):
+    """Test that application status email publish failures are logged."""
+    application = Application()
+    application.registration_type = Registration.RegistrationType.HOST
+    application.status = Application.Status.AUTO_APPROVED
+    application.application_number = "A-888888"
+
+    with app.app_context():
+        with (
+            patch(
+                "strr_api.services.email_service.gcp_queue_publisher.publish_to_queue",
+                side_effect=RuntimeError("publish failed"),
+            ),
+            patch("strr_api.services.email_service.logger.error") as mock_logger,
+        ):
+            EmailService.send_application_status_update_email(application)
+
+    mock_logger.assert_called_once()
+    assert mock_logger.call_args.args[0] == "Failed to publish email notification: %s"
+    assert str(mock_logger.call_args.args[1]) == "publish failed"

--- a/strr-api/tests/unit/services/test_email_service.py
+++ b/strr-api/tests/unit/services/test_email_service.py
@@ -204,3 +204,52 @@ def test_send_renewal_reminder_logs_publish_failure(session, setup_parents, inje
     mock_logger.assert_called_once()
     assert mock_logger.call_args.args[0] == "Failed to publish email notification: %s"
     assert str(mock_logger.call_args.args[1]) == "publish failed"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_email_type"),
+    [
+        (Application.Status.PROVISIONAL_REVIEW_NOC_PENDING, "PROVISIONAL_REVIEW_NOC"),
+        (Application.Status.AUTO_APPROVED, "NOC"),
+    ],
+)
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_notice_of_consideration_for_application_publishes_payload(
+    app, status, expected_email_type, inject_config
+):
+    """Test that application notice-of-consideration emails publish the expected payload."""
+    application = Application()
+    application.application_number = "A-123456"
+    application.status = status
+
+    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+        EmailService.send_notice_of_consideration_for_application(application)
+
+    mock_publish.assert_called_once()
+    queue_message = mock_publish.call_args.args[0]
+
+    assert queue_message.topic == "test"
+    assert queue_message.payload == {
+        "applicationNumber": "A-123456",
+        "emailType": expected_email_type,
+    }
+
+
+@pytest.mark.conf(GCP_EMAIL_TOPIC="test")
+def test_send_set_aside_email_publishes_payload(app, inject_config):
+    """Test that set-aside emails publish the expected payload."""
+    application = Application()
+    application.application_number = "A-654321"
+
+    with patch("strr_api.services.email_service.gcp_queue_publisher.publish_to_queue") as mock_publish:
+        EmailService.send_set_aside_email(application, email_content="set aside body")
+
+    mock_publish.assert_called_once()
+    queue_message = mock_publish.call_args.args[0]
+
+    assert queue_message.topic == "test"
+    assert queue_message.payload == {
+        "applicationNumber": "A-654321",
+        "emailType": "SET_ASIDE",
+        "message": "set aside body",
+    }


### PR DESCRIPTION
*Issue:* 
SRE: No emails being sent in TEST and UAT environments #1482

https://app.zenhub.com/workspaces/strr-65b2a7146835aa0cdf315b79/issues/gh/bcgov/strr/1482

the interaction lookups were broken.
find_by_id_idempotency_key() was effectively doing idempotency_key == idempotency_key
find_by_uuid() was effectively doing interaction_uuid == interaction_uuid

so the query could match the wrong row and break the email chain.

note: there were lots of coverage issues so i added a ton of tests in the emailer test suite that aren't directly related to the issue. 

- bcgov/entity/issues/

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
