### PR TITLE
test(strr-api): add integration harness and shared seed utilities

### DIFF
--- a/.github/workflows/strr-api-ci.yaml
+++ b/.github/workflows/strr-api-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "strr-api/**"
+      - "tests/python-test-utils/**"
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/strr-auto-approval-job-ci.yaml
+++ b/.github/workflows/strr-auto-approval-job-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/auto-approval/**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/.github/workflows/strr-backfiller-ci.yaml
+++ b/.github/workflows/strr-backfiller-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/strr-backfiller/**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/.github/workflows/strr-batch-validator-job-ci.yaml
+++ b/.github/workflows/strr-batch-validator-job-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/batch-permit-validator/**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/.github/workflows/strr-batch-validator-listener-ci.yaml
+++ b/.github/workflows/strr-batch-validator-listener-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "queue_services/batch-permit-validator/**"
+      - "tests/python-test-utils/**"
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/strr-email-ci.yaml
+++ b/.github/workflows/strr-email-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "queue_services/strr-email/**"
+      - "tests/python-test-utils/**"
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/strr-interaction-updates-job-ci.yml
+++ b/.github/workflows/strr-interaction-updates-job-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [ main, develop ]
     paths:
       - "jobs/interactions-update/**"
+      - "tests/python-test-utils/**"
   pull_request:
     branches: [ main ]
     paths:
       - "jobs/interactions-update/**"
+      - "tests/python-test-utils/**"
 
 # Set the default directory for all shell commands
 defaults:

--- a/.github/workflows/strr-nod-expiry-ci.yaml
+++ b/.github/workflows/strr-nod-expiry-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/noc_expiry/**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/.github/workflows/strr-pay-ci.yaml
+++ b/.github/workflows/strr-pay-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "queue_services/strr-pay/**"
+      - "tests/python-test-utils/**"
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/strr-provisional-approval-job-ci.yaml
+++ b/.github/workflows/strr-provisional-approval-job-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/provisional-approval**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/.github/workflows/strr-registration-expiry-job-ci.yaml
+++ b/.github/workflows/strr-registration-expiry-job-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/registration_expiry/**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/.github/workflows/strr-renewal-reminders-ci.yaml
+++ b/.github/workflows/strr-renewal-reminders-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "jobs/renewal-reminders**"
+      - "tests/python-test-utils/**"
       - "src/strr_api/models/**"
       - "src/strr_api/services/**"
       - "src/strr_api/enums/**"

--- a/strr-api/Makefile
+++ b/strr-api/Makefile
@@ -42,8 +42,14 @@ fmt-check: ## Check isort and black without changing files
 	poetry run isort . --check
 	poetry run black . --check
 
-test: ## Unit testing
-	pytest
+test: ## Run full test suite (same as ``pytest`` / CI default)
+	poetry run pytest
+
+test-unit: ## Run unit tests only (``tests/unit``; no coverage gate)
+	poetry run pytest tests/unit
+
+test-integration: ## Run integration tests only (``tests/integration``; no coverage)
+	poetry run pytest tests/integration --no-cov
 
 build: ## Build the docker container
 	docker build . -t $(DOCKER_NAME) \

--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -127,12 +127,16 @@ norecursedirs = [
 log_cli = true
 log_cli_level = "1"
 filterwarnings = [
-   "ignore::UserWarning"
+   "ignore::UserWarning",
+   "ignore::DeprecationWarning:testcontainers.*:",
+   "ignore::DeprecationWarning:docker.*:",
+   "ignore::ResourceWarning:testcontainers.*:",
 ]
 markers = [
    "slow",
    "serial",
    "conf: Inject flask config values into the app fixture",
+   "integration: full-stack tests using strr_test_utils (Postgres, Redis, HTTP)",
 ]
 
 [tool.coverage.run]

--- a/strr-api/tests/conftest.py
+++ b/strr-api/tests/conftest.py
@@ -37,24 +37,20 @@ from contextlib import contextmanager
 
 import pytest
 from flask import g
-from flask_migrate import upgrade
 from ldclient.integrations.test_data import TestData
-from sqlalchemy.orm import Session as AppSession
-from testcontainers.postgres import PostgresContainer
 
 pytest_plugins = (
-    "tests.fixtures.local",
     "strr_test_utils.utils_fixtures",
+    "strr_test_utils.db_fixtures",
     "strr_test_utils.redis_fixtures",
+    "strr_test_utils.client_fixtures",
     "strr_test_utils.parent_fixtures",
 )
 
-# from strr_api import create_app
-from strr_api import db as _db
-from strr_api import jwt as _jwt
-from strr_api.config import Testing
+from sqlalchemy.orm import Session as AppSession
 
-postgres_image = "postgres:16-alpine"
+from strr_api import db as _db
+from strr_api.config import Testing
 
 
 @contextmanager
@@ -76,35 +72,10 @@ def ld():
     yield td
 
 
-# @pytest.fixture(scope="session")
-# def client(app):  # pylint: disable=redefined-outer-name
-#     """Return a session-wide Flask test client."""
-#     return app.test_client()
-@pytest.fixture(scope="function")
-def client(app):
-    """
-    Return a function-scoped test client.
-    This allows @patch decorators on individual tests to work correctly
-    without leaking state or context between tests.
-    """
-    with app.test_client() as client:
-        # We provide the client, and the @patch decorators in your test
-        # will now correctly intercept calls made during client.get()
-        yield client
-
-
-@pytest.fixture(scope="session")
-def jwt():
-    """Return a session-wide jwt manager."""
-    return _jwt
-
-
 @pytest.fixture
 def authed_g(app):
     """Fixture to seed 'g' with basic JWT info for tests that use mocks."""
-    # This automatically uses the app context provided by the app fixture
     with app.app_context():
-        # Pre-seed the attribute that flask-jwt-oidc expects
         setattr(g, "jwt_oidc_token_info", {"sub": "test-user", "realm_access": {"roles": []}})
         yield g
 
@@ -117,70 +88,52 @@ def client_ctx(app):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture(scope="session")
-def postgres_container():
-    """
-    Spins up a Postgres container.
-    """
-    with PostgresContainer(postgres_image) as postgres:
-        yield postgres
-
-
-@pytest.fixture(scope="session")
-def app(ld, postgres_container):
+def app(ld, db_engine):
+    """Flask app bound to the migrated test DB from strr_test_utils.db_fixtures."""
     from strr_api import create_app
 
-    db_url = postgres_container.get_connection_url()
+    # str(engine.url) masks the password; Flask needs the real credentials.
+    db_url = db_engine.url.render_as_string(hide_password=False)
     Testing.SQLALCHEMY_DATABASE_URI = db_url
     Testing.POD_NAMESPACE = "Testing"
-
-    # Still set this so the standalone-logic in env.py has a backup
     os.environ["DATABASE_URL"] = db_url
 
-    app = create_app(Testing, **{"ld_test_data": ld})
-    return app
-
-
-@pytest.fixture(scope="session")
-def setup_database(app):
-    # This is the ONLY place where the context is pushed for migrations
-    with app.app_context():
-        upgrade()
-    yield
+    _app = create_app(Testing, **{"ld_test_data": ld})
+    return _app
 
 
 @pytest.fixture(scope="function")
-def session(app, setup_database):
+def session(app, db_engine):
     """
-    Creates a test session that behaves like a scoped_session but
-    is bound to an external transaction for easy rollback.
+    Transactional ORM session bound to a savepoint-nested connection.
+
+    strr_test_utils.db_fixtures.session uses a plain scoped_session; strr-api
+    relies on join_transaction_mode=\"create_savepoint\" so HTTP handler commits
+    nest inside an outer rollback (see sql_versioning + Flask request cycles).
     """
-    with app.app_context():  # Re-establish context for the individual test
-        # 1. Start the external transaction on the connection
+    _ = db_engine  # fixture dependency: migrations before app binds engine
+    with app.app_context():
         connection = _db.engine.connect()
         transaction = connection.begin()
 
-        # 2. Create the Session
-        session = AppSession(bind=connection, join_transaction_mode="create_savepoint")
+        orm_session = AppSession(bind=connection, join_transaction_mode="create_savepoint")
 
-        # 3. Create a Proxy to mimic Flask-SQLAlchemy's db.session
         class TestScopedSession:
             def __call__(self):
-                return session
+                return orm_session
 
             def __getattr__(self, name):
-                return getattr(session, name)
+                return getattr(orm_session, name)
 
             def remove(self):
-                session.close()
+                orm_session.close()
 
-        # 4. Patch global db.session
         original_session_lookup = _db.session
         _db.session = TestScopedSession()
 
-        yield session
+        yield orm_session
 
-        # 5. Cleanup
-        session.close()
+        orm_session.close()
         transaction.rollback()
         connection.close()
         _db.session = original_session_lookup

--- a/strr-api/tests/integration/__init__.py
+++ b/strr-api/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests: Postgres, Redis, and HTTP using strr_test_utils fixtures."""

--- a/strr-api/tests/integration/application_seed.py
+++ b/strr-api/tests/integration/application_seed.py
@@ -1,0 +1,112 @@
+"""Seed applications (and optional events) for integration tests.
+
+P2 policy: patch external I/O (``DocumentService``, ``strr_pay``, GCP) at the test
+boundary—see ``test_applications_staff_api`` / ``test_registrations_staff_api``.
+"""
+
+from __future__ import annotations
+
+import copy
+import random
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from strr_api.enums.enum import ApplicationType
+from strr_api.models import Application, Events, Registration
+from tests.integration.helpers import load_mock_json
+
+
+def seed_listable_application(
+    session: Session,
+    *,
+    account_id: int,
+    submitter_user_id: int,
+    registration_id: int | None,
+    application_number: str,
+    status: str,
+    application_json: dict[str, Any] | None = None,
+    invoice_id: int | None = None,
+    payment_status_code: str | None = None,
+) -> dict[str, Any]:
+    """Insert an ``Application`` with ``payment_account`` set for list/GET by account."""
+    body = copy.deepcopy(application_json) if application_json is not None else load_mock_json("host_registration.json")
+    app = Application(
+        application_number=application_number,
+        application_json=body,
+        type=ApplicationType.REGISTRATION.value,
+        registration_type=Registration.RegistrationType.HOST,
+        status=status,
+        registration_id=registration_id,
+        submitter_id=submitter_user_id,
+        payment_account=str(account_id),
+        invoice_id=invoice_id,
+        payment_status_code=payment_status_code,
+    )
+    session.add(app)
+    session.flush()
+    return {
+        "application_id": app.id,
+        "application_number": application_number,
+        "registration_id": registration_id,
+    }
+
+
+def generate_application_number() -> str:
+    """14-digit application number (matches production style)."""
+    return "".join(random.choices("0123456789", k=14))
+
+
+def seed_draft_application(
+    session: Session,
+    *,
+    account_id: int,
+    submitter_user_id: int,
+    registration_id: int | None,
+    application_number: str,
+    application_type: str = ApplicationType.REGISTRATION.value,
+    application_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Insert a DRAFT ``Application`` (e.g. delete / draft-save flows)."""
+    body = copy.deepcopy(application_json) if application_json is not None else load_mock_json("host_registration.json")
+    header = body.setdefault("header", {})
+    header["applicationType"] = application_type
+    if registration_id is not None:
+        header["registrationId"] = registration_id
+    app = Application(
+        application_number=application_number,
+        application_json=body,
+        type=application_type,
+        registration_type=Registration.RegistrationType.HOST,
+        status=Application.Status.DRAFT.value,
+        registration_id=registration_id,
+        submitter_id=submitter_user_id,
+        payment_account=str(account_id),
+    )
+    session.add(app)
+    session.flush()
+    return {
+        "application_id": app.id,
+        "application_number": application_number,
+        "registration_id": registration_id,
+    }
+
+
+def seed_applicant_visible_application_event(
+    session: Session,
+    application_id: int,
+    *,
+    user_id: int | None = None,
+) -> dict[str, Any]:
+    """Insert an application event visible to applicants (``GET .../events``)."""
+    ev = Events(
+        application_id=application_id,
+        user_id=user_id,
+        event_type=Events.EventType.APPLICATION,
+        event_name=Events.EventName.APPLICATION_SUBMITTED,
+        details="Integration seed",
+        visible_to_applicant=True,
+    )
+    session.add(ev)
+    session.flush()
+    return {"event_id": ev.id, "application_id": application_id}

--- a/strr-api/tests/integration/application_seed.py
+++ b/strr-api/tests/integration/application_seed.py
@@ -1,8 +1,4 @@
-"""Seed applications (and optional events) for integration tests.
-
-P2 policy: patch external I/O (``DocumentService``, ``strr_pay``, GCP) at the test
-boundary—see ``test_applications_staff_api`` / ``test_registrations_staff_api``.
-"""
+"""Seed applications (and optional events) for integration tests."""
 
 from __future__ import annotations
 

--- a/strr-api/tests/integration/conftest.py
+++ b/strr-api/tests/integration/conftest.py
@@ -1,0 +1,150 @@
+"""Integration-only pytest hooks and fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.resources.conftest import ACCOUNT_ID, MOCK_INVOICE_RESPONSE
+from tests.unit.utils.auth_helpers import PUBLIC_USER, STRR_EXAMINER, STRR_INVESTIGATOR, SYSTEM_ROLE, create_header
+
+# Role strings (defined here so ``src`` and shared unit auth_helpers stay unchanged).
+_ROLE_STRR_TESTER = "strr_tester"
+_ROLE_STRR_CANCEL_REGISTRATION = "strr_cancel_registration"
+
+# Stable JWT ``sub`` values so ``User.get_or_create_user_by_jwt`` maps to the same DB row across requests.
+_INTEGRATION_EXAMINER_SUB = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_INTEGRATION_INVESTIGATOR_SUB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_INTEGRATION_TESTER_SUB = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+
+
+def pytest_collection_modifyitems(config, items) -> None:
+    """Register ``integration`` marker on every test in this directory (for ``-m integration``)."""
+    for item in items:
+        path = str(getattr(item, "path", getattr(item, "fspath", ""))).replace("\\", "/")
+        if "tests/integration/" in path:
+            item.add_marker(pytest.mark.integration)
+
+
+def pytest_collection_finish(session) -> None:
+    """Integration-only runs measure a slice of ``src``; do not enforce global coverage ``fail_under``."""
+    items = session.items or []
+    if not items:
+        return
+    paths = [str(getattr(item, "path", getattr(item, "fspath", ""))).replace("\\", "/") for item in items]
+    if not all("tests/integration/" in p for p in paths):
+        return
+    cov = session.config.pluginmanager.getplugin("_cov")
+    if cov is not None and getattr(cov, "options", None) is not None:
+        cov.options.cov_fail_under = 0
+
+
+@pytest.fixture
+def integration_account_id() -> int:
+    """SBC-style account id used across STRR tests."""
+    return ACCOUNT_ID
+
+
+@pytest.fixture
+def mock_invoice_response() -> dict:
+    return MOCK_INVOICE_RESPONSE
+
+
+@pytest.fixture
+def headers_public_user(jwt):
+    """JWT + ``Account-Id`` for a public (host) user."""
+
+    def _make(account_id: int | str | None = ACCOUNT_ID, **kwargs):
+        h = create_header(jwt, [PUBLIC_USER], **kwargs)
+        if account_id is not None:
+            h["Account-Id"] = str(account_id)
+        return h
+
+    return _make
+
+
+@pytest.fixture
+def headers_strr_examiner(jwt):
+    """JWT for staff examiner (no Account-Id unless caller adds)."""
+
+    def _make(**kwargs):
+        kwargs.setdefault("sub", _INTEGRATION_EXAMINER_SUB)
+        kwargs.setdefault("username", "integration-strr-examiner")
+        return create_header(jwt, [STRR_EXAMINER], **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def headers_strr_investigator(jwt):
+    """JWT for staff investigator."""
+
+    def _make(**kwargs):
+        kwargs.setdefault("sub", _INTEGRATION_INVESTIGATOR_SUB)
+        kwargs.setdefault("username", "integration-strr-investigator")
+        return create_header(jwt, [STRR_INVESTIGATOR], **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def headers_strr_tester(jwt):
+    """JWT with ``strr_tester`` (expiry test endpoint)."""
+
+    def _make(**kwargs):
+        kwargs.setdefault("sub", _INTEGRATION_TESTER_SUB)
+        kwargs.setdefault("username", "integration-strr-tester")
+        return create_header(jwt, [_ROLE_STRR_TESTER], **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def headers_system(jwt):
+    """JWT with ``system`` role."""
+
+    def _make(**kwargs):
+        return create_header(jwt, [SYSTEM_ROLE], **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def headers_strr_cancel(jwt):
+    """JWT with ``strr_cancel_registration`` role."""
+
+    def _make(**kwargs):
+        kwargs.setdefault("sub", _INTEGRATION_EXAMINER_SUB)
+        kwargs.setdefault("username", "integration-strr-cancel")
+        return create_header(jwt, [_ROLE_STRR_CANCEL_REGISTRATION], **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def serializable_host_registration(session, integration_account_id, random_string):
+    """HOST registration with rental + primary contact so list/detail serialization succeeds."""
+    from tests.integration.registration_seed import seed_serializable_host_registration
+
+    suffix = random_string(10).upper().replace("-", "")[:10]
+    reg_number = f"INT{suffix}"
+    return seed_serializable_host_registration(
+        session,
+        account_id=integration_account_id,
+        registration_number=reg_number,
+    )
+
+
+@pytest.fixture
+def serializable_application(session, integration_account_id, serializable_host_registration):
+    """HOST application tied to ``serializable_host_registration`` and listable by ``Account-Id``."""
+    from strr_api.models.application import Application as AppModel
+    from tests.integration.application_seed import generate_application_number, seed_listable_application
+
+    return seed_listable_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=generate_application_number(),
+        status=AppModel.Status.FULL_REVIEW.value,
+    )

--- a/strr-api/tests/integration/helpers.py
+++ b/strr-api/tests/integration/helpers.py
@@ -1,0 +1,108 @@
+"""Shared helpers for API integration tests."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from pathlib import Path
+from typing import Any
+
+from werkzeug.test import TestResponse
+
+PUBLIC_ROUTES = frozenset(
+    {
+        ("GET", "/ops/healthz"),
+        ("GET", "/ops/readyz"),
+        ("GET", "/meta/info"),
+    }
+)
+
+
+def tests_dir() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def load_mock_json(*parts: str) -> Any:
+    """Load JSON from ``tests/mocks/json`` (paths relative to that dir)."""
+    path = tests_dir() / "mocks" / "json" / Path(*parts)
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def resolve_path(rule: str) -> str:
+    """Turn a Werkzeug ``rule`` into a concrete URL for smoke / auth tests."""
+    if "/<path:action>" in rule:
+        if "permits" in rule:
+            return rule.replace("<path:action>", ":validatePermit")
+        return rule.replace("<path:action>", "requirements")
+    path = rule
+    # Distinct paths so parametrized test ids stay unique for string vs default converter.
+    path = path.replace("<string:application_number>", "9000002")
+    path = path.replace("<application_number>", "9000001")
+    path = path.replace("<registration_id>", "1")
+    path = path.replace("<registration_number>", "R9000001")
+    path = path.replace("<snapshot_id>", "1")
+    path = path.replace("<file_key>", "fake-file-key")
+    return path
+
+
+def resolve_path_for_unauth(rule: str) -> str:
+    """Like ``resolve_path`` but adds minimal query strings where routes expect them."""
+    p = resolve_path(rule)
+    if p == "/accounts/search":
+        return f"{p}?name=test"
+    if p == "/applications/search":
+        return f"{p}?text=test"
+    if p == "/registrations/search":
+        return f"{p}?text=test"
+    if p.endswith("/user/search"):
+        return f"{p}?text=test"
+    return p
+
+
+def assert_status(rv: TestResponse, expected: HTTPStatus | int, msg: str = "") -> None:
+    assert rv.status_code == int(expected), msg or f"expected {expected}, got {rv.status_code}: {rv.data!r}"
+
+
+def assert_json_keys(rv: TestResponse, *keys: str) -> dict[str, Any]:
+    assert rv.is_json, "response is not JSON"
+    data = rv.get_json()
+    assert isinstance(data, dict), data
+    for k in keys:
+        assert k in data, f"missing key {k!r} in {data!r}"
+    return data
+
+
+def routes_with_prefix(routes: frozenset[tuple[str, str]], prefix: str) -> list[tuple[str, str]]:
+    """Return sorted (method, rule) pairs under ``prefix`` (exact rule or ``prefix/…``)."""
+    out = [(m, r) for m, r in routes if r == prefix or r.startswith(prefix + "/")]
+    return sorted(out)
+
+
+def unauthenticated_request(client, method: str, path: str):
+    """Perform one HTTP call without ``Authorization`` (for auth contract tests)."""
+    if method == "GET":
+        return client.get(path)
+    if method == "DELETE":
+        return client.delete(path)
+    if method == "POST" and path == "/documents":
+        return client.post(path, data={}, content_type="multipart/form-data")
+    if method in ("POST", "PUT", "PATCH"):
+        return client.open(path, method=method, json={})
+    raise ValueError(method)
+
+
+def collect_strr_routes(app) -> frozenset[tuple[str, str]]:
+    """All (method, rule) for the app excluding Flasgger and static."""
+    out: set[tuple[str, str]] = set()
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint.startswith("flasgger") or rule.endpoint == "static":
+            continue
+        for method in rule.methods - {"HEAD", "OPTIONS"}:
+            out.add((method, rule.rule))
+    return frozenset(out)
+
+
+def protected_routes_with_prefix(app, prefix: str) -> list[tuple[str, str]]:
+    """Collect protected routes matching ``prefix`` from the running app map."""
+    return routes_with_prefix(collect_strr_routes(app) - PUBLIC_ROUTES, prefix)

--- a/strr-api/tests/integration/registration_seed.py
+++ b/strr-api/tests/integration/registration_seed.py
@@ -1,0 +1,177 @@
+"""Seed a minimal HOST registration graph so ``RegistrationService.serialize`` succeeds."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from strr_api.enums.enum import PropertyType, RegistrationStatus
+from strr_api.models import (
+    Address,
+    Contact,
+    Document,
+    Events,
+    PropertyContact,
+    Registration,
+    RegistrationSnapshot,
+    RentalProperty,
+    User,
+)
+
+
+def seed_serializable_host_registration(
+    session: Session,
+    *,
+    account_id: int,
+    registration_number: str,
+) -> dict[str, Any]:
+    """Insert User + Registration + RentalProperty + primary PropertyContact (flushed, not committed)."""
+    owner = User()
+    session.add(owner)
+    session.flush()
+
+    unit_address = Address(
+        country="CA",
+        street_address="100 Integration St",
+        city="Victoria",
+        province="BC",
+        postal_code="V8V1A1",
+        street_number="100",
+        unit_number="",
+    )
+    mailing_address = Address(
+        country="CA",
+        street_address="200 Mail St",
+        city="Victoria",
+        province="BC",
+        postal_code="V8V1B2",
+    )
+    session.add_all([unit_address, mailing_address])
+    session.flush()
+
+    contact = Contact(
+        firstname="Int",
+        lastname="Host",
+        email="host@example.test",
+        phone_number="250-555-0100",
+        address_id=mailing_address.id,
+        date_of_birth=datetime(1985, 5, 15).date(),
+    )
+    session.add(contact)
+    session.flush()
+
+    now = datetime.now(timezone.utc)
+    expiry = now + timedelta(days=365)
+    reg = Registration(
+        registration_type=Registration.RegistrationType.HOST,
+        registration_number=registration_number,
+        sbc_account_id=account_id,
+        status=RegistrationStatus.ACTIVE,
+        user_id=owner.id,
+        start_date=now,
+        expiry_date=expiry,
+    )
+    session.add(reg)
+    session.flush()
+
+    rental = RentalProperty(
+        registration_id=reg.id,
+        address_id=unit_address.id,
+        property_type=PropertyType.SINGLE_FAMILY_HOME,
+        ownership_type=RentalProperty.OwnershipType.OWN,
+        is_principal_residence=True,
+        rental_act_accepted=True,
+        parcel_identifier="PID-INT-001",
+        local_business_licence="BL-INT-001",
+        local_business_licence_expiry_date=(now + timedelta(days=180)).date(),
+        nickname="Integration Rental",
+        jurisdiction="Victoria",
+        space_type=RentalProperty.RentalUnitSpaceType.ENTIRE_HOME,
+        host_residence=RentalProperty.HostResidence.SAME_UNIT,
+        is_unit_on_principal_residence_property=True,
+        number_of_rooms_for_rent=1,
+        host_type=RentalProperty.HostType.OWNER,
+        rental_space_option=RentalProperty.RentalSpaceOption.PRIMARY_RESIDENCE_OR_SHARED_SPACE,
+    )
+    session.add(rental)
+    session.flush()
+
+    pc = PropertyContact(
+        property_id=rental.id,
+        contact_id=contact.id,
+        is_primary=True,
+        contact_type=PropertyContact.ContactType.INDIVIDUAL,
+    )
+    session.add(pc)
+    session.flush()
+
+    return {
+        "user_id": owner.id,
+        "registration_id": reg.id,
+        "registration_number": registration_number,
+        "rental_property_id": rental.id,
+    }
+
+
+def seed_registration_snapshot(
+    session: Session,
+    registration_id: int,
+    *,
+    snapshot_data: dict | None = None,
+) -> dict[str, Any]:
+    """Insert a ``RegistrationSnapshot`` row (flushed, not committed)."""
+    latest = RegistrationSnapshot.find_latest_snapshot(registration_id)
+    version = (latest.version + 1) if latest else 1
+    snap = RegistrationSnapshot(
+        registration_id=registration_id,
+        version=version,
+        snapshot_datetime=datetime.now(timezone.utc),
+        snapshot_data=snapshot_data or {"integration": True, "registrationId": registration_id},
+    )
+    session.add(snap)
+    session.flush()
+    return {"snapshot_id": snap.id, "registration_id": registration_id}
+
+
+def seed_registration_document(
+    session: Session,
+    registration_id: int,
+    *,
+    file_key: str,
+    file_name: str = "integration-doc.txt",
+    file_type: str = "text/plain",
+) -> dict[str, Any]:
+    """Insert a ``Document`` row for a registration (flushed, not committed)."""
+    doc = Document(
+        registration_id=registration_id,
+        path=file_key,
+        file_name=file_name,
+        file_type=file_type,
+        document_type=Document.DocumentType.OTHERS,
+        added_on=datetime.now(timezone.utc).date(),
+    )
+    session.add(doc)
+    session.flush()
+    return {"document_id": doc.id, "file_key": file_key, "registration_id": registration_id}
+
+
+def seed_applicant_visible_registration_event(
+    session: Session,
+    registration_id: int,
+    *,
+    user_id: int | None = None,
+) -> dict[str, Any]:
+    """Insert a registration event visible to applicants (for ``GET .../events`` shape tests)."""
+    ev = Events(
+        registration_id=registration_id,
+        user_id=user_id,
+        event_type=Events.EventType.REGISTRATION,
+        event_name=Events.EventName.REGISTRATION_CREATED,
+        details="Integration seed event",
+        visible_to_applicant=True,
+    )
+    session.add(ev)
+    session.flush()
+    return {"event_id": ev.id, "registration_id": registration_id}

--- a/strr-api/tests/integration/resources/__init__.py
+++ b/strr-api/tests/integration/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests aligned with ``strr_api.resources`` blueprints."""

--- a/tests/python-test-utils/src/strr_test_utils/parent_fixtures.py
+++ b/tests/python-test-utils/src/strr_test_utils/parent_fixtures.py
@@ -25,6 +25,8 @@ def seed_parent_user_registration_application(
     """Insert User, Registration, Application; return IDs and ORM instances.
 
     ``application_kwargs`` are merged into ``Application`` (e.g. ``invoice_id``, ``status``).
+    For integration suites that need full ``application_json`` + ``payment_account``, prefer
+    ``strr-api/tests/integration/application_seed.py`` (``seed_listable_application``).
     """
     customer = User()
     user = User()
@@ -44,7 +46,6 @@ def seed_parent_user_registration_application(
     session.flush()
 
     app_fields: dict[str, Any] = {
-        "id": random_integer(),
         "application_json": {},
         "registration_id": reg.id,
         "application_number": random_string(10),


### PR DESCRIPTION

*Issue:* #1543

## Summary
- add integration test harness wiring in `tests/conftest.py` and `tests/integration/conftest.py`, using shared reusable fixture plugins from `strr_test_utils`
- add shared integration helpers and deterministic seed utilities in `tests/integration/helpers.py`, `tests/integration/registration_seed.py`, and `tests/integration/application_seed.py`
- include supporting integration config updates in `strr-api/Makefile`, `strr-api/pyproject.toml`, and `tests/python-test-utils/src/strr_test_utils/parent_fixtures.py`
- all the ci trigger paths have been updated since there is dependency on fixtures which comes from this path. so its best to run these ci checks just to ensure nothings broken with the new changes.
---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
