### PR TITLE
fix(api): preserve document upload date in registrations

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.18"
+version = "0.3.19"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -191,6 +191,7 @@ class RegistrationService:
                 file_type=doc.get("fileType"),
                 path=doc.get("fileKey"),
                 document_type=doc.get("documentType"),
+                added_on=doc.get("uploadDate") or doc.get("addedOn"),
             )
             registration.documents.append(document)
         if registration_type == RegistrationType.HOST.value:
@@ -236,6 +237,7 @@ class RegistrationService:
                 file_type=doc.get("fileType"),
                 path=doc.get("fileKey"),
                 document_type=doc.get("documentType"),
+                added_on=doc.get("uploadDate") or doc.get("addedOn"),
             )
             documents.append(document)
         if documents:

--- a/strr-host-pm-web/app/stores/document.ts
+++ b/strr-host-pm-web/app/stores/document.ts
@@ -328,7 +328,7 @@ export const useDocumentStore = defineStore('host/document', () => {
       id: uuidv4(),
       loading: true,
       uploadStep,
-      uploadDate: new Date().toISOString().split('T')[0]
+      uploadDate: new Date().toISOString()
     }
 
     storedDocuments.value.push(uiDoc)
@@ -441,8 +441,6 @@ export const useDocumentStore = defineStore('host/document', () => {
       const formData = new FormData()
       formData.append('file', uiDoc.file)
       formData.append('documentType', uiDoc.type)
-      uiDoc.uploadStep && formData.append('uploadStep', uiDoc.uploadStep)
-      uiDoc.uploadDate && formData.append('uploadDate', uiDoc.uploadDate)
 
       // submit file
       const res = await $strrApi<ApiDocument>('/documents', {
@@ -451,6 +449,8 @@ export const useDocumentStore = defineStore('host/document', () => {
       })
       // api doesn't give documentType back in this response
       res.documentType = uiDoc.type
+      if (uiDoc.uploadStep) { res.uploadStep = uiDoc.uploadStep }
+      if (uiDoc.uploadDate) { res.uploadDate = uiDoc.uploadDate }
       // update ui object with backend response
       updateStoredDocument(uiDoc.id, 'apiDoc', res)
     } catch (e) {

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1553

*Description of changes:*
- Preserve document upload date in registrations (initial and renewals)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
