### PR TITLE
fix(ui): small fix to update payload during address requirements check

### DIFF
--- a/strr-base-web/app/utils/formattingHelpers.ts
+++ b/strr-base-web/app/utils/formattingHelpers.ts
@@ -32,7 +32,7 @@ export function formatAddressUI <T extends ApiBaseAddress> (add: T): ConnectAddr
     city: add.city,
     postalCode: add.postalCode,
     street: add.address || '',
-    streetAdditional: add.addressLineTwo,
+    streetAdditional: add.addressLineTwo || '',
     region: add.province,
     locationDescription: add.locationDescription
   }

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1508

*Description of changes:*
- Update the addressLineTwo to be an empty string instead of null (in certain cases) to allow for successful address check

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
