### PR TITLE
feat(ui): remove confirmation dialogue boxes in examiner's UI

### DIFF
--- a/strr-examiner-web/app/components/ActionButtons.vue
+++ b/strr-examiner-web/app/components/ActionButtons.vue
@@ -102,27 +102,9 @@ const suspendRegistrationAction = () => {
   refreshNuxtData()
 }
 
+// Reinstates a cancelled/suspended registration by re-applying the ACTIVE status
 const reinstateRegistration = () => {
-  openConfirmActionModal(
-    t('modal.reinstateRegistration.title'),
-    t('modal.reinstateRegistration.message'),
-    t('btn.yesReinstate'),
-    () => {
-      closeConfirmActionModal()
-      updateRegistrationStatus(
-        activeReg.value.id,
-        RegistrationStatus.ACTIVE,
-        decisionEmailContent.value.content,
-        {
-          predefinedConditions: conditions.value,
-          ...(customConditions.value && { customConditions: customConditions.value }),
-          ...(minBookingDays.value !== null && { minBookingDays: minBookingDays.value })
-        }
-      )
-      refreshNuxtData()
-    },
-    t('btn.cancel')
-  )
+  applyActiveApprovalStatus()
 }
 
 const sendNoticeAction = async () => {

--- a/strr-examiner-web/app/components/ActionButtons.vue
+++ b/strr-examiner-web/app/components/ActionButtons.vue
@@ -58,87 +58,51 @@ const hasDecisionChanges = computed(() =>
 const isApproveDecisionSelected = computed((): boolean => decisionIntent.value === ApplicationActionsE.APPROVE)
 
 const approveRegistrationAction = () => {
-  openConfirmActionModal(
-    t('modal.approveRegistration.title'),
-    t('modal.approveRegistration.message'),
-    t('btn.yesApprove'),
-    () => {
-      closeConfirmActionModal()
-      updateRegistrationStatus(
-        activeReg.value.id,
-        RegistrationStatus.ACTIVE,
-        decisionEmailContent.value.content,
-        {
-          predefinedConditions: conditions.value,
-          ...(customConditions.value && { customConditions: customConditions.value }),
-          ...(minBookingDays.value !== null && { minBookingDays: minBookingDays.value })
-        }
-      )
-      refreshNuxtData()
-    },
-    t('btn.cancel')
+  updateRegistrationStatus(
+    activeReg.value.id,
+    RegistrationStatus.ACTIVE,
+    decisionEmailContent.value.content,
+    {
+      predefinedConditions: conditions.value,
+      ...(customConditions.value && { customConditions: customConditions.value }),
+      ...(minBookingDays.value !== null && { minBookingDays: minBookingDays.value })
+    }
   )
+  refreshNuxtData()
 }
 
 const updateApprovalAction = () => {
-  openConfirmActionModal(
-    t('modal.updateApproval.title'),
-    t('modal.updateApproval.message'),
-    t('btn.updateApproval'),
-    () => {
-      closeConfirmActionModal()
-      updateRegistrationStatus(
-        activeReg.value.id,
-        RegistrationStatus.ACTIVE,
-        decisionEmailContent.value.content,
-        {
-          predefinedConditions: conditions.value,
-          ...(customConditions.value && { customConditions: customConditions.value }),
-          ...(minBookingDays.value !== null && { minBookingDays: minBookingDays.value })
-        }
-      )
-      refreshNuxtData()
-    },
-    t('btn.cancel')
+  updateRegistrationStatus(
+    activeReg.value.id,
+    RegistrationStatus.ACTIVE,
+    decisionEmailContent.value.content,
+    {
+      predefinedConditions: conditions.value,
+      ...(customConditions.value && { customConditions: customConditions.value }),
+      ...(minBookingDays.value !== null && { minBookingDays: minBookingDays.value })
+    }
   )
+  refreshNuxtData()
 }
 
 const cancelRegistrationAction = async () => {
   // validate email form
   if (!await isDecisionEmailValid()) { return }
 
-  openConfirmActionModal(
-    t('modal.cancelRegistration.title'),
-    t('modal.cancelRegistration.message'),
-    t('btn.cancelRegistration'),
-    () => {
-      closeConfirmActionModal()
-      updateRegistrationStatus(
-        activeReg.value.id,
-        RegistrationStatus.CANCELLED,
-        decisionEmailContent.value.content
-      )
-      refreshNuxtData()
-    },
-    t('btn.back')
+  updateRegistrationStatus(
+    activeReg.value.id,
+    RegistrationStatus.CANCELLED,
+    decisionEmailContent.value.content
   )
+  refreshNuxtData()
 }
 
 const suspendRegistrationAction = () => {
-  openConfirmActionModal(
-    t('modal.suspendRegistration.title'),
-    t('modal.suspendRegistration.message'),
-    t('btn.yesSuspend'),
-    () => {
-      closeConfirmActionModal()
-      updateRegistrationStatus(
-        activeReg.value.id,
-        RegistrationStatus.SUSPENDED
-      )
-      refreshNuxtData()
-    },
-    t('btn.cancel')
+  updateRegistrationStatus(
+    activeReg.value.id,
+    RegistrationStatus.SUSPENDED
   )
+  refreshNuxtData()
 }
 
 const reinstateRegistration = () => {
@@ -168,20 +132,12 @@ const sendNoticeAction = async () => {
   // validate email form
   if (!await isDecisionEmailValid()) { return }
 
-  openConfirmActionModal(
-    t('modal.sendNotice.title'),
-    t('modal.sendNotice.message'),
-    t('btn.yesSend'),
-    () => {
-      closeConfirmActionModal()
-      sendNoticeOfConsiderationForRegistration(
-        activeReg.value.id,
-        decisionEmailContent.value.content
-      )
-      decisionEmailContent.value.content = ''
-      refreshNuxtData()
-    }
+  sendNoticeOfConsiderationForRegistration(
+    activeReg.value.id,
+    decisionEmailContent.value.content
   )
+  decisionEmailContent.value.content = ''
+  refreshNuxtData()
 }
 
 const actionButtons: ConnectBtnControlItem[] = [

--- a/strr-examiner-web/app/components/ActionButtons.vue
+++ b/strr-examiner-web/app/components/ActionButtons.vue
@@ -57,7 +57,8 @@ const hasDecisionChanges = computed(() =>
 
 const isApproveDecisionSelected = computed((): boolean => decisionIntent.value === ApplicationActionsE.APPROVE)
 
-const approveRegistrationAction = () => {
+// Shared ACTIVE status update for approve actions
+const applyActiveApprovalStatus = () => {
   updateRegistrationStatus(
     activeReg.value.id,
     RegistrationStatus.ACTIVE,
@@ -71,18 +72,14 @@ const approveRegistrationAction = () => {
   refreshNuxtData()
 }
 
+// Handles first time approval from the main action button
+const approveRegistrationAction = () => {
+  applyActiveApprovalStatus()
+}
+
+// Handles approval updates when a registration is already active
 const updateApprovalAction = () => {
-  updateRegistrationStatus(
-    activeReg.value.id,
-    RegistrationStatus.ACTIVE,
-    decisionEmailContent.value.content,
-    {
-      predefinedConditions: conditions.value,
-      ...(customConditions.value && { customConditions: customConditions.value }),
-      ...(minBookingDays.value !== null && { minBookingDays: minBookingDays.value })
-    }
-  )
-  refreshNuxtData()
+  applyActiveApprovalStatus()
 }
 
 const cancelRegistrationAction = async () => {

--- a/strr-examiner-web/app/pages/examine/[applicationId].vue
+++ b/strr-examiner-web/app/pages/examine/[applicationId].vue
@@ -75,6 +75,8 @@ const handleApplicationAction = (
       ApplicationStatus.PROVISIONAL_REVIEW_NOC_EXPIRED
     ].includes(activeHeader.value?.status)
     additionalArgs = [isProvisional, emailContent.value.content]
+    // validate email form
+    validateFn = async () => await validateForm(emailFormRef.value, true).then(errors => !errors)
   } else if (action === ApplicationActionsE.SET_ASIDE) {
     actionFn = setAsideApplication
   }
@@ -98,43 +100,7 @@ const handleAssigneeAction = (
   buttonIndex: number
 ) => {
   if (isAssignedToUser.value) {
-    if (action === ApplicationActionsE.APPROVE || action === ApplicationActionsE.PROVISIONAL_APPROVE) {
-      openConfirmActionModal(
-        t('modal.approveApplication.title'),
-        t('modal.approveApplication.message'),
-        t('btn.yesApprove'),
-        () => {
-          closeConfirmActionModal() // for smoother UX, close the modal before initiating the action
-          handleApplicationAction(id, action, buttonPosition, buttonIndex)
-        }
-      )
-    } else if (action === ApplicationActionsE.SEND_NOC) {
-      openConfirmActionModal(
-        t('modal.sendNotice.title'),
-        t('modal.sendNotice.message'),
-        t('btn.yesSend'),
-        () => {
-          closeConfirmActionModal() // for smoother UX, close the modal before initiating the action
-          handleApplicationAction(id, action, buttonPosition, buttonIndex)
-        }
-      )
-    } else if (action === ApplicationActionsE.REJECT) {
-      openConfirmActionModal(
-        activeHeader.value?.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING
-          ? t('modal.cancelRegistration.title')
-          : t('modal.rejectApplication.title'),
-        activeHeader.value?.status === ApplicationStatus.PROVISIONAL_REVIEW_NOC_PENDING
-          ? t('modal.cancelRegistration.message')
-          : t('modal.rejectApplication.message'),
-        t('btn.yesRefuse'),
-        () => {
-          closeConfirmActionModal() // for smoother UX, close the modal before initiating the action
-          handleApplicationAction(id, action, buttonPosition, buttonIndex)
-        }
-      )
-    } else {
-      return handleApplicationAction(id, action, buttonPosition, buttonIndex)
-    }
+    return handleApplicationAction(id, action, buttonPosition, buttonIndex)
   } else {
     openConfirmActionModal(
       t('modal.assignError.title'),

--- a/strr-examiner-web/app/pages/registration/[registrationId]/index.vue
+++ b/strr-examiner-web/app/pages/registration/[registrationId]/index.vue
@@ -50,6 +50,8 @@ const handleRegistrationAction = (
   if (action === RegistrationActionsE.CANCEL) {
     actionFn = updateRegistrationStatus
     additionalArgs = [RegistrationStatus.CANCELLED, emailContent.value.content]
+    // validate email form
+    validateFn = async () => await validateForm(emailFormRef.value, true).then(errors => !errors)
   } else if (action === RegistrationActionsE.REINSTATE || action === RegistrationActionsE.APPROVE) {
     actionFn = updateRegistrationStatus
     additionalArgs = [RegistrationStatus.ACTIVE]
@@ -87,18 +89,7 @@ const handleAssigneeAction = (
   buttonIndex: number
 ) => {
   if (isAssignedToUser.value) {
-    if (action === RegistrationActionsE.CANCEL) {
-      openConfirmActionModal(
-        t('modal.cancelRegistration.title'),
-        t('modal.cancelRegistration.message'),
-        t('btn.cancelRegistration'),
-        () => {
-          closeConfirmActionModal()
-          handleRegistrationAction(id, action, buttonPosition, buttonIndex)
-        },
-        t('btn.back')
-      )
-    } else if (action === RegistrationActionsE.REINSTATE) {
+    if (action === RegistrationActionsE.REINSTATE) {
       openConfirmActionModal(
         t('modal.reinstateRegistration.title'),
         t('modal.reinstateRegistration.message'),
@@ -108,38 +99,6 @@ const handleAssigneeAction = (
           handleRegistrationAction(id, action, buttonPosition, buttonIndex)
         },
         t('btn.cancel')
-      )
-    } else if (action === RegistrationActionsE.APPROVE) {
-      openConfirmActionModal(
-        t('modal.approveRegistration.title'),
-        t('modal.approveRegistration.message'),
-        t('btn.yesApprove'),
-        () => {
-          closeConfirmActionModal()
-          handleRegistrationAction(id, action, buttonPosition, buttonIndex)
-        },
-        t('btn.cancel')
-      )
-    } else if (action === RegistrationActionsE.SUSPEND) {
-      openConfirmActionModal(
-        t('modal.suspendRegistration.title'),
-        t('modal.suspendRegistration.message'),
-        t('btn.yesSuspend'),
-        () => {
-          closeConfirmActionModal()
-          handleRegistrationAction(id, action, buttonPosition, buttonIndex)
-        },
-        t('btn.cancel')
-      )
-    } else if (action === RegistrationActionsE.SEND_NOC) {
-      openConfirmActionModal(
-        t('modal.sendNotice.title'),
-        t('modal.sendNotice.message'),
-        t('btn.yesSend'),
-        () => {
-          closeConfirmActionModal()
-          handleRegistrationAction(id, action, buttonPosition, buttonIndex)
-        }
       )
     } else {
       return handleRegistrationAction(id, action, buttonPosition, buttonIndex)

--- a/strr-examiner-web/app/pages/registration/[registrationId]/index.vue
+++ b/strr-examiner-web/app/pages/registration/[registrationId]/index.vue
@@ -89,20 +89,7 @@ const handleAssigneeAction = (
   buttonIndex: number
 ) => {
   if (isAssignedToUser.value) {
-    if (action === RegistrationActionsE.REINSTATE) {
-      openConfirmActionModal(
-        t('modal.reinstateRegistration.title'),
-        t('modal.reinstateRegistration.message'),
-        t('btn.yesReinstate'),
-        () => {
-          closeConfirmActionModal()
-          handleRegistrationAction(id, action, buttonPosition, buttonIndex)
-        },
-        t('btn.cancel')
-      )
-    } else {
-      return handleRegistrationAction(id, action, buttonPosition, buttonIndex)
-    }
+    return handleRegistrationAction(id, action, buttonPosition, buttonIndex)
   } else {
     openConfirmActionModal(
       t('modal.assignError.title'),

--- a/strr-examiner-web/i18n/locales/en-CA.ts
+++ b/strr-examiner-web/i18n/locales/en-CA.ts
@@ -297,7 +297,6 @@ export default {
     declineApplication: 'Refuse Application',
     approveApplication: 'Approve Application',
     setAside: 'Set Aside',
-    yesReinstate: 'Yes, Reinstate',
     yesUpdate: 'Update Approval',
     // examiner decisions buttons
     APPROVE: 'Approve Registration',
@@ -447,10 +446,6 @@ export default {
     unsavedChanges: {
       title: 'Unsaved Changes',
       message: 'Are you sure you want to discard your changes?'
-    },
-    reinstateRegistration: {
-      title: 'Reinstate Registration',
-      message: 'Reinstating the registration will make it valid again. Are you sure you want to continue?'
     }
   },
   table: {

--- a/strr-examiner-web/i18n/locales/en-CA.ts
+++ b/strr-examiner-web/i18n/locales/en-CA.ts
@@ -297,10 +297,6 @@ export default {
     declineApplication: 'Refuse Application',
     approveApplication: 'Approve Application',
     setAside: 'Set Aside',
-    yesApprove: 'Yes, Approve',
-    yesSend: 'Yes, Send',
-    yesRefuse: 'Yes, Refuse',
-    yesSuspend: 'Yes, Suspend',
     yesReinstate: 'Yes, Reinstate',
     yesUpdate: 'Update Approval',
     // examiner decisions buttons
@@ -452,37 +448,9 @@ export default {
       title: 'Unsaved Changes',
       message: 'Are you sure you want to discard your changes?'
     },
-    approveApplication: {
-      title: 'Approve Application',
-      message: 'This action will fully register the short-term rental unit. Are you sure you want to continue?'
-    },
-    sendNotice: {
-      title: 'Send Notice of Consideration',
-      message: 'This action will notify the applicant to provide additional documents. Are you sure you want to continue?'
-    },
-    rejectApplication: {
-      title: 'Refuse Application',
-      message: 'Are you sure you want to refuse the application? This will send an email to the host letting them know their application has been refused.'
-    },
-    cancelRegistration: {
-      title: 'Cancel Registration',
-      message: 'Are you sure you want to cancel the registration? This will send an email to the host letting them know their registration has been cancelled.'
-    },
     reinstateRegistration: {
       title: 'Reinstate Registration',
       message: 'Reinstating the registration will make it valid again. Are you sure you want to continue?'
-    },
-    approveRegistration: {
-      title: 'Approve Registration',
-      message: 'This action will fully register the short-term rental unit. Are you sure you want to continue?'
-    },
-    suspendRegistration: {
-      title: 'Suspend Registration',
-      message: 'Suspending this registration will make it temporarily invalid. You can reinstate it at any time. Do you want to continue?'
-    },
-    updateApproval: {
-      title: 'Are you sure you want to update the approval? ',
-      message: 'This will send an email to the host letting them know about the changes made.'
     }
   },
   table: {

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -50,6 +50,5 @@
     "nuxt": "3.15.4",
     "uuid": "^11.1.0",
     "v-calendar": "^3.1.2"
-  },
-  "packageManager": "pnpm@10.21.0+sha1.a2cb35d3f07a58fecfe050af9277c5dc43a1b2e7"
+  }
 }

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "engines": {
     "node": ">=24"
   },
@@ -50,5 +50,6 @@
     "nuxt": "3.15.4",
     "uuid": "^11.1.0",
     "v-calendar": "^3.1.2"
-  }
+  },
+  "packageManager": "pnpm@10.21.0+sha1.a2cb35d3f07a58fecfe050af9277c5dc43a1b2e7"
 }

--- a/strr-examiner-web/tests/unit/action-buttons.spec.ts
+++ b/strr-examiner-web/tests/unit/action-buttons.spec.ts
@@ -61,9 +61,6 @@ const mount = () => mountSuspended(ActionButtons, { global: { plugins: [enI18n] 
 const clickMainButton = (wrapper: any) =>
   wrapper.find('[data-testid="main-action-button"]').trigger('click')
 
-// Get confirmHandler action, from openConfirmActionModal (confirmHandler is at position 3)
-const getConfirmCallback = () => mockOpenConfirmActionModal.mock.lastCall!.at(3) as () => void
-
 describe('ActionButtons Component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -209,7 +206,7 @@ describe('ActionButtons Component', () => {
     expect(mockUnassignRegistration).not.toHaveBeenCalled()
   })
 
-  it('should open confirm modal for APPROVE decision on an active registration', async () => {
+  it('should update registration status with ACTIVE immediately when approve is clicked', async () => {
     activeReg.value = {
       ...activeReg.value,
       status: RegistrationStatus.ACTIVE,
@@ -223,10 +220,17 @@ describe('ActionButtons Component', () => {
     await clickMainButton(wrapper)
     await flushPromises()
 
-    expect(mockOpenConfirmActionModal).toHaveBeenCalledOnce()
+    expect(mockOpenConfirmActionModal).not.toHaveBeenCalled()
+    expect(mockUpdateRegistrationStatus).toHaveBeenCalledOnce()
+    expect(mockUpdateRegistrationStatus).toHaveBeenCalledWith(
+      'reg-123',
+      RegistrationStatus.ACTIVE,
+      '',
+      { predefinedConditions: conditions.value }
+    )
   })
 
-  it('should update registration status with CANCELLED when cancel confirm is clicked', async () => {
+  it('should update registration status with CANCELLED directly when cancel is clicked', async () => {
     decisionIntent.value = RegistrationActionsE.CANCEL
     decisionEmailContent.value = { content: 'cancellation notice' }
 
@@ -236,11 +240,7 @@ describe('ActionButtons Component', () => {
     await clickMainButton(wrapper)
     await flushPromises()
 
-    expect(mockOpenConfirmActionModal).toHaveBeenCalledOnce()
-
-    getConfirmCallback()()
-    await flushPromises()
-
+    expect(mockOpenConfirmActionModal).not.toHaveBeenCalled()
     expect(mockUpdateRegistrationStatus).toHaveBeenCalledOnce()
     expect(mockUpdateRegistrationStatus).toHaveBeenCalledWith(
       'reg-123',
@@ -249,7 +249,7 @@ describe('ActionButtons Component', () => {
     )
   })
 
-  it('should update registration status with ACTIVE when approve confirm is clicked', async () => {
+  it('should update registration status with ACTIVE when approve is clicked', async () => {
     activeReg.value = {
       ...activeReg.value,
       status: RegistrationStatus.CANCELLED,
@@ -266,17 +266,7 @@ describe('ActionButtons Component', () => {
     await clickMainButton(wrapper)
     await flushPromises()
 
-    expect(mockOpenConfirmActionModal).toHaveBeenCalledWith(
-      expect.stringContaining('Approve'),
-      expect.any(String),
-      expect.stringContaining('Approve'),
-      expect.any(Function),
-      expect.any(String)
-    )
-
-    getConfirmCallback()()
-    await flushPromises()
-
+    expect(mockOpenConfirmActionModal).not.toHaveBeenCalled()
     expect(mockUpdateRegistrationStatus).toHaveBeenCalledOnce()
     expect(mockUpdateRegistrationStatus).toHaveBeenCalledWith(
       'reg-123',
@@ -286,7 +276,7 @@ describe('ActionButtons Component', () => {
     )
   })
 
-  it('should send notice and clear content when send notice confirm is clicked', async () => {
+  it('should send notice and clear content directly when send notice is clicked', async () => {
     decisionIntent.value = ApplicationActionsE.SEND_NOC
     decisionEmailContent.value = { content: 'notice of consideration body' }
 
@@ -297,16 +287,7 @@ describe('ActionButtons Component', () => {
     await clickMainButton(wrapper)
     await flushPromises()
 
-    expect(mockOpenConfirmActionModal).toHaveBeenCalledWith(
-      expect.stringContaining('Notice'),
-      expect.any(String),
-      expect.stringContaining('Send'),
-      expect.any(Function)
-    )
-
-    getConfirmCallback()()
-    await flushPromises()
-
+    expect(mockOpenConfirmActionModal).not.toHaveBeenCalled()
     expect(mockSendNotice).toHaveBeenCalledOnce()
     expect(mockSendNotice).toHaveBeenCalledWith('reg-123', 'notice of consideration body')
     expect(decisionEmailContent.value.content).toBe('')


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1142

*Description of changes:*
- Removed confirmation dialogue boxes from:
  - Approvals
  - Sending NOCs
  - Cancelling
  - Suspending

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
