### PR TITLE
test(strr-api): add platform slice integration tests

### DIFF
--- a/strr-api/tests/integration/resources/test_account_api.py
+++ b/strr-api/tests/integration/resources/test_account_api.py
@@ -1,0 +1,131 @@
+"""Integration tests for ``/accounts`` endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+import pytest
+
+from strr_api.exceptions import ExternalServiceException
+from tests.integration.helpers import (
+    assert_json_keys,
+    assert_status,
+    protected_routes_with_prefix,
+    resolve_path_for_unauth,
+    unauthenticated_request,
+)
+
+
+def test_accounts_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/accounts")
+    assert rows, "expected at least one protected /accounts route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+@patch(
+    "strr_api.resources.account.AuthService.get_user_accounts",
+    return_value={"orgs": [{"id": 1, "name": "Integration Org", "orgStatus": "ACTIVE"}]},
+)
+def test_get_user_accounts_ok_shape(mock_get, client, jwt, integration_account_id):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    headers["Account-Id"] = str(integration_account_id)
+    rv = client.get("/accounts/", headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "orgs")
+    assert isinstance(data["orgs"], list)
+    assert data["orgs"][0]["id"] == 1
+    assert "name" in data["orgs"][0]
+
+
+@patch(
+    "strr_api.resources.account.AuthService.search_accounts",
+    return_value={"orgs": [{"id": 99, "name": "SearchCo", "orgStatus": "ACTIVE"}]},
+)
+def test_search_accounts_ok_shape_and_name_param(mock_search, client, jwt):
+    from tests.unit.utils.auth_helpers import STRR_EXAMINER, create_header
+
+    headers = create_header(jwt, [STRR_EXAMINER])
+    rv = client.get("/accounts/search?name=SearchCo", headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "orgs")
+    mock_search.assert_called_once_with(account_name="SearchCo")
+    assert data["orgs"][0]["name"] == "SearchCo"
+
+
+def test_search_accounts_missing_name_bad_request(client, jwt):
+    from tests.unit.utils.auth_helpers import STRR_EXAMINER, create_header
+
+    headers = create_header(jwt, [STRR_EXAMINER])
+    rv = client.get("/accounts/search", headers=headers)
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+@patch("strr_api.resources.account.AuthService.search_accounts")
+def test_search_accounts_returns_status_when_auth_service_raises(mock_search, client, jwt):
+    mock_search.side_effect = ExternalServiceException(
+        error="sbc",
+        message="SBC account search unavailable",
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+    )
+    from tests.unit.utils.auth_helpers import STRR_EXAMINER, create_header
+
+    headers = create_header(jwt, [STRR_EXAMINER])
+    rv = client.get("/accounts/search?name=AnyCo", headers=headers)
+    assert_status(rv, HTTPStatus.SERVICE_UNAVAILABLE)
+    err = rv.get_json()
+    assert err is not None
+    assert "unavailable" in (err.get("message") or "").lower()
+
+
+@patch("strr_api.resources.account.AuthService.get_user_accounts")
+def test_get_user_accounts_returns_status_when_auth_service_raises(mock_get, client, jwt, integration_account_id):
+    """Deterministic substitute for optional live SBC calls (set STRR_INTEGRATION_REAL_AUTH=1 locally if needed)."""
+    mock_get.side_effect = ExternalServiceException(
+        error="sbc",
+        message="SBC account service unavailable",
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+    )
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    headers["Account-Id"] = str(integration_account_id)
+    rv = client.get("/accounts/", headers=headers)
+    assert_status(rv, HTTPStatus.SERVICE_UNAVAILABLE)
+    err = rv.get_json()
+    assert err is not None
+    assert "unavailable" in (err.get("message") or "").lower()
+
+
+@patch("strr_api.resources.account.AuthService.add_contact_info")
+@patch("strr_api.resources.account.AuthService.create_user_account")
+def test_post_create_user_account_created_with_patched_sbc(
+    mock_create, mock_add_contact, client, jwt, integration_account_id
+):
+    mock_create.return_value = {"id": 4242}
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    headers["Account-Id"] = str(integration_account_id)
+    payload = {
+        "name": "Integration New Co",
+        "phone": "250-555-0199",
+        "email": "newco@example.test",
+        "mailingAddress": {
+            "street": "1 Integration Rd",
+            "city": "Victoria",
+            "region": "BC",
+            "postalCode": "V8V1A1",
+            "country": "CA",
+        },
+    }
+    rv = client.post("/accounts/", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.CREATED)
+    body = rv.get_json()
+    assert body["sbc_account_id"] == 4242
+    assert isinstance(body.get("user_id"), int)
+    mock_create.assert_called_once()
+    mock_add_contact.assert_called_once()

--- a/strr-api/tests/integration/resources/test_address_api.py
+++ b/strr-api/tests/integration/resources/test_address_api.py
@@ -1,0 +1,75 @@
+"""Integration tests for ``/address`` and ``/v1/address`` endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+from tests.integration.helpers import (
+    assert_status,
+    protected_routes_with_prefix,
+    resolve_path_for_unauth,
+    unauthenticated_request,
+)
+
+
+def test_address_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/address")
+    assert rows, "expected at least one protected /address route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+def test_v1_address_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/v1/address")
+    assert rows, "expected at least one protected /v1/address route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+@patch("strr_api.resources.str_address_requirements.ApprovalService.getSTRDataForAddress", return_value={"ok": True})
+def test_post_address_requirements_ok(mock_str, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    body = {
+        "address": {
+            "unitNumber": "1",
+            "streetNumber": "123",
+            "streetName": "Main St",
+            "city": "Victoria",
+            "province": "BC",
+            "postalCode": "V8V1A1",
+        }
+    }
+    rv = client.post("/address/requirements", json=body, headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+
+
+@patch("strr_api.resources.str_address_requirements.ApprovalService.getSTRDataForAddress", return_value={"ok": True})
+def test_post_v1_address_requirements_ok(mock_str, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    body = {
+        "address": {
+            "unitNumber": "",
+            "streetNumber": "500",
+            "streetName": "Permit Rd",
+            "city": "Victoria",
+            "province": "BC",
+            "postalCode": "V8V2B2",
+        }
+    }
+    rv = client.post("/v1/address/requirements", json=body, headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+
+
+def test_post_v1_address_requirements_invalid_body_bad_request(client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post("/v1/address/requirements", json={"address": {}}, headers=headers)
+    assert_status(rv, HTTPStatus.BAD_REQUEST)

--- a/strr-api/tests/integration/resources/test_documents_api.py
+++ b/strr-api/tests/integration/resources/test_documents_api.py
@@ -1,0 +1,74 @@
+"""Integration tests for ``/documents`` (global upload/delete)."""
+
+from http import HTTPStatus
+from io import BytesIO
+from unittest.mock import patch
+
+from strr_api.exceptions import ExternalServiceException
+from tests.integration.helpers import (
+    assert_status,
+    protected_routes_with_prefix,
+    resolve_path_for_unauth,
+    unauthenticated_request,
+)
+
+
+def test_documents_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/documents")
+    assert rows, "expected at least one protected /documents route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+def test_post_documents_validation_no_file_bad_request(client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post("/documents", data={}, content_type="multipart/form-data", headers=headers)
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_post_documents_ok_patched_upload(client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    with patch(
+        "strr_api.services.document_service.DocumentService.upload_document",
+        return_value={"fileKey": "global-doc-1", "fileName": "a.txt", "fileType": "text/plain"},
+    ):
+        rv = client.post(
+            "/documents",
+            headers=headers,
+            data={"file": (BytesIO(b"x"), "a.txt")},
+            content_type="multipart/form-data",
+        )
+    assert_status(rv, HTTPStatus.CREATED)
+    body = rv.get_json()
+    assert body.get("fileKey") == "global-doc-1"
+
+
+def test_delete_documents_ok_patched(client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    with patch("strr_api.services.document_service.DocumentService.delete_document", return_value=None):
+        rv = client.delete("/documents/global-doc-1", headers=headers)
+    assert_status(rv, HTTPStatus.NO_CONTENT)
+
+
+def test_delete_documents_external_error(client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    with patch(
+        "strr_api.services.document_service.DocumentService.delete_document",
+        side_effect=ExternalServiceException(
+            error="downstream",
+            message="storage unavailable",
+            status_code=HTTPStatus.BAD_GATEWAY,
+        ),
+    ):
+        rv = client.delete("/documents/missing", headers=headers)
+    assert rv.status_code == HTTPStatus.BAD_GATEWAY

--- a/strr-api/tests/integration/resources/test_users_api.py
+++ b/strr-api/tests/integration/resources/test_users_api.py
@@ -1,0 +1,122 @@
+"""Integration tests for ``/users`` endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+from strr_api.exceptions import ExternalServiceException
+from tests.integration.helpers import (
+    assert_status,
+    protected_routes_with_prefix,
+    resolve_path_for_unauth,
+    unauthenticated_request,
+)
+
+
+def test_users_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/users")
+    assert rows, "expected at least one protected /users route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+@patch("strr_api.resources.users.AuthService.get_user_tos", return_value={"isTermsOfUseAccepted": True})
+def test_get_user_tos_ok(mock_tos, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.get("/users/tos", headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+
+
+@patch("strr_api.resources.users.AuthService.update_user_profile", return_value={"profileUpdated": True})
+def test_post_users_profile_ok_patched(mock_post, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post("/users/", headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json().get("profileUpdated") is True
+
+
+@patch("strr_api.resources.users.AuthService.update_user_tos", return_value={"isTermsOfUseAccepted": True})
+def test_patch_user_tos_ok_patched(mock_patch, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.patch(
+        "/users/tos",
+        headers=headers,
+        json={"termsversion": "v1", "istermsaccepted": True},
+    )
+    assert_status(rv, HTTPStatus.OK)
+
+
+@patch(
+    "strr_api.resources.users.validate_schema",
+    return_value=(False, [{"path": "/istermsaccepted", "message": "required"}]),
+)
+def test_patch_user_tos_invalid_schema_bad_request(mock_schema, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.patch("/users/tos", headers=headers, json={"termsversion": "v1"})
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+    err = rv.get_json()
+    assert "errors" in err or "message" in err
+
+
+@patch("strr_api.resources.users.AuthService.get_user_tos")
+def test_get_user_tos_returns_status_when_auth_service_raises(mock_tos, client, jwt):
+    mock_tos.side_effect = ExternalServiceException(
+        error="sbc",
+        message="SBC ToS service unavailable",
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+    )
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.get("/users/tos", headers=headers)
+    assert_status(rv, HTTPStatus.SERVICE_UNAVAILABLE)
+    err = rv.get_json()
+    assert err is not None
+    assert "unavailable" in (err.get("message") or "").lower()
+
+
+@patch("strr_api.resources.users.AuthService.update_user_profile")
+def test_post_users_profile_returns_status_when_auth_service_raises(mock_prof, client, jwt):
+    mock_prof.side_effect = ExternalServiceException(
+        error="sbc",
+        message="SBC profile service unavailable",
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+    )
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post("/users/", headers=headers)
+    assert_status(rv, HTTPStatus.SERVICE_UNAVAILABLE)
+    err = rv.get_json()
+    assert err is not None
+    assert "unavailable" in (err.get("message") or "").lower()
+
+
+@patch("strr_api.resources.users.AuthService.update_user_tos")
+def test_patch_user_tos_returns_status_when_auth_service_raises(mock_upd, client, jwt):
+    mock_upd.side_effect = ExternalServiceException(
+        error="sbc",
+        message="SBC ToS update unavailable",
+        status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+    )
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.patch(
+        "/users/tos",
+        headers=headers,
+        json={"termsversion": "v1", "istermsaccepted": True},
+    )
+    assert_status(rv, HTTPStatus.SERVICE_UNAVAILABLE)
+    err = rv.get_json()
+    assert err is not None
+    assert "unavailable" in (err.get("message") or "").lower()

--- a/strr-api/tests/integration/resources/test_validation_api.py
+++ b/strr-api/tests/integration/resources/test_validation_api.py
@@ -1,0 +1,103 @@
+"""Integration tests for ``/permits`` and ``/v1/permits`` validation endpoints."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+from tests.integration.helpers import (
+    assert_status,
+    protected_routes_with_prefix,
+    resolve_path_for_unauth,
+    unauthenticated_request,
+)
+
+
+def test_permits_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/permits")
+    assert rows, "expected at least one protected /permits route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+def test_v1_permits_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/v1/permits")
+    assert rows, "expected at least one protected /v1/permits route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+@patch("strr_api.resources.validation.ValidationService.validate_permit", return_value=({}, HTTPStatus.OK))
+def test_validate_permit_legacy_ok(mock_val, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post("/permits/:validatePermit", json={"registrationNumber": "X"}, headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+
+
+@patch("strr_api.resources.validation.ValidationService.validate_permit", return_value=({}, HTTPStatus.OK))
+def test_validate_permit_v1_ok(mock_val, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post("/v1/permits/:validatePermit", json={"registrationNumber": "X"}, headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+
+
+def test_validate_permit_legacy_real_service_ok(client, headers_public_user, serializable_host_registration):
+    reg_number = serializable_host_registration["registration_number"]
+    body = {
+        "identifier": reg_number,
+        "address": {"streetNumber": "100", "postalCode": "V8V1A1", "unitNumber": ""},
+    }
+    rv = client.post("/permits/:validatePermit", json=body, headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    data = rv.get_json()
+    assert data.get("status") == "ACTIVE"
+    assert "validUntil" in data
+
+
+def test_validate_permit_v1_real_service_ok(client, headers_public_user, serializable_host_registration):
+    reg_number = serializable_host_registration["registration_number"]
+    body = {
+        "identifier": reg_number,
+        "address": {"streetNumber": "100", "postalCode": "V8V1A1", "unitNumber": ""},
+    }
+    rv = client.post("/v1/permits/:validatePermit", json=body, headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json().get("status") == "ACTIVE"
+
+
+@patch(
+    "strr_api.resources.validation.ValidationService.validate_permit",
+    return_value=({"errors": [{"code": "PERMIT_NOT_FOUND"}]}, HTTPStatus.NOT_FOUND),
+)
+def test_validate_permit_legacy_not_found_shape(mock_val, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post(
+        "/permits/:validatePermit",
+        json={"identifier": "NO-SUCH-REG", "address": {"streetNumber": "1", "postalCode": "V8V1A1"}},
+        headers=headers,
+    )
+    assert_status(rv, HTTPStatus.NOT_FOUND)
+
+
+@patch(
+    "strr_api.resources.validation.ValidationService.validate_permit",
+    return_value=({"errors": [{"code": "PERMIT_NOT_FOUND"}]}, HTTPStatus.NOT_FOUND),
+)
+def test_validate_permit_v1_not_found_shape(mock_val, client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.post(
+        "/v1/permits/:validatePermit",
+        json={"identifier": "NO-SUCH-REG", "address": {"streetNumber": "1", "postalCode": "V8V1A1"}},
+        headers=headers,
+    )
+    assert_status(rv, HTTPStatus.NOT_FOUND)

--- a/strr-api/tests/unit/models/test_interactions.py
+++ b/strr-api/tests/unit/models/test_interactions.py
@@ -6,40 +6,47 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from strr_api.enums.enum import ChannelType, InteractionStatus
+from strr_api.enums.enum import ChannelType, InteractionStatus, RegistrationStatus
 from strr_api.models import Application, Registration, User
 from strr_api.models.interactions import CustomerInteraction
 
 
 @pytest.fixture
-def setup_parents(session: Session, random_string):
+def interaction_parents(session: Session, random_string, random_integer):
     """
-    Creates one parent record in each table so we have valid IDs
-    to link our interactions to.
+    Seed User / Registration / Application rows for interaction tests.
 
-    TODO: this should be part of a session wide set of fixture strategy
+    Uses DB-generated primary keys (no hard-coded ids) so tests stay isolated when the
+    shared ``setup_parents`` fixture from ``strr_test_utils.parent_fixtures`` also inserts
+    users in the same Postgres database during the suite.
     """
-    customer = User(id=2)
-    user = User(id=1)
-    app = Application(
-        id=1,
-        application_json={},
-        application_number=random_string(10),
-        type="",
-        registration_type=Registration.RegistrationType.HOST,
-    )
+    customer = User()
+    user = User()
+    session.add_all([user, customer])
+    session.flush()
+
     reg = Registration(
-        id=1,
         registration_type=Registration.RegistrationType.HOST,
         registration_number=random_string(10),
-        sbc_account_id=1,
-        status="ACTIVE",
+        sbc_account_id=random_integer(),
+        status=RegistrationStatus.ACTIVE,
         user_id=user.id,
         start_date=datetime.now(timezone.utc),
         expiry_date=(datetime.now(timezone.utc) + timedelta(days=365)).date(),
     )
+    session.add(reg)
+    session.flush()
 
-    session.add_all([user, app, customer, reg])
+    app = Application(
+        application_json={},
+        application_number=random_string(10),
+        type="",
+        registration_type=Registration.RegistrationType.HOST,
+        registration_id=reg.id,
+    )
+    session.add(app)
+    session.flush()
+
     session.commit()
 
     return {
@@ -66,9 +73,11 @@ def generate_interaction_data(**kwargs):
 # -------------------------------------------------------------------
 
 
-def test_create_interaction_with_customer(session, setup_parents):
+def test_create_interaction_with_customer(session, interaction_parents):
     """Test creating an interaction linked ONLY to a Customer."""
-    interaction = generate_interaction_data(user_id=setup_parents["user_id"], customer_id=setup_parents["customer_id"])
+    interaction = generate_interaction_data(
+        user_id=interaction_parents["user_id"], customer_id=interaction_parents["customer_id"]
+    )
 
     session.add(interaction)
     session.commit()
@@ -76,28 +85,28 @@ def test_create_interaction_with_customer(session, setup_parents):
     # Verify data persistence
     stored = session.scalar(select(CustomerInteraction).where(CustomerInteraction.id == interaction.id))
     assert stored is not None
-    assert stored.user_id == setup_parents["user_id"]
-    assert stored.customer_id == setup_parents["customer_id"]
+    assert stored.user_id == interaction_parents["user_id"]
+    assert stored.customer_id == interaction_parents["customer_id"]
     assert stored.application_id is None
     assert stored.registration_id is None
     assert stored.status == InteractionStatus.SENT
     assert stored.created_at is not None  # Verify server default func.now()
 
 
-def test_create_interaction_with_application(session, setup_parents):
+def test_create_interaction_with_application(session, interaction_parents):
     """Test creating an interaction linked ONLY to an Application."""
-    interaction = generate_interaction_data(application_id=setup_parents["app_id"])
+    interaction = generate_interaction_data(application_id=interaction_parents["app_id"])
     session.add(interaction)
     session.commit()
 
     assert interaction.id is not None
-    assert interaction.application_id == setup_parents["app_id"]
+    assert interaction.application_id == interaction_parents["app_id"]
 
 
-def test_find_by_uuid_returns_requested_interaction(session, setup_parents):
+def test_find_by_uuid_returns_requested_interaction(session, interaction_parents):
     """Test that UUID lookup does not match unrelated interaction rows."""
-    interaction_one = generate_interaction_data(customer_id=setup_parents["customer_id"])
-    interaction_two = generate_interaction_data(application_id=setup_parents["app_id"])
+    interaction_one = generate_interaction_data(customer_id=interaction_parents["customer_id"])
+    interaction_two = generate_interaction_data(application_id=interaction_parents["app_id"])
     session.add_all([interaction_one, interaction_two])
     session.commit()
 
@@ -106,22 +115,28 @@ def test_find_by_uuid_returns_requested_interaction(session, setup_parents):
     assert stored.id == interaction_two.id
 
 
-def test_find_by_id_idempotency_key_respects_key(session, setup_parents):
+def test_find_by_id_idempotency_key_respects_key(session, interaction_parents):
     """Test that idempotency lookup filters by the requested key."""
-    interaction_one = generate_interaction_data(registration_id=setup_parents["reg_id"], idempotency_key="job-key-one")
-    interaction_two = generate_interaction_data(registration_id=setup_parents["reg_id"], idempotency_key="job-key-two")
+    interaction_one = generate_interaction_data(
+        registration_id=interaction_parents["reg_id"], idempotency_key="job-key-one"
+    )
+    interaction_two = generate_interaction_data(
+        registration_id=interaction_parents["reg_id"], idempotency_key="job-key-two"
+    )
     session.add_all([interaction_one, interaction_two])
     session.commit()
 
-    stored = CustomerInteraction.find_by_id_idempotency_key("job-key-two", registration_id=setup_parents["reg_id"])
+    stored = CustomerInteraction.find_by_id_idempotency_key(
+        "job-key-two", registration_id=interaction_parents["reg_id"]
+    )
 
     assert stored.id == interaction_two.id
 
 
-def test_jsonb_metadata_storage(session, setup_parents):
+def test_jsonb_metadata_storage(session, interaction_parents):
     """Test that the JSONB column correctly stores and retrieves dictionaries."""
     meta = {"campaign_id": 123, "tags": ["urgent", "promo"]}
-    interaction = generate_interaction_data(customer_id=setup_parents["customer_id"], meta_data=meta)
+    interaction = generate_interaction_data(customer_id=interaction_parents["customer_id"], meta_data=meta)
     session.add(interaction)
     session.commit()
 
@@ -135,13 +150,14 @@ def test_jsonb_metadata_storage(session, setup_parents):
 # -------------------------------------------------------------------
 
 
-def test_constraint_fails_if_multiple_parents(session, setup_parents):
+def test_constraint_fails_if_multiple_parents(session, interaction_parents):
     """
     Ensure the DB rejects rows that have MORE than 1 parent set.
     (e.g., customer_id AND application_id are both set)
     """
     interaction = generate_interaction_data(
-        customer_id=setup_parents["customer_id"], application_id=setup_parents["app_id"]  # Invalid: Can't have both
+        customer_id=interaction_parents["customer_id"],
+        application_id=interaction_parents["app_id"],  # Invalid: Can't have both
     )
     session.add(interaction)
 
@@ -171,17 +187,17 @@ def test_constraint_fails_if_zero_parents(session):
 # -------------------------------------------------------------------
 
 
-def test_unique_interaction_uuid(session, setup_parents):
+def test_unique_interaction_uuid(session, interaction_parents):
     """Test that interaction_uuid must be unique."""
     uid = str(uuid.uuid4())
 
     # First one
-    i1 = generate_interaction_data(interaction_uuid=uid, customer_id=setup_parents["customer_id"])
+    i1 = generate_interaction_data(interaction_uuid=uid, customer_id=interaction_parents["customer_id"])
     session.add(i1)
     session.commit()
 
     # Second one with same UUID
-    i2 = generate_interaction_data(interaction_uuid=uid, customer_id=setup_parents["customer_id"])
+    i2 = generate_interaction_data(interaction_uuid=uid, customer_id=interaction_parents["customer_id"])
     session.add(i2)
 
     with pytest.raises(IntegrityError):


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1543

*Description of changes:*

Adds integration tests for the “platform” API slice (auth smoke + patched/live scenarios where applicable):

- `tests/integration/resources/test_address_api.py` — `/address` and `/v1/address`
- `tests/integration/resources/test_validation_api.py` — `/permits` and `/v1/permits` validation
- `tests/integration/resources/test_documents_api.py` — global `/documents` upload/delete paths
- `tests/integration/resources/test_account_api.py` — `/accounts` (SBC paths patched where needed)
- `tests/integration/resources/test_users_api.py` — `/users` profile and ToS

Depends on integration harness in #1608. Independent of the smoke-only PR (#1612); rebase onto `main` after #1612 merges if you want a strictly sequential merge order.

**Test plan**

- `cd strr-api && make test-integration`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License