### PR TITLE
fix(ui): 1604 show action buttons for strata hotel renewal applications

### DIFF
--- a/strr-examiner-web/app/layouts/examine.vue
+++ b/strr-examiner-web/app/layouts/examine.vue
@@ -11,7 +11,7 @@ const isStrataHotelRenewalApplication = computed(() => {
   const header = activeHeader.value as { applicationType?: string } | undefined
   return isApplication.value &&
     hasRegistrationNumber.value &&
-    activeReg.value?.registrationType === 'STRATA_HOTEL' &&
+    activeReg.value?.registrationType === ApplicationType.STRATA_HOTEL &&
     header?.applicationType === 'renewal'
 })
 

--- a/strr-examiner-web/app/layouts/examine.vue
+++ b/strr-examiner-web/app/layouts/examine.vue
@@ -2,9 +2,23 @@
 const { isAuthenticated } = useKeycloak()
 const headerOptions = useAppConfig().connect.core.header.options
 const localePath = useLocalePath()
-const { isApplication, hasRegistrationNumber } = storeToRefs(useExaminerStore())
+const { isApplication, hasRegistrationNumber, activeReg, activeHeader } = storeToRefs(useExaminerStore())
 const { isExaminerDecisionsEnabled } = useExaminerFeatureFlags()
 const { isSnapshotRoute } = useExaminerRoute()
+
+/* show the bottom action buttons for strata hotel renewal applications */
+const isStrataHotelRenewalApplication = computed(() => {
+  const header = activeHeader.value as { applicationType?: string } | undefined
+  return isApplication.value &&
+    hasRegistrationNumber.value &&
+    activeReg.value?.registrationType === 'STRATA_HOTEL' &&
+    header?.applicationType === 'renewal'
+})
+
+/* hide the bottom action buttons for other applications */
+const shouldHideBottomActions = computed(() => {
+  return isApplication.value && hasRegistrationNumber.value && !isStrataHotelRenewalApplication.value
+})
 
 </script>
 <template>
@@ -47,7 +61,7 @@ const { isSnapshotRoute } = useExaminerRoute()
         </p>
       </template>
     </NuxtErrorBoundary>
-    <template v-if="!(isApplication && hasRegistrationNumber)">
+    <template v-if="!shouldHideBottomActions">
       <ConnectButtonControl v-if="!isExaminerDecisionsEnabled || isApplication" />
       <ActionButtons v-else-if="isExaminerDecisionsEnabled && !isSnapshotRoute" />
     </template>

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.39",
+  "version": "0.2.39a",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/mocks/mockedData.ts
+++ b/strr-examiner-web/tests/mocks/mockedData.ts
@@ -344,6 +344,15 @@ export const mockHostApplicationWithoutRegistrationNumber: HostApplicationResp =
   }
 }
 
+export const mockStrataRenewalApplicationWithRegistrationNumber: StrataApplicationResp = {
+  ...mockStrataApplication,
+  header: {
+    ...mockStrataApplication.header,
+    applicationType: 'renewal',
+    registrationNumber: 'REG54321876'
+  }
+}
+
 export const mockApplications: ApiApplicationBaseResp [] = [
   mockHostApplication,
   mockStrataApplication,

--- a/strr-examiner-web/tests/unit/examine-layout.spec.ts
+++ b/strr-examiner-web/tests/unit/examine-layout.spec.ts
@@ -2,7 +2,12 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { nextTick } from 'vue'
 
-import { mockProvisionalReviewApplication, mockFullReviewApplication, mockHostRegistration } from '../mocks/mockedData'
+import {
+  mockProvisionalReviewApplication,
+  mockFullReviewApplication,
+  mockHostRegistration,
+  mockStrataRenewalApplicationWithRegistrationNumber
+} from '../mocks/mockedData'
 import { enI18n } from '../mocks/i18n'
 import ExamineLayout from '~/layouts/examine.vue'
 import { ActionButtons, ConnectButtonControl } from '#components'
@@ -55,6 +60,14 @@ describe('Examine Layout', () => {
 
   it('should show ConnectButtonControl for Applications in Full Review', async () => {
     store.activeRecord = mockFullReviewApplication
+    await nextTick()
+
+    expect(wrapper.findComponent(ConnectButtonControl).exists()).toBe(true)
+    expect(wrapper.findComponent(ActionButtons).exists()).toBe(false)
+  })
+
+  it('should show ConnectButtonControl for strata hotel renewal applications with registration number', async () => {
+    store.activeRecord = mockStrataRenewalApplicationWithRegistrationNumber
     await nextTick()
 
     expect(wrapper.findComponent(ConnectButtonControl).exists()).toBe(true)


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1604

*Description of changes:*
In DEV, this is the issue:
<img width="1956" height="1228" alt="image" src="https://github.com/user-attachments/assets/267a6a5c-be68-44f8-a5ae-9e49fdf4cf9b" />

A strata hotel renewal has no action buttons. It's stuck.

Now, in local:
<img width="1816" height="1148" alt="image" src="https://github.com/user-attachments/assets/cf7f13b7-1b1e-4516-81be-6e1b3c34eca3" />

We can actually see the buttons.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
