### PR TITLE
fix(ui): show email to completing party for strata hotel renewals

### DIFF
--- a/strr-examiner-web/app/components/ComposeNoc.vue
+++ b/strr-examiner-web/app/components/ComposeNoc.vue
@@ -22,9 +22,9 @@ const isStrataHotelRenewalApplication = computed(() => {
 })
 
 const canShowComposeEmail = computed(() =>
-  (showComposeEmail.value || showComposeNocEmail.value) &&
-  isAssignedToUser.value &&
-  (!hasRegistrationNumber.value || isStrataHotelRenewalApplication.value)
+  (!!showComposeEmail?.value || !!showComposeNocEmail?.value) &&
+  !!isAssignedToUser?.value &&
+  (!hasRegistrationNumber?.value || isStrataHotelRenewalApplication.value)
 )
 const formSchema = computed(
   () =>

--- a/strr-examiner-web/app/components/ComposeNoc.vue
+++ b/strr-examiner-web/app/components/ComposeNoc.vue
@@ -7,9 +7,25 @@ const {
   showComposeNocEmail,
   isAssignedToUser,
   activeHeader,
-  hasRegistrationNumber
+  hasRegistrationNumber,
+  isApplication,
+  activeReg
 } = storeToRefs(useExaminerStore())
 const { t } = useNuxtApp().$i18n
+
+const isStrataHotelRenewalApplication = computed(() => {
+  const header = activeHeader.value as { applicationType?: string } | undefined
+  return isApplication.value &&
+    hasRegistrationNumber.value &&
+    activeReg.value?.registrationType === ApplicationType.STRATA_HOTEL &&
+    header?.applicationType === 'renewal'
+})
+
+const canShowComposeEmail = computed(() =>
+  (showComposeEmail.value || showComposeNocEmail.value) &&
+  isAssignedToUser.value &&
+  (!hasRegistrationNumber.value || isStrataHotelRenewalApplication.value)
+)
 const formSchema = computed(
   () =>
     [
@@ -34,7 +50,7 @@ onMounted(() => {
 
 <template>
   <div
-    v-if="(showComposeEmail || showComposeNocEmail) && isAssignedToUser && !hasRegistrationNumber"
+    v-if="canShowComposeEmail"
     class="app-inner-container"
   >
     <div class="mb-8 rounded bg-white py-6">

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.39a",
+  "version": "0.2.39b",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/compose-noc.spec.ts
+++ b/strr-examiner-web/tests/unit/compose-noc.spec.ts
@@ -6,18 +6,25 @@ import ComposeNoc from '~/components/ComposeNoc.vue'
 const mockState = {
   hasRegistrationNumber: false,
   showComposeEmail: true,
-  isAssignedToUser: true
+  showComposeNocEmail: false,
+  isAssignedToUser: true,
+  isApplication: true,
+  registrationType: ApplicationType.HOST,
+  applicationType: 'registration'
 }
 
 vi.mock('@/stores/examiner', () => ({
   useExaminerStore: () => ({
     hasRegistrationNumber: ref(mockState.hasRegistrationNumber),
     showComposeEmail: ref(mockState.showComposeEmail),
-    showComposeNocEmail: ref(false),
+    showComposeNocEmail: ref(mockState.showComposeNocEmail),
     isAssignedToUser: ref(mockState.isAssignedToUser),
+    isApplication: ref(mockState.isApplication),
+    activeReg: ref({ registrationType: mockState.registrationType }),
     emailContent: ref({ content: '' }),
-    activeHeader: ref(null),
-    sendNocSchema: ref({})
+    activeHeader: ref({ applicationType: mockState.applicationType }),
+    sendNocSchema: ref({}),
+    sendEmailSchema: ref({})
   })
 }))
 
@@ -25,7 +32,11 @@ describe('ComposeNoc Component', () => {
   beforeEach(() => {
     mockState.hasRegistrationNumber = false
     mockState.showComposeEmail = true
+    mockState.showComposeNocEmail = false
     mockState.isAssignedToUser = true
+    mockState.isApplication = true
+    mockState.registrationType = ApplicationType.HOST
+    mockState.applicationType = 'registration'
   })
 
   it('should show compose email form when application has no registration number', async () => {
@@ -41,5 +52,16 @@ describe('ComposeNoc Component', () => {
       global: { plugins: [enI18n] }
     })
     expect(wrapper.find('[data-testid="compose-email"]').exists()).toBe(false)
+  })
+
+  it('should show compose email form for strata hotel renewal with registration number', async () => {
+    mockState.hasRegistrationNumber = true
+    mockState.showComposeNocEmail = true
+    mockState.registrationType = ApplicationType.STRATA_HOTEL
+    mockState.applicationType = 'renewal'
+    const wrapper = await mountSuspended(ComposeNoc, {
+      global: { plugins: [enI18n] }
+    })
+    expect(wrapper.find('[data-testid="compose-email"]').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1604

*Description of changes:*
Same as https://github.com/bcgov/STRR/pull/1606 but for the completing party (sending NOC) section...
<img width="1910" height="1163" alt="image" src="https://github.com/user-attachments/assets/d5fa57ca-ab6d-44af-91b0-1db6bfe53f02" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
