### PR TITLE
fix(strr-api): use keyword args for error_response 

### DIFF
--- a/strr-api/src/strr_api/resources/account.py
+++ b/strr-api/src/strr_api/resources/account.py
@@ -69,7 +69,7 @@ def search_accounts():
             )
         return AuthService.search_accounts(account_name=account_name), HTTPStatus.OK
     except ExternalServiceException as service_exception:
-        return error_response(service_exception.message, service_exception.status_code)
+        return error_response(http_status=service_exception.status_code, message=service_exception.message)
 
 
 @bp.route("/", methods=("GET",))
@@ -94,7 +94,7 @@ def get_user_accounts():
         token = jwt.get_token_auth_header()
         return AuthService.get_user_accounts(bearer_token=token), HTTPStatus.OK
     except ExternalServiceException as service_exception:
-        return error_response(service_exception.message, service_exception.status_code)
+        return error_response(http_status=service_exception.status_code, message=service_exception.message)
 
 
 @bp.route("/", methods=("POST",))

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -900,7 +900,7 @@ def get_document(application_number, file_key):
             if doc.get("fileKey") == file_key
         ]
         if not application_documents:
-            return error_response(ErrorMessage.DOCUMENT_NOT_FOUND.value, HTTPStatus.BAD_REQUEST)
+            return error_response(http_status=HTTPStatus.BAD_REQUEST, message=ErrorMessage.DOCUMENT_NOT_FOUND.value)
         document = application_documents[0]
         file_content = DocumentService.get_file_by_key(file_key)
         return send_file(

--- a/strr-api/src/strr_api/resources/users.py
+++ b/strr-api/src/strr_api/resources/users.py
@@ -35,7 +35,7 @@ def update_user_profile():
         user_details = AuthService.update_user_profile()
         return user_details, HTTPStatus.OK
     except ExternalServiceException as service_exception:
-        return error_response(service_exception.message, service_exception.status_code)
+        return error_response(http_status=service_exception.status_code, message=service_exception.message)
 
 
 @bp.route("/tos", methods=["GET"])
@@ -47,7 +47,7 @@ def get_user_tos():
         user_tos = AuthService.get_user_tos()
         return user_tos, HTTPStatus.OK
     except ExternalServiceException as service_exception:
-        return error_response(service_exception.message, service_exception.status_code)
+        return error_response(http_status=service_exception.status_code, message=service_exception.message)
 
 
 @bp.route("/tos", methods=["PATCH"])
@@ -65,4 +65,4 @@ def update_user_tos():
         user_tos = AuthService.update_user_tos(request_json)
         return user_tos, HTTPStatus.OK
     except ExternalServiceException as service_exception:
-        return error_response(service_exception.message, service_exception.status_code)
+        return error_response(http_status=service_exception.status_code, message=service_exception.message)


### PR DESCRIPTION


*Issue:* #1543 (partial)

---
### Description of changes
When writing integration tests I noticed that some error_response functions were passing in the params in the wrong order. This PR fixes that in multiple files where I have observed this

> Note: This work will invovle a series of PRs. This is just the first one and is isolated to just source code changes. This should make the reviews and deployment manageable.



---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
