### PR TITLE
test(strr-api): add applications integration tests

### DIFF
--- a/strr-api/tests/integration/resources/test_applications_api.py
+++ b/strr-api/tests/integration/resources/test_applications_api.py
@@ -1,0 +1,326 @@
+"""Integration tests for public/account ``/applications`` paths and auth smoke."""
+
+from http import HTTPStatus
+from unittest.mock import patch
+
+import pytest
+
+from strr_api.enums.enum import ApplicationType, ErrorMessage
+from tests.integration.application_seed import (
+    generate_application_number,
+    seed_applicant_visible_application_event,
+    seed_draft_application,
+    seed_listable_application,
+)
+from tests.integration.helpers import (
+    assert_json_keys,
+    assert_status,
+    load_mock_json,
+    protected_routes_with_prefix,
+    resolve_path_for_unauth,
+    unauthenticated_request,
+)
+
+
+def test_applications_routes_require_auth_without_bearer(client, app):
+    rows = protected_routes_with_prefix(app, "/applications")
+    assert rows, "expected at least one protected /applications route"
+    for method, rule in rows:
+        path = resolve_path_for_unauth(rule)
+        rv = unauthenticated_request(client, method, path)
+        assert rv.status_code == HTTPStatus.UNAUTHORIZED, f"{method} {rule}"
+
+
+@patch("strr_api.services.strr_pay.create_invoice")
+@pytest.mark.slow
+def test_post_application_with_invoice_mock_returns_success(
+    mock_invoice, client, jwt, integration_account_id, mock_invoice_response
+):
+    mock_invoice.return_value = mock_invoice_response
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    headers["Account-Id"] = str(integration_account_id)
+    payload = load_mock_json("host_registration.json")
+    rv = client.post("/applications", json=payload, headers=headers)
+    assert rv.status_code in (HTTPStatus.OK, HTTPStatus.CREATED), rv.get_data(as_text=True)
+
+
+def test_get_applications_list_ok(client, jwt, integration_account_id):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    headers["Account-Id"] = str(integration_account_id)
+    rv = client.get("/applications", headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.is_json
+
+
+def test_get_applications_list_envelope_and_row(client, headers_public_user, serializable_application):
+    rv = client.get("/applications", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "page", "limit", "applications", "total")
+    assert isinstance(data["applications"], list)
+    nums = {a["header"]["applicationNumber"] for a in data["applications"]}
+    assert serializable_application["application_number"] in nums
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "status=FULL_REVIEW",
+        "registrationType=HOST",
+        "sortBy=id&sortOrder=desc",
+        "limit=10&page=1",
+        "status=FULL_REVIEW&registrationType=HOST",
+    ],
+)
+def test_get_applications_list_query_params_ok(client, headers_public_user, serializable_application, query):
+    num = serializable_application["application_number"]
+    rv = client.get(f"/applications?{query}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "page", "limit", "applications", "total")
+    nums = {a["header"]["applicationNumber"] for a in data["applications"]}
+    assert num in nums
+
+
+@patch("strr_api.services.application_service.ApplicationService.enrich_document_added_on_from_gcp", lambda d: d)
+def test_get_application_detail_shape(client, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.get(f"/applications/{num}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "header", "registration")
+    assert data["header"]["applicationNumber"] == num
+    assert isinstance(data["registration"], dict)
+
+
+@patch("strr_api.services.application_service.ApplicationService.enrich_document_added_on_from_gcp", lambda d: d)
+def test_get_application_events_item_keys(client, session, headers_public_user, serializable_application):
+    aid = serializable_application["application_id"]
+    num = serializable_application["application_number"]
+    seed_applicant_visible_application_event(session, aid)
+    rv = client.get(f"/applications/{num}/events", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    events = rv.get_json()
+    assert isinstance(events, list)
+    assert events, "expected seeded applicant-visible event"
+    first = events[0]
+    for k in ("eventType", "eventName", "message", "createdDate"):
+        assert k in first, first
+
+
+def test_get_application_not_found_wrong_account(client, session, headers_public_user, serializable_host_registration):
+    from tests.integration.application_seed import generate_application_number, seed_listable_application
+
+    other = seed_listable_application(
+        session,
+        account_id=999999991,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=None,
+        application_number=generate_application_number(),
+        status="FULL_REVIEW",
+        application_json=load_mock_json("host_registration.json"),
+    )
+    rv = client.get(
+        f"/applications/{other['application_number']}",
+        headers=headers_public_user(),
+    )
+    assert_status(rv, HTTPStatus.NOT_FOUND)
+
+
+def test_applications_user_search_envelope(client, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.get(f"/applications/user/search?text={num[:8]}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "page", "limit", "applications", "total")
+
+
+def test_applications_user_search_short_query_bad_request(client, headers_public_user):
+    rv = client.get("/applications/user/search?text=ab", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_applications_user_search_requires_account_id(client, jwt):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.get("/applications/user/search?text=abc", headers=headers)
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_delete_draft_application_returns_no_content_and_get_is_not_found(
+    client, session, headers_public_user, integration_account_id, serializable_host_registration
+):
+    num = generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+    )
+    session.flush()
+    rv = client.delete(f"/applications/{num}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.NO_CONTENT)
+    rv2 = client.get(f"/applications/{num}", headers=headers_public_user())
+    assert_status(rv2, HTTPStatus.NOT_FOUND)
+
+
+def test_delete_application_returns_bad_request_when_not_draft(
+    client, session, headers_public_user, integration_account_id, serializable_host_registration
+):
+    num = generate_application_number()
+    seed_listable_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+        status="FULL_REVIEW",
+        application_json=load_mock_json("host_registration.json"),
+    )
+    session.flush()
+    rv = client.delete(f"/applications/{num}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+    err = rv.get_json()
+    assert err is not None
+    assert ErrorMessage.APPLICATION_CANNOT_BE_DELETED.value in (err.get("message") or "")
+
+
+def test_delete_draft_application_not_found_wrong_account(
+    client, session, headers_public_user, serializable_host_registration
+):
+    num = generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=999999991,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+    )
+    session.flush()
+    rv = client.delete(f"/applications/{num}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.NOT_FOUND)
+
+
+@patch("strr_api.services.strr_pay.create_invoice")
+def test_put_draft_application_with_is_draft_does_not_call_invoice(
+    mock_invoice,
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+):
+    num = generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+    )
+    session.flush()
+    payload = load_mock_json("host_registration.json")
+    headers = headers_public_user()
+    headers["isDraft"] = "true"
+    rv = client.put(f"/applications/{num}", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    mock_invoice.assert_not_called()
+    body = rv.get_json()
+    assert body["header"]["applicationNumber"] == num
+
+
+@patch("strr_api.services.strr_pay.create_invoice")
+def test_post_draft_application_with_is_draft_does_not_call_invoice(
+    mock_invoice,
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+):
+    """``POST /applications/<string:application_number>`` shares create handler with PUT."""
+    num = generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+    )
+    session.flush()
+    payload = load_mock_json("host_registration.json")
+    headers = headers_public_user()
+    headers["isDraft"] = "true"
+    rv = client.post(f"/applications/{num}", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    mock_invoice.assert_not_called()
+    body = rv.get_json()
+    assert body["header"]["applicationNumber"] == num
+
+
+def test_put_renewal_draft_registration_id_mismatch_returns_bad_request(
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+):
+    rid = serializable_host_registration["registration_id"]
+    num = generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=rid,
+        application_number=num,
+        application_type=ApplicationType.RENEWAL.value,
+    )
+    session.flush()
+    payload = load_mock_json("host_registration.json")
+    payload.setdefault("header", {})["applicationType"] = ApplicationType.RENEWAL.value
+    payload["header"]["registrationId"] = rid + 987654321  # differs from draft row
+    headers = headers_public_user()
+    headers["isDraft"] = "true"
+    rv = client.put(f"/applications/{num}", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+    err = rv.get_json()
+    assert err is not None
+    assert ErrorMessage.REGISTRATION_ID_MISMATCH.value in (err.get("message") or "")
+
+
+@patch("strr_api.services.strr_pay.create_invoice")
+@pytest.mark.slow
+def test_put_renewal_draft_final_submit_with_invoice_mock(
+    mock_invoice,
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+    mock_invoice_response,
+):
+    """Non-draft PUT on a renewal draft runs validation, invoice, and status update (SBC pay mocked)."""
+    rid = serializable_host_registration["registration_id"]
+    num = generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=rid,
+        application_number=num,
+        application_type=ApplicationType.RENEWAL.value,
+    )
+    session.flush()
+    payload = load_mock_json("host_registration.json")
+    payload["header"] = {
+        "applicationType": ApplicationType.RENEWAL.value,
+        "registrationId": rid,
+    }
+    mock_invoice.return_value = mock_invoice_response
+    rv = client.put(f"/applications/{num}", json=payload, headers=headers_public_user())
+    assert rv.status_code in (HTTPStatus.OK, HTTPStatus.CREATED), rv.get_data(as_text=True)
+    mock_invoice.assert_called()
+    body = rv.get_json()
+    assert body["header"]["applicationNumber"] == num

--- a/strr-api/tests/integration/resources/test_applications_staff_api.py
+++ b/strr-api/tests/integration/resources/test_applications_staff_api.py
@@ -1,0 +1,303 @@
+"""Integration tests for staff / privileged ``/applications`` flows."""
+
+from http import HTTPStatus
+from io import BytesIO
+from unittest.mock import patch
+
+from flask import Response
+
+from strr_api.models.application import Application as AppModel
+from tests.integration.application_seed import generate_application_number, seed_listable_application
+from tests.integration.helpers import assert_json_keys, assert_status, load_mock_json
+from tests.unit.resources.conftest import MOCK_PAYMENT_COMPLETED_RESPONSE
+
+
+def test_applications_search_examiner_envelope(client, headers_strr_examiner):
+    rv = client.get("/applications/search?text=abc", headers=headers_strr_examiner())
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "page", "limit", "applications", "total")
+    assert isinstance(data["applications"], list)
+
+
+def test_applications_search_investigator_envelope(client, headers_strr_investigator):
+    rv = client.get("/applications/search?text=abc", headers=headers_strr_investigator())
+    assert_status(rv, HTTPStatus.OK)
+    data = assert_json_keys(rv, "page", "limit", "applications", "total")
+    assert isinstance(data["applications"], list)
+
+
+def test_applications_search_short_query_bad_request(client, headers_strr_examiner):
+    rv = client.get("/applications/search?text=ab", headers=headers_strr_examiner())
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_put_assign_then_status_additional_info(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    assert_status(client.put(f"/applications/{num}/assign", headers=headers_strr_examiner()), HTTPStatus.OK)
+    rv = client.put(
+        f"/applications/{num}/status",
+        headers=headers_strr_examiner(),
+        json={"status": AppModel.Status.ADDITIONAL_INFO_REQUESTED.value},
+    )
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json()["header"]["status"] == AppModel.Status.ADDITIONAL_INFO_REQUESTED.value
+
+
+def test_put_status_forbidden_when_not_assignee(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.put(
+        f"/applications/{num}/status",
+        headers=headers_strr_examiner(),
+        json={"status": AppModel.Status.ADDITIONAL_INFO_REQUESTED.value},
+    )
+    assert_status(rv, HTTPStatus.FORBIDDEN)
+
+
+def test_post_notice_forbidden_when_not_assignee(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.post(
+        f"/applications/{num}/notice-of-consideration",
+        headers=headers_strr_examiner(),
+        json={"content": "NOC body"},
+    )
+    assert_status(rv, HTTPStatus.FORBIDDEN)
+
+
+def test_post_set_aside_forbidden_when_not_assignee(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.post(
+        f"/applications/{num}/decision/set-aside",
+        headers=headers_strr_examiner(),
+        json={},
+    )
+    assert_status(rv, HTTPStatus.FORBIDDEN)
+
+
+def test_put_assign_unassign_then_unassign_bad_request(
+    client, session, headers_strr_examiner, serializable_application
+):
+    num = serializable_application["application_number"]
+    assert_status(client.put(f"/applications/{num}/assign", headers=headers_strr_examiner()), HTTPStatus.OK)
+    assert_status(client.put(f"/applications/{num}/unassign", headers=headers_strr_examiner()), HTTPStatus.OK)
+    rv2 = client.put(f"/applications/{num}/unassign", headers=headers_strr_examiner())
+    assert_status(rv2, HTTPStatus.BAD_REQUEST)
+
+
+def test_post_notice_ok_when_assignee(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    assert_status(client.put(f"/applications/{num}/assign", headers=headers_strr_examiner()), HTTPStatus.OK)
+    rv = client.post(
+        f"/applications/{num}/notice-of-consideration",
+        headers=headers_strr_examiner(),
+        json={"content": "Notice content for integration."},
+    )
+    assert_status(rv, HTTPStatus.OK)
+
+
+def test_post_set_aside_ok_when_assignee(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    assert_status(client.put(f"/applications/{num}/assign", headers=headers_strr_examiner()), HTTPStatus.OK)
+    rv = client.post(
+        f"/applications/{num}/decision/set-aside",
+        headers=headers_strr_examiner(),
+        json={},
+    )
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json()["header"].get("isSetAside") is True
+
+
+def test_patch_str_address_invalid_schema_bad_request(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.patch(
+        f"/applications/{num}/str-address",
+        headers=headers_strr_examiner(),
+        json={"unitAddress": {}},
+    )
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_patch_str_address_ok(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    payload = {
+        "unitAddress": {
+            "streetNumber": "12167",
+            "streetName": "GREENWELL ST MAPLE RIDGE",
+            "city": "MAPLE RIDGE",
+            "postalCode": "V2X 7N1",
+            "province": "BC",
+        }
+    }
+    rv = client.patch(
+        f"/applications/{num}/str-address",
+        headers=headers_strr_examiner(),
+        json=payload,
+    )
+    assert_status(rv, HTTPStatus.OK)
+    ua = rv.get_json().get("registration", {}).get("unitAddress", {})
+    assert ua.get("streetNumber") == "12167"
+
+
+def test_get_ltsa_ok_patched(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    with patch("strr_api.services.ltsa_service.LtsaService.get_application_ltsa_records", return_value=[]):
+        rv = client.get(f"/applications/{num}/ltsa", headers=headers_strr_examiner())
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json() == []
+
+
+def test_get_auto_approval_records_ok_patched(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    with patch(
+        "strr_api.services.approval_service.ApprovalService.get_approval_records_for_application",
+        return_value=[],
+    ):
+        rv = client.get(f"/applications/{num}/auto-approval-records", headers=headers_strr_examiner())
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json() == []
+
+
+def test_get_related_registrations_ok(client, session, headers_strr_examiner, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.get(
+        f"/applications/{num}/host/related-registrations",
+        headers=headers_strr_examiner(),
+    )
+    assert_status(rv, HTTPStatus.OK)
+    assert isinstance(rv.get_json(), list)
+
+
+def test_post_application_document_ok_patched_upload(client, session, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    with patch(
+        "strr_api.services.document_service.DocumentService.upload_document",
+        return_value={
+            "fileKey": "app-doc-key-01",
+            "fileName": "doc.txt",
+            "fileType": "text/plain",
+        },
+    ):
+        rv = client.post(
+            f"/applications/{num}/documents",
+            headers=headers_public_user(),
+            data={
+                "file": (BytesIO(b"hello"), "hello.txt"),
+                "documentType": "OTHERS",
+            },
+            content_type="multipart/form-data",
+        )
+    assert_status(rv, HTTPStatus.CREATED)
+    body = rv.get_json()
+    assert body.get("fileKey") == "app-doc-key-01"
+
+
+def test_put_application_document_ok_patched_upload(client, session, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    with patch(
+        "strr_api.services.document_service.DocumentService.upload_document",
+        return_value={
+            "fileKey": "app-doc-put-01",
+            "fileName": "put.txt",
+            "fileType": "text/plain",
+        },
+    ):
+        rv = client.put(
+            f"/applications/{num}/documents",
+            headers=headers_public_user(),
+            data={
+                "file": (BytesIO(b"put-body"), "put.txt"),
+                "documentType": "OTHERS",
+            },
+            content_type="multipart/form-data",
+        )
+    assert_status(rv, HTTPStatus.OK)
+    keys = {d.get("fileKey") for d in rv.get_json().get("registration", {}).get("documents", [])}
+    assert "app-doc-put-01" in keys
+
+
+@patch("strr_api.services.application_service.ApplicationService.enrich_document_added_on_from_gcp", lambda d: d)
+def test_get_application_document_ok_patched_storage(client, session, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    with patch("strr_api.services.document_service.DocumentService.get_file_by_key", return_value=b"bytes"):
+        rv = client.get(
+            f"/applications/{num}/documents/a1234",
+            headers=headers_public_user(),
+        )
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.data == b"bytes"
+
+
+def test_get_application_document_wrong_key_bad_request(client, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    rv = client.get(
+        f"/applications/{num}/documents/does-not-exist",
+        headers=headers_public_user(),
+    )
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_delete_application_document_ok_patched(client, session, headers_public_user, serializable_application):
+    num = serializable_application["application_number"]
+    with patch("strr_api.services.document_service.DocumentService.delete_document", return_value=None):
+        rv = client.delete(
+            f"/applications/{num}/documents/a1234",
+            headers=headers_public_user(),
+        )
+    assert_status(rv, HTTPStatus.NO_CONTENT)
+
+
+def test_put_payment_details_missing_account_id_bad_request(client, jwt, serializable_application):
+    from tests.unit.utils.auth_helpers import PUBLIC_USER, create_header
+
+    num = serializable_application["application_number"]
+    headers = create_header(jwt, [PUBLIC_USER])
+    rv = client.put(f"/applications/{num}/payment-details", headers=headers, json={})
+    assert_status(rv, HTTPStatus.BAD_REQUEST)
+
+
+def test_put_payment_details_ok_patched_pay(
+    client, session, headers_public_user, serializable_host_registration, integration_account_id
+):
+    num = generate_application_number()
+    seed_listable_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+        status=AppModel.Status.PAYMENT_DUE.value,
+        application_json=load_mock_json("host_registration.json"),
+        invoice_id=555,
+        payment_status_code="CREATED",
+    )
+    with patch(
+        "strr_api.resources.application.strr_pay.get_payment_details_by_invoice_id",
+        return_value=MOCK_PAYMENT_COMPLETED_RESPONSE,
+    ):
+        rv = client.put(f"/applications/{num}/payment-details", headers=headers_public_user(), json={})
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json()["header"]["status"] == AppModel.Status.PAID.value
+
+
+def test_get_payment_receipt_ok_patched(
+    client, session, headers_public_user, serializable_host_registration, integration_account_id
+):
+    num = generate_application_number()
+    seed_listable_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=serializable_host_registration["registration_id"],
+        application_number=num,
+        status=AppModel.Status.PAID.value,
+        application_json=load_mock_json("host_registration.json"),
+        invoice_id=777,
+        payment_status_code="COMPLETED",
+    )
+
+    def _fake_receipt(_jwt, _application):
+        return Response(b"%PDF-1.4", mimetype="application/pdf", status=HTTPStatus.OK)
+
+    with patch("strr_api.resources.application.strr_pay.get_payment_receipt", side_effect=_fake_receipt):
+        rv = client.get(f"/applications/{num}/payment/receipt", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.data.startswith(b"%PDF")

--- a/strr-api/tests/unit/resources/test_registration_applications.py
+++ b/strr-api/tests/unit/resources/test_registration_applications.py
@@ -78,11 +78,23 @@ def test_delete_draft_applications(session, client, jwt):
 
 
 def test_staff_cannot_access_draft_applications(session, client, jwt):
-    headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-    rv = client.get("/applications/search", headers=headers)
+    """Examiner search excludes drafts; do not assume an otherwise empty database."""
+    with open(CREATE_REGISTRATION_INDIVIDUAL_AS_COHOST) as f:
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        headers["isDraft"] = True
+        json_data = json.load(f)
+
+        rv = client.post("/applications", json=json_data, headers=headers)
+        assert HTTPStatus.OK == rv.status_code
+        draft_number = rv.json.get("header").get("applicationNumber")
+
+    examiner_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+    rv = client.get("/applications/search", headers=examiner_headers)
     assert HTTPStatus.OK == rv.status_code
-    applications = rv.json
-    assert len(applications.get("applications")) == 0
+    applications = rv.json.get("applications") or []
+    returned_numbers = {a.get("header", {}).get("applicationNumber") for a in applications}
+    assert draft_number not in returned_numbers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1543

*Description of changes:*

- Add `tests/integration/resources/test_applications_api.py` — applicant/account `/applications` flows (list/detail, user search, draft delete, renewal draft/submit with mocked pay where marked slow).
- Add `tests/integration/resources/test_applications_staff_api.py` — staff search, assign/unassign, status/NOC/set-aside, STR address, LTSA, documents, payment/receipt (patched external services as needed).

Builds on integration harness (#1608) and current `main` (includes platform slice #1613).

**Test plan**

- `cd strr-api && make test`

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License