### PR TITLE
test(e2e): 1556 setup and configure e2e tests in examiner app

### DIFF
--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -626,14 +626,14 @@ async function handleRowSelect (row: any) {
   if (row.id) {
     regStatus.value = 'pending'
     const currentTab = isApplicationTab.value ? 'applications' : 'registrations'
-    await navigateTo(localePath(`${RoutesE.REGISTRATION}/${row.id}?returnTab=${currentTab}`))
+    await navigateTo(`${localePath(`${RoutesE.REGISTRATION}/${row.id}`)}?returnTab=${currentTab}`)
   }
 }
 
 async function goToRegistration (registrationId: string) {
   regStatus.value = 'pending'
   const currentTab = isApplicationTab.value ? 'applications' : 'registrations'
-  await navigateTo(localePath(`${RoutesE.REGISTRATION}/${registrationId}?returnTab=${currentTab}`))
+  await navigateTo(`${localePath(`${RoutesE.REGISTRATION}/${registrationId}`)}?returnTab=${currentTab}`)
 }
 
 function handleColumnSort (column: string) {
@@ -745,6 +745,7 @@ const updateTabQuery = (isApp: boolean) => {
 const tabLinks = computed(() => [
   {
     label: t('label.newApplicationsTab'),
+    'data-testid': 'tab-applications',
     click: () => {
       isApplicationTab.value = true
       updateTabQuery(true)
@@ -753,6 +754,7 @@ const tabLinks = computed(() => [
   },
   {
     label: t('label.registrationsAndRenewalsTab'),
+    'data-testid': 'tab-registrations',
     click: () => {
       isApplicationTab.value = false
       updateTabQuery(false)
@@ -786,7 +788,10 @@ const tabLinks = computed(() => [
       :aria-label="$t('label.applicationListSectionAria', { count: applicationOrRegistrationList?.total || 0 })"
     >
       <template #header>
-        <div class="flex flex-wrap items-center justify-between gap-3 text-gray-900">
+        <div
+          class="flex flex-wrap items-center justify-between gap-3 text-gray-900"
+          data-testid="applications-table-header"
+        >
           <div class="flex flex-wrap items-center gap-3">
             <UInput
               v-model="exStore.tableFilters.searchText"
@@ -796,6 +801,7 @@ const tabLinks = computed(() => [
               size="sm"
               trailing
               icon="i-mdi-search"
+              data-testid="dashboard-search-input"
               :ui="{
                 icon: {
                   base: 'text-bcGovColor-activeBlue',
@@ -818,6 +824,7 @@ const tabLinks = computed(() => [
               variant="link"
               :padded="false"
               :ui="{ gap: { sm: 'gap-x-1' } }"
+              data-testid="clear-filters-button"
               @click="exStore.resetFilters()"
             />
           </div>

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -18,8 +18,8 @@
     "test": "vitest --dir tests/unit --passWithNoTests --coverage && cp ./tests/coverage/clover.xml ./coverage.xml",
     "test:unit": "vitest --dir tests/unit",
     "test:unit:cov": "vitest run --dir tests/unit --coverage",
-    "test:e2e": "npx playwright test",
-    "test:e2e:ui": "npx playwright test --ui"
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.9.1",

--- a/strr-examiner-web/playwright.config.ts
+++ b/strr-examiner-web/playwright.config.ts
@@ -1,15 +1,14 @@
-import { defineConfig, devices } from '@playwright/test';
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import path, { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import dotenv from 'dotenv'
+import { defineConfig, devices } from '@playwright/test'
 
-//manually build the path (workaround with node.js)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+// manually build the path (workaround with node.js)
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 // Load environment variables from .env file
-dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '.env') })
 
 export default defineConfig({
   testDir: './tests/e2e/', // Specifies the directory where your test files are located
@@ -18,23 +17,31 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0, // Number of retries on CI
   workers: process.env.CI ? 1 : undefined, // Number of workers on CI
   reporter: 'html', // Use the 'html' reporter
+  globalSetup: './tests/e2e/test-utils/global-setup',
+  // automatically starts the dev server before tests and tears it down after
+  webServer: {
+    command: 'pnpm dev', // start the dev server before tests run
+    url: process.env.NUXT_BASE_URL ?? 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI, // reuse dev server locally (start new one in CI)
+    timeout: 120_000
+  },
   use: {
-    //baseURL: process.env.BASE_URL, // Use the BASE_URL from the .env file
     baseURL: process.env.NUXT_BASE_URL,
     trace: 'on-first-retry',
+    storageState: './tests/e2e/.auth/idir-user.json' // load saved IDIR session so tests start pre-authenticated
   },
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'] }
     },
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: { ...devices['Desktop Firefox'] }
     },
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-  ],
-});
+      use: { ...devices['Desktop Safari'] }
+    }
+  ]
+})

--- a/strr-examiner-web/playwright.config.ts
+++ b/strr-examiner-web/playwright.config.ts
@@ -1,5 +1,5 @@
-import path, { dirname } from 'path'
-import { fileURLToPath } from 'url'
+import path, { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import { defineConfig, devices } from '@playwright/test'
 

--- a/strr-examiner-web/tests/e2e/test-1.spec.ts
+++ b/strr-examiner-web/tests/e2e/test-1.spec.ts
@@ -1,17 +1,12 @@
 import { test, expect } from '@playwright/test'
 
-// The test block defines a single test case
 test('Check for newly added host app', async ({ page }) => {
-  await page.goto('/') // The '/' is relative to the `baseURL` specified in the PW config
+  await page.goto('/en-CA/dashboard')
 
-  // login
-  await page.getByRole('button', { name: 'Continue with IDIR' }).click()
-  await page.locator('#user').fill(process.env.PLAYWRIGHT_TEST_USERNAME!)
-  await page.getByRole('textbox', { name: 'Password' }).fill(process.env.PLAYWRIGHT_TEST_PASSWORD!)
-  await page.getByRole('button', { name: 'Continue' }).click()
+  // verify we landed on the examiner dashboard page (allow time for auth redirect + data load)
+  await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+  await expect(page.getByTestId('applications-table')).toBeVisible({ timeout: 30000 })
 
-  // check examiner dashboard has our test registration
-  await expect(page.getByRole('heading')).toContainText('Search')
-  await expect(page.getByRole('textbox', { name: 'Find in application...' })).toBeVisible()
-  await expect(page.locator('tbody')).toContainText('31333398143962')
+  // verify the test registration is present in the table
+  await expect(page.getByTestId('applications-table').locator('tbody')).toContainText('31333398143962')
 })

--- a/strr-examiner-web/tests/e2e/test-1.spec.ts
+++ b/strr-examiner-web/tests/e2e/test-1.spec.ts
@@ -1,12 +1,74 @@
 import { test, expect } from '@playwright/test'
 
-test('Check for newly added host app', async ({ page }) => {
-  await page.goto('/en-CA/dashboard')
+const DASHBOARD_URL = '/en-CA/dashboard'
 
-  // verify we landed on the examiner dashboard page (allow time for auth redirect + data load)
-  await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
-  await expect(page.getByTestId('applications-table')).toBeVisible({ timeout: 30000 })
+test.describe('Examiner Dashboard', () => {
+  test('load the page with tabs, table and its components', async ({ page }) => {
+    await page.goto(DASHBOARD_URL)
 
-  // verify the test registration is present in the table
-  await expect(page.getByTestId('applications-table').locator('tbody')).toContainText('31333398143962')
+    await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByTestId('application-and-registrations-tabs')).toBeVisible()
+    await expect(page.getByTestId('applications-table-header')).toBeVisible()
+
+    const table = page.getByTestId('applications-table')
+    await expect(table.locator('tbody tr').first()).toBeVisible({ timeout: 15000 })
+    await expect(table.locator('thead th')).toHaveCount(8)
+
+    await expect(page.getByTestId('dashboard-search-input')).toBeVisible()
+    await expect(page.getByTestId('clear-filters-button')).toBeVisible()
+  })
+
+  test('switching tab should update url and columns', async ({ page }) => {
+    await page.goto(DASHBOARD_URL)
+    await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByTestId('applications-table').locator('tbody tr').first()).toBeVisible({ timeout: 15000 })
+
+    // switch to registrations tab and verify urls and columns
+    await page.getByTestId('tab-registrations').click()
+
+    await expect(page).toHaveURL(/tab=registrations/)
+    const table = page.getByTestId('applications-table')
+    await expect(table.locator('thead th')).toHaveCount(9, { timeout: 10000 })
+
+    // reload with registrations tab and verify url and columns
+    await page.goto(`${DASHBOARD_URL}?returnTab=registrations`)
+    await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+    await expect(table.locator('thead th')).toHaveCount(9, { timeout: 10000 })
+    await expect(page).toHaveURL(/tab=registrations/)
+    await expect(page).not.toHaveURL(/returnTab=/)
+  })
+
+  test('registration row click should navigate to registration page', async ({ page }) => {
+    await page.goto(`${DASHBOARD_URL}?tab=registrations`)
+    await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+
+    const table = page.getByTestId('applications-table')
+    // click first registration row and verify navigation to registration url
+    await expect(table.locator('tbody tr').first()).toBeVisible({ timeout: 15000 })
+    await table.locator('tbody tr').first().click()
+    await expect(page).toHaveURL(/\/registration\/\d+/, { timeout: 15000 })
+  })
+
+  test('application row click should navigate to application page', async ({ page }) => {
+    await page.goto(DASHBOARD_URL)
+    await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+
+    const table = page.getByTestId('applications-table')
+    // click first application row and verify navigation to examine url
+    await expect(table.locator('tbody tr').first()).toBeVisible({ timeout: 15000 })
+    await table.locator('tbody tr').first().click()
+    await expect(page).toHaveURL(/\/examine\//, { timeout: 15000 })
+  })
+
+  test('clear all filters button', async ({ page }) => {
+    await page.goto(DASHBOARD_URL)
+    await expect(page.getByTestId('examiner-dashboard-page')).toBeVisible({ timeout: 30000 })
+
+    // type in search, then clear and verify
+    const searchInput = page.getByTestId('dashboard-search-input')
+    await searchInput.fill('abc')
+    await expect(searchInput).toHaveValue('abc')
+    await page.getByTestId('clear-filters-button').click()
+    await expect(searchInput).toHaveValue('')
+  })
 })

--- a/strr-examiner-web/tests/e2e/test-utils/global-setup.ts
+++ b/strr-examiner-web/tests/e2e/test-utils/global-setup.ts
@@ -5,34 +5,9 @@ import { authSetup } from './auth-setup'
 // load default env
 dotenvConfig()
 
-// checks if site is available before running setup
-async function isServerReady (url: string, timeout: number = 30000): Promise<boolean> {
-  const startTime = Date.now()
-  while (Date.now() - startTime < timeout) { // loop until timeout is reached
-    try {
-      const response = await fetch(url) // try to ping site
-      // return true if site is ready
-      if (response.ok) {
-        return true
-      }
-    } catch {
-      // not ready yet
-    }
-    await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1sec between fetches
-  }
-  return false // return false if reached timeout and no site is loaded
-}
-
+// runs once before all tests: performs login and saves the browser session to tests/e2e/.auth/
+// server should be running because of playwright's webServer config
 async function globalSetup () {
-  const baseUrl = process.env.NUXT_BASE_URL!
-
-  console.info('Waiting for the server to be ready...')
-  // make sure app is available
-  const serverReady = await isServerReady(baseUrl)
-  if (!serverReady) {
-    throw new Error(`Server at ${baseUrl} did not become ready within the timeout period.`)
-  }
-
   await Promise.all([
     authSetup(
       LoginSource.IDIR,


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1556

*Description of changes:*
- setup and configure e2e tests in the Examiner app
- run command `pnpm test:e2e` will start a local dev server (if not running yet) and run the e2e tests

<img width="2142" height="724" alt="Screenshot 2026-04-23 at 08 21 05" src="https://github.com/user-attachments/assets/fb80ff03-230d-4cc8-b174-f1aba9feb7d7" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
