### PR TITLE
test(strr-api): add integration smoke tests for stack, ops, and meta

### DIFF
--- a/strr-api/tests/integration/resources/test_meta_api.py
+++ b/strr-api/tests/integration/resources/test_meta_api.py
@@ -1,0 +1,14 @@
+"""Integration tests for ``/meta`` endpoints."""
+
+from http import HTTPStatus
+
+import pytest
+
+from tests.integration.helpers import assert_json_keys, assert_status
+
+
+def test_meta_info_returns_version_json(client):
+    rv = client.get("/meta/info")
+    assert_status(rv, HTTPStatus.OK)
+    body = assert_json_keys(rv, "API", "FrameWork")
+    assert "strr_api" in body["API"] or "/" in body["API"]

--- a/strr-api/tests/integration/resources/test_ops_api.py
+++ b/strr-api/tests/integration/resources/test_ops_api.py
@@ -1,0 +1,21 @@
+"""Integration tests for ``/ops`` endpoints."""
+
+from http import HTTPStatus
+
+import pytest
+
+from tests.integration.helpers import assert_json_keys, assert_status
+
+
+def test_ops_healthz_returns_ok_json(client):
+    rv = client.get("/ops/healthz")
+    assert_status(rv, HTTPStatus.OK)
+    body = assert_json_keys(rv, "message")
+    assert body["message"] == "api is healthy"
+
+
+def test_ops_readyz_returns_ok_json(client):
+    rv = client.get("/ops/readyz")
+    assert_status(rv, HTTPStatus.OK)
+    body = assert_json_keys(rv, "message")
+    assert body["message"] == "api is ready"

--- a/strr-api/tests/integration/test_stack_smoke.py
+++ b/strr-api/tests/integration/test_stack_smoke.py
@@ -1,0 +1,21 @@
+# Copyright © 2023 Province of British Columbia
+#
+# Licensed under the BSD 3 Clause License, (the "License");
+# you may not use this file except in compliance with the License.
+"""Fast infra smoke: Postgres + Redis + ORM seed (HTTP ops covered in ``resources/test_ops_api``)."""
+
+import pytest
+
+from strr_api.models.rental import Registration
+
+
+def test_postgres_migrated_schema_and_setup_parents(session, setup_parents):
+    assert setup_parents["registration_id"] is not None
+    reg = session.get(Registration, setup_parents["registration_id"])
+    assert reg is not None
+    assert reg.id == setup_parents["registration_id"]
+
+
+def test_redis_client_roundtrip(redis_client):
+    redis_client.set("strr_integration_smoke", "ok")
+    assert redis_client.get("strr_integration_smoke") == b"ok"


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1543

*Description of changes:*

- Add `tests/integration/test_stack_smoke.py`: Postgres + migrated schema (`setup_parents`) and Redis round-trip smoke.
- Add `tests/integration/resources/test_ops_api.py` and `test_meta_api.py`: HTTP smoke for `/ops/healthz`, `/ops/readyz`, and `/meta/info` (public routes).

Depends on integration harness merged in #1608.

**Test plan**

- `cd strr-api && poetry run pytest -o addopts='' tests/integration/test_stack_smoke.py tests/integration/resources/test_ops_api.py tests/integration/resources/test_meta_api.py -q`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License