### PR TITLE
feat(ui): 1081 - hide address error in host renewals

### DIFF
--- a/strr-host-pm-web/app/components/form/DefineYourRental/UnitRequirements/index.vue
+++ b/strr-host-pm-web/app/components/form/DefineYourRental/UnitRequirements/index.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 defineProps<{ isComplete: boolean }>()
 const reqStore = usePropertyReqStore()
+const { isRegistrationRenewal } = storeToRefs(useHostPermitStore())
 </script>
 <template>
   <div class="flex flex-col gap-4" data-testid="property-requirements-section">
     <FormDefineYourRentalUnitRequirementsError
-      v-if="reqStore.propertyReqError.type !== undefined"
+      v-if="reqStore.propertyReqError.type !== undefined && !isRegistrationRenewal"
       class="mt-10"
     />
 

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1081

*Description of changes:*
- Hide error in Host renewals when address validation returns no found address

<img width="2362" height="1658" alt="Screenshot 2026-05-06 at 14 20 44" src="https://github.com/user-attachments/assets/70ee008c-c94c-4808-8312-2552bcfe1888" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
