### PR TITLE
feat(api): 1525 let examiners update address of expired regs

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.16"
+version = "0.3.17"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -71,7 +71,10 @@ from strr_api.models.dataclass import RegistrationSearch
 from strr_api.responses import Events
 from strr_api.schemas.utils import validate
 from strr_api.services import DocumentService, EventsService, RegistrationService, SnapshotService, UserService
-from strr_api.services.registration_service import REGISTRATION_STATES_STAFF_ACTION
+from strr_api.services.registration_service import (
+    REGISTRATION_STATES_STAFF_ACTION,
+    REGISTRATION_STATES_STAFF_ASSIGNABLE,
+)
 from strr_api.validators.DocumentUploadValidator import validate_document_upload
 
 logger = logging.getLogger("api")
@@ -635,12 +638,12 @@ def update_registration_unit_address(registration_id):
         registration = RegistrationService.get_registration_by_id(registration_id)
         if not registration:
             return error_response(http_status=HTTPStatus.NOT_FOUND, message=ErrorMessage.REGISTRATION_NOT_FOUND.value)
-        if (
-            registration.registration_type != RegistrationType.HOST.value
-            or registration.status != RegistrationStatus.ACTIVE
+        if registration.registration_type != RegistrationType.HOST.value or registration.status not in (
+            RegistrationStatus.ACTIVE,
+            RegistrationStatus.EXPIRED,
         ):
             return error_response(
-                message="Unit address update is only allowed for active Host type registrations",
+                message="Unit address update is only allowed for active or expired Host type registrations",
                 http_status=HTTPStatus.BAD_REQUEST,
             )
         registration = RegistrationService.update_host_unit_address(registration, unit_address, user)
@@ -885,7 +888,7 @@ def assign_registration(registration_id):
         registration = RegistrationService.get_registration_by_id(registration_id)
         if not registration:
             return error_response(http_status=HTTPStatus.NOT_FOUND, message=ErrorMessage.REGISTRATION_NOT_FOUND.value)
-        if registration.status.value not in REGISTRATION_STATES_STAFF_ACTION:
+        if registration.status.value not in REGISTRATION_STATES_STAFF_ASSIGNABLE:
             return error_response(
                 message="Registration status does not allow assignment",
                 http_status=HTTPStatus.BAD_REQUEST,
@@ -933,7 +936,7 @@ def unassign_registration(registration_id):
         registration = RegistrationService.get_registration_by_id(registration_id)
         if not registration:
             return error_response(http_status=HTTPStatus.NOT_FOUND, message=ErrorMessage.REGISTRATION_NOT_FOUND.value)
-        if registration.status.value not in REGISTRATION_STATES_STAFF_ACTION:
+        if registration.status.value not in REGISTRATION_STATES_STAFF_ASSIGNABLE:
             return error_response(
                 message="Registration status does not allow assignment changes",
                 http_status=HTTPStatus.BAD_REQUEST,

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -889,7 +889,9 @@ class RegistrationService:
             registration.save()
             event_details = previous_address_details
             if jurisdiction_update_warning:
-                event_details = f"{previous_address_details}; Jurisdiction lookup warning: {jurisdiction_update_warning}"
+                event_details = (
+                    f"{previous_address_details}; Jurisdiction lookup warning: {jurisdiction_update_warning}"
+                )
             EventsService.save_event(
                 event_type=Events.EventType.REGISTRATION,
                 event_name=Events.EventName.HOST_REGISTRATION_UNIT_ADDRESS_UPDATED,

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -94,6 +94,16 @@ REGISTRATION_STATES_STAFF_ACTION = [
     RegistrationStatus.CANCELLED.value,
 ]
 
+# Registration statuses where an examiner is allowed to assign/unassign themselves
+# and update the STR unit address. EXPIRED is included so that staff can still
+# intervene on expired registrations (correct an address to unblock renewals).
+REGISTRATION_STATES_STAFF_ASSIGNABLE = [
+    RegistrationStatus.ACTIVE.value,
+    RegistrationStatus.SUSPENDED.value,
+    RegistrationStatus.CANCELLED.value,
+    RegistrationStatus.EXPIRED.value,
+]
+
 
 class RegistrationService:
     """Service to save and load registration details from the database."""
@@ -864,15 +874,29 @@ class RegistrationService:
                     update_applied = True
 
         if update_applied:
+            jurisdiction_update_warning = None
             address_obj.save()
             if not jurisdiction_provided:
-                RegistrationService._update_jurisdiction_for_address(registration)
+                try:
+                    RegistrationService._update_jurisdiction_for_address(registration)
+                except JurisdictionUpdateException as exception:
+                    jurisdiction_update_warning = exception.message
+                    logger.warning(
+                        "Address updated for registration %s but jurisdiction lookup failed: %s",
+                        registration.id,
+                        exception.message,
+                    )
             registration.save()
+            event_details = previous_address_details
+            if jurisdiction_update_warning:
+                event_details = (
+                    f"{previous_address_details}; " f"Jurisdiction lookup warning: {jurisdiction_update_warning}"
+                )
             EventsService.save_event(
                 event_type=Events.EventType.REGISTRATION,
                 event_name=Events.EventName.HOST_REGISTRATION_UNIT_ADDRESS_UPDATED,
                 registration_id=registration.id,
-                details=previous_address_details,
+                details=event_details,
                 user_id=user.id,
                 visible_to_applicant=True,
             )

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -889,9 +889,7 @@ class RegistrationService:
             registration.save()
             event_details = previous_address_details
             if jurisdiction_update_warning:
-                event_details = (
-                    f"{previous_address_details}; " f"Jurisdiction lookup warning: {jurisdiction_update_warning}"
-                )
+                event_details = f"{previous_address_details}; Jurisdiction lookup warning: {jurisdiction_update_warning}"
             EventsService.save_event(
                 event_type=Events.EventType.REGISTRATION,
                 event_name=Events.EventName.HOST_REGISTRATION_UNIT_ADDRESS_UPDATED,

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -841,10 +841,74 @@ def test_update_registration_str_address(mock_get_str_data, app, session, client
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
 @patch(
+    "strr_api.services.approval_service.ApprovalService.getSTRDataForAddress",
+    return_value={"organizationNm": "Test Municipality"},
+)
+def test_update_registration_str_address_expired(mock_get_str_data, app, session, client, jwt):
+    """Staff should be able to update the STR address on an expired host registration."""
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        json_data = json.load(f)
+        rv = client.post("/applications", json=json_data, headers=headers)
+        response_json = rv.json
+        application_number = response_json.get("header").get("applicationNumber")
+
+        application = Application.find_by_application_number(application_number=application_number)
+        application.payment_status = PaymentStatus.COMPLETED.value
+        application.status = Application.Status.FULL_REVIEW
+        application.save()
+
+        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
+        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        registration_id = response_json.get("header").get("registrationId")
+
+        # Expire the registration
+        registration = Registration.query.filter_by(id=registration_id).one_or_none()
+        registration.status = RegistrationStatus.EXPIRED
+        registration.save()
+
+        # Examiner can still assign themselves to an expired registration
+        rv = client.put(f"/registrations/{registration_id}/assign", headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+
+        valid_updated_address = {
+            "unitAddress": {
+                "unitNumber": "1",
+                "streetNumber": "66211",
+                "streetName": "COTTONWOOD DR",
+                "city": "MAPLE RIDGE",
+                "postalCode": "V2X 3L8",
+                "province": "BC",
+                "locationDescription": "Located at the corner of Cottonwood Dr and 119 Ave",
+            }
+        }
+        rv = client.patch(
+            f"/registrations/{registration_id}/str-address", json=valid_updated_address, headers=staff_headers
+        )
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        updated_addr_response = response_json.get("unitAddress")
+        assert updated_addr_response.get("streetNumber") == "66211"
+        assert updated_addr_response.get("streetName") == "COTTONWOOD DR"
+        assert updated_addr_response.get("unitNumber") == "1"
+        assert updated_addr_response.get("city") == "MAPLE RIDGE"
+        assert updated_addr_response.get("postalCode") == "V2X 3L8"
+        # Status should remain EXPIRED after the address update
+        assert response_json.get("status") == RegistrationStatus.EXPIRED.name
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+@patch(
     "strr_api.services.approval_service.ApprovalService.getSTRDataForAddress", side_effect=Exception("Service error")
 )
 def test_update_registration_str_address_service_error_with_jurisdiction(mock_get_str_data, app, session, client, jwt):
-    """Test updating STR address when getSTRDataForAddress returns an error."""
+    """Address updates should succeed even if jurisdiction lookup errors."""
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
         headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
         headers["Account-Id"] = ACCOUNT_ID
@@ -882,15 +946,17 @@ def test_update_registration_str_address_service_error_with_jurisdiction(mock_ge
         rv = client.patch(
             f"/registrations/{registration_id}/str-address", json=valid_updated_address, headers=staff_headers
         )
-        assert HTTPStatus.UNPROCESSABLE_ENTITY == rv.status_code
+        assert HTTPStatus.OK == rv.status_code
         response_json = rv.json
-        assert "Error updating jurisdiction" in response_json.get("message", "")
+        updated_addr_response = response_json.get("unitAddress")
+        assert updated_addr_response.get("streetNumber") == "66211"
+        assert updated_addr_response.get("streetName") == "COTTONWOOD DR"
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
 @patch("strr_api.services.approval_service.ApprovalService.getSTRDataForAddress", return_value={"organizationNm": ""})
 def test_update_registration_str_address_empty_jurisdiction(mock_get_str_data, app, session, client, jwt):
-    """Test updating STR address when getSTRDataForAddress returns empty jurisdiction."""
+    """Address updates should succeed even when lookup returns no jurisdiction."""
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
         headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
         headers["Account-Id"] = ACCOUNT_ID
@@ -928,9 +994,11 @@ def test_update_registration_str_address_empty_jurisdiction(mock_get_str_data, a
         rv = client.patch(
             f"/registrations/{registration_id}/str-address", json=valid_updated_address, headers=staff_headers
         )
-        assert HTTPStatus.UNPROCESSABLE_ENTITY == rv.status_code
+        assert HTTPStatus.OK == rv.status_code
         response_json = rv.json
-        assert "No jurisdiction found for address" in response_json.get("message", "")
+        updated_addr_response = response_json.get("unitAddress")
+        assert updated_addr_response.get("streetNumber") == "66211"
+        assert updated_addr_response.get("streetName") == "COTTONWOOD DR"
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
@@ -1443,15 +1511,21 @@ def test_assign_and_unassign_registration(app, session, client, jwt):
         response_json = rv.json
         assert response_json.get("header").get("assignee") == {}
 
+        # Expired registrations should still allow examiners to assign/unassign
+        # so staff can intervene (e.g. correct STR address) after expiry.
         registration = Registration.query.filter_by(id=registration_id).one_or_none()
         registration.status = RegistrationStatus.EXPIRED
         registration.save()
 
         rv = client.put(f"/registrations/{registration_id}/assign", headers=staff_headers)
-        assert HTTPStatus.BAD_REQUEST == rv.status_code
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        assert response_json.get("header").get("assignee").get("username") is not None
 
         rv = client.put(f"/registrations/{registration_id}/unassign", headers=staff_headers)
-        assert HTTPStatus.BAD_REQUEST == rv.status_code
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        assert response_json.get("header").get("assignee") == {}
 
         non_existent_reg_id = 999999
         rv = client.put(f"/registrations/{non_existent_reg_id}/assign", headers=staff_headers)


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1525

*Description of changes:*
One the registration expires, still allow staff to assign the registration and edit the STR address

Expired registrations:
- Now examiners can unassign, assign them
- Press the edit button of the address and change the address

<img width="1785" height="1116" alt="image" src="https://github.com/user-attachments/assets/4622f841-d147-4509-83b6-cf3ab10883a9" />

<img width="496" height="417" alt="image" src="https://github.com/user-attachments/assets/73f52dd1-26b6-43f2-a671-b4c3c637b0fb" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
