### PR TITLE
feat(ui): hide email compose if application has reg number

### DIFF
--- a/strr-examiner-web/app/components/ComposeNoc.vue
+++ b/strr-examiner-web/app/components/ComposeNoc.vue
@@ -6,7 +6,8 @@ const {
   emailContent,
   showComposeNocEmail,
   isAssignedToUser,
-  activeHeader
+  activeHeader,
+  hasRegistrationNumber
 } = storeToRefs(useExaminerStore())
 const { t } = useNuxtApp().$i18n
 const formSchema = computed(
@@ -32,7 +33,10 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="(showComposeEmail || showComposeNocEmail) && isAssignedToUser" class="app-inner-container">
+  <div
+    v-if="(showComposeEmail || showComposeNocEmail) && isAssignedToUser && !hasRegistrationNumber"
+    class="app-inner-container"
+  >
     <div class="mb-8 rounded bg-white py-6">
       <UForm
         ref="emailFormRef"

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/compose-noc.spec.ts
+++ b/strr-examiner-web/tests/unit/compose-noc.spec.ts
@@ -1,0 +1,45 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, it, vi, expect, beforeEach } from 'vitest'
+import { enI18n } from '../mocks/i18n'
+import ComposeNoc from '~/components/ComposeNoc.vue'
+
+const mockState = {
+  hasRegistrationNumber: false,
+  showComposeEmail: true,
+  isAssignedToUser: true
+}
+
+vi.mock('@/stores/examiner', () => ({
+  useExaminerStore: () => ({
+    hasRegistrationNumber: ref(mockState.hasRegistrationNumber),
+    showComposeEmail: ref(mockState.showComposeEmail),
+    showComposeNocEmail: ref(false),
+    isAssignedToUser: ref(mockState.isAssignedToUser),
+    emailContent: ref({ content: '' }),
+    activeHeader: ref(null),
+    sendNocSchema: ref({})
+  })
+}))
+
+describe('ComposeNoc Component', () => {
+  beforeEach(() => {
+    mockState.hasRegistrationNumber = false
+    mockState.showComposeEmail = true
+    mockState.isAssignedToUser = true
+  })
+
+  it('should show compose email form when application has no registration number', async () => {
+    const wrapper = await mountSuspended(ComposeNoc, {
+      global: { plugins: [enI18n] }
+    })
+    expect(wrapper.find('[data-testid="compose-email"]').exists()).toBe(true)
+  })
+
+  it('should not show compose email form when application has a registration number', async () => {
+    mockState.hasRegistrationNumber = true
+    const wrapper = await mountSuspended(ComposeNoc, {
+      global: { plugins: [enI18n] }
+    })
+    expect(wrapper.find('[data-testid="compose-email"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1498

*Description of changes:*
- If the Application has a Registration Number hide Compose Email component 
- This is in addition to (prev work where) the Action Buttons are also hidden   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
