### PR TITLE
tests(e2e): add tests for Examiner Application Details page

### DIFF
--- a/strr-examiner-web/app/components/ExaminerErrorState.vue
+++ b/strr-examiner-web/app/components/ExaminerErrorState.vue
@@ -12,7 +12,7 @@ defineProps<{
 </script>
 
 <template>
-  <div class="m-auto flex max-w-screen-sm flex-col">
+  <div class="m-auto flex max-w-screen-sm flex-col" data-testid="examiner-error-state">
     <ConnectPageSection
       :heading="{
         label: `Error Fetching ${itemType}`,

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/e2e/test-2.spec.ts
+++ b/strr-examiner-web/tests/e2e/test-2.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const DASHBOARD_URL = '/en-CA/dashboard'
+
+async function navigateToFirstApplication (page: Page) {
+  await page.goto(DASHBOARD_URL)
+  const table = page.getByTestId('applications-table')
+  await expect(table.locator('tbody tr').first()).toBeVisible({ timeout: 15000 })
+  await table.locator('tbody tr').first().click()
+  await expect(page).toHaveURL(/\/examine\//, { timeout: 15000 })
+}
+
+test.describe('Application Details Page', () => {
+  test('load the page with all components visible', async ({ page }) => {
+    await navigateToFirstApplication(page)
+
+    // ApplicationInfoHeader
+    await expect(page.getByTestId('application-number')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByTestId('application-name')).toBeVisible()
+    await expect(page.getByTestId('application-status-badge')).toBeVisible()
+    await expect(page.getByTestId('view-receipt-button')).toBeVisible()
+    await expect(page.getByTestId('toggle-history-btn')).toBeVisible()
+
+    // HostSubHeader
+    await expect(page.getByTestId('host-sub-header')).toBeVisible()
+    await expect(page.getByTestId('edit-rental-unit-button')).toBeVisible()
+
+    // HostSupportingInfo
+    await expect(page.getByTestId('business-lic-section')).toBeVisible()
+    await expect(page.getByTestId('pr-req-section')).toBeVisible()
+
+    // Applications always render ConnectButtonControl, not ActionButtons
+    await expect(page.getByTestId('button-control')).toBeVisible()
+  })
+
+  test('toggle filing history shows and hides history table', async ({ page }) => {
+    await navigateToFirstApplication(page)
+    await expect(page.getByTestId('application-number')).toBeVisible({ timeout: 30000 })
+
+    await page.getByTestId('toggle-history-btn').click()
+    await expect(page.getByTestId('history-table')).toBeVisible({ timeout: 10000 })
+
+    await page.getByTestId('toggle-history-btn').click()
+    await expect(page.getByTestId('history-table')).not.toBeVisible()
+  })
+
+  test('action buttons are rendered in the button control', async ({ page }) => {
+    await navigateToFirstApplication(page)
+    await expect(page.getByTestId('application-number')).toBeVisible({ timeout: 30000 })
+
+    // Applications always render ConnectButtonControl, not ActionButtons
+    await expect(page.getByTestId('button-control')).toBeVisible()
+    await expect(page.getByTestId('main-action-button')).not.toBeVisible()
+    const assignBtn = page.getByTestId('action-button-assign')
+    const unassignBtn = page.getByTestId('action-button-unassign')
+    await expect(assignBtn.or(unassignBtn)).not.toBeVisible()
+  })
+
+  test('error state shown for non-existent application ID', async ({ page }) => {
+    await page.goto('/en-CA/examine/0000000000000000')
+
+    await expect(page.getByTestId('examiner-error-state')).toBeVisible({ timeout: 30000 })
+    await expect(page.getByTestId('application-number')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1578

*Description of changes:*
- add tests for Examiner Application Details page

<img width="1132" height="150" alt="Screenshot 2026-05-01 at 14 32 14" src="https://github.com/user-attachments/assets/9f8177dd-b354-4d5c-89b6-b375e703edd6" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
