### PR TITLE
fix(ui): 1573 host add Individuals/businesses field pre-populated fix

### DIFF
--- a/strr-host-pm-web/app/stores/hostOwner.ts
+++ b/strr-host-pm-web/app/stores/hostOwner.ts
@@ -130,6 +130,9 @@ export const useHostOwnerStore = defineStore('host/owner', () => {
 
   const $reset = () => {
     hostOwners.value = []
+    activeOwner.value = undefined
+    activeOwnerEditIndex.value = -1
+    isCraNumberOptional.value = false
   }
 
   return {

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "engines": {
     "node": ">=24"
   },

--- a/strr-host-pm-web/tests/unit/store-host-owner.spec.ts
+++ b/strr-host-pm-web/tests/unit/store-host-owner.spec.ts
@@ -231,3 +231,20 @@ describe('useHostOwnerStore - add/remove owners', () => {
     expect(store.hostOwners).toHaveLength(0)
   })
 })
+
+describe('useHostOwnerStore - $reset', () => {
+  it('should clear transient owner form state', () => {
+    const store = useHostOwnerStore()
+    store.activeOwner = { ...mockHostOwner }
+    store.activeOwnerEditIndex = 2
+    store.isCraNumberOptional = true
+    store.addHostOwner({ ...mockHostOwner, role: OwnerRole.HOST })
+
+    store.$reset()
+
+    expect(store.hostOwners).toEqual([])
+    expect(store.activeOwner).toBeUndefined()
+    expect(store.activeOwnerEditIndex).toBe(-1)
+    expect(store.isCraNumberOptional).toBe(false)
+  })
+})


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1573

*Description of changes:*
### THE BUG:
- Sign in as a HOST
- Start a new application
- Fill in all fields in the 1st step: Define your short-term rental.
- Go to the 2nd step: Add individuals and businesses
- Fill in all fields
- Click on Save and resume later
- Now start another application
- Fill in all fields in the 1st step: Define your short-term rental using exactly the same information provided in the draft you just saved
- Go to the 2nd step
- Observe that the fields are prepopulated

This PR fixes the above issue^ The fields are now not prepopulated:
<img width="1398" height="1131" alt="image" src="https://github.com/user-attachments/assets/b2bf1f24-c29f-4ca3-8e3d-3e5e5ed32429" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
