### PR TITLE
fix(strr-email): log renewal dispatch failures and clarify error response (#1623)

### DIFF
--- a/docs/runbooks/queue-services-and-jobs.md
+++ b/docs/runbooks/queue-services-and-jobs.md
@@ -86,6 +86,25 @@ resource.labels.service_name="strr-email-prod"
 jsonPayload.message=~"(completed ce|Error)"
 ```
 
+**Trace one queue event (recommended):**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-email-prod"
+jsonPayload.message=~"event_id=<cloud_event_id>"
+```
+
+Use this to follow a single message across received/completed/error logs in `strr-email`.
+
+**Errors for one event:**
+
+```text
+resource.type="cloud_run_revision"
+resource.labels.service_name="strr-email-prod"
+severity>="ERROR"
+jsonPayload.message=~"event_id=<cloud_event_id>"
+```
+
 ## Log diving: Cloud Run Jobs
 
 **Resource type:** `cloud_run_job` (verify in your project; filters differ from `cloud_run_revision`).

--- a/queue_services/strr-email/src/strr_email/resources/email_listener.py
+++ b/queue_services/strr-email/src/strr_email/resources/email_listener.py
@@ -194,7 +194,7 @@ def worker():
                 "Error dispatching renewal reminder email via InteractionService (ce=%s)",
                 ce,
             )
-            return jsonify({"message": "Error posting email to notify-api."}), 400
+            return jsonify({"message": "Unable to send renewal reminder email."}), 400
 
     else:
         token = AuthService.get_service_client_token()

--- a/queue_services/strr-email/src/strr_email/resources/email_listener.py
+++ b/queue_services/strr-email/src/strr_email/resources/email_listener.py
@@ -189,8 +189,11 @@ def worker():
             logger.info(f"completed ce: {str(ce)}")
             return jsonify({"interaction": resp.interaction_uuid}), HTTPStatus.OK
 
-        except Exception as err:
-            logger.error(f"Error posting email to notify-api for: {str(ce)}")
+        except Exception:
+            logger.exception(
+                "Error dispatching renewal reminder email via InteractionService (ce=%s)",
+                ce,
+            )
             return jsonify({"message": "Error posting email to notify-api."}), 400
 
     else:

--- a/queue_services/strr-email/src/strr_email/resources/email_listener.py
+++ b/queue_services/strr-email/src/strr_email/resources/email_listener.py
@@ -104,7 +104,8 @@ def worker():
         logger.info("get_simple_cloud_event returned none")
         return {}, HTTPStatus.OK
 
-    logger.info(f"received ce: {str(ce)}")
+    event_id = getattr(ce, "id", None)
+    logger.info("received ce (event_id=%s): %s", event_id, ce)
 
     # 2. Get email information
     if not (email_info := get_email_info(ce)):
@@ -126,7 +127,11 @@ def worker():
             application := Application.find_by_application_number(email_info.application_number)
         ):
             # no application matching the application number
-            logger.error(f"Error: application {email_info.application_number} not found.")
+            logger.error(
+                "Error: application %s not found (event_id=%s)",
+                email_info.application_number,
+                event_id,
+            )
             return (
                 jsonify(
                     {"message": f"Application number ({email_info.application_number}) not found."}
@@ -143,7 +148,11 @@ def worker():
             )
         ):
             # no application matching the application number
-            logger.error(f"Error: Registration {email_info.registration_number} not found.")
+            logger.error(
+                "Error: Registration %s not found (event_id=%s)",
+                email_info.registration_number,
+                event_id,
+            )
             return (
                 jsonify(
                     {
@@ -186,12 +195,14 @@ def worker():
                 application_id=application.id if application else None,
                 registration_id=registration.id if registration else None,
             )
-            logger.info(f"completed ce: {str(ce)}")
+            logger.info("completed ce (event_id=%s): %s", event_id, ce)
             return jsonify({"interaction": resp.interaction_uuid}), HTTPStatus.OK
 
         except Exception:
             logger.exception(
-                "Error dispatching renewal reminder email via InteractionService (ce=%s)",
+                "Error dispatching renewal reminder email via InteractionService "
+                "(event_id=%s, ce=%s)",
+                event_id,
                 ce,
             )
             return jsonify({"message": "Unable to send renewal reminder email."}), 400
@@ -209,11 +220,16 @@ def worker():
         )
 
     if resp.status_code not in [HTTPStatus.OK, HTTPStatus.ACCEPTED, HTTPStatus.CREATED]:
-        logger.info(f"Error {resp.status_code} - {str(resp.json())}")
-        logger.error(f"Error posting email to notify-api for: {str(ce)}")
+        logger.error(
+            "Error posting email to notify-api (event_id=%s, status=%s, response=%s, ce=%s)",
+            event_id,
+            resp.status_code,
+            resp.text,
+            ce,
+        )
         return jsonify({"message": "Error posting email to notify-api."}), resp.status_code
 
-    logger.info(f"completed ce: {str(ce)}")
+    logger.info("completed ce (event_id=%s): %s", event_id, ce)
     return {}, HTTPStatus.OK
 
 

--- a/queue_services/strr-email/tests/unit/test_email_listener_worker.py
+++ b/queue_services/strr-email/tests/unit/test_email_listener_worker.py
@@ -249,6 +249,7 @@ def test_worker_strata_renewal_dispatch_success(app, mocker, ce_factory):
 
 
 def test_worker_renewal_dispatch_raises_returns_400(app, mocker, ce_factory):
+    log_mock = mocker.patch("strr_email.resources.email_listener.logger")
     ce = ce_factory(registrationNumber="H1", emailType="HOST_RENEWAL_REMINDER")
     reg = _host_reg()
     mocker.patch(
@@ -258,6 +259,10 @@ def test_worker_renewal_dispatch_raises_returns_400(app, mocker, ce_factory):
     _patch_read_pipeline(mocker, ce, reg, _HOST_TPL)
     with app.test_request_context("/", method="POST", data=b"{}"):
         assert worker()[1] == 400
+    log_mock.exception.assert_called_once_with(
+        "Error dispatching renewal reminder email via InteractionService (ce=%s)",
+        ce,
+    )
 
 
 def _minimal_app_dict():

--- a/queue_services/strr-email/tests/unit/test_email_listener_worker.py
+++ b/queue_services/strr-email/tests/unit/test_email_listener_worker.py
@@ -258,7 +258,9 @@ def test_worker_renewal_dispatch_raises_returns_400(app, mocker, ce_factory):
     )
     _patch_read_pipeline(mocker, ce, reg, _HOST_TPL)
     with app.test_request_context("/", method="POST", data=b"{}"):
-        assert worker()[1] == 400
+        body, status = worker()
+    assert status == 400
+    assert body.get_json()["message"] == "Unable to send renewal reminder email."
     log_mock.exception.assert_called_once_with(
         "Error dispatching renewal reminder email via InteractionService (ce=%s)",
         ce,

--- a/queue_services/strr-email/tests/unit/test_email_listener_worker.py
+++ b/queue_services/strr-email/tests/unit/test_email_listener_worker.py
@@ -126,13 +126,17 @@ def test_worker_no_cloud_event_returns_200(app, mocker):
 
 
 def test_worker_no_email_info_returns_200(app, mocker, ce_factory):
-    mocker.patch.object(gcp_queue, "get_simple_cloud_event", return_value=ce_factory(foo="bar"))
+    log_mock = mocker.patch("strr_email.resources.email_listener.logger")
+    ce = ce_factory(foo="bar")
+    mocker.patch.object(gcp_queue, "get_simple_cloud_event", return_value=ce)
     mocker.patch("strr_email.resources.email_listener.get_email_info", return_value=None)
     with app.test_request_context("/", method="POST", data=b"{}"):
         assert worker()[1] == HTTPStatus.OK
+    log_mock.info.assert_any_call("received ce (event_id=%s): %s", "e1", ce)
 
 
 def test_worker_application_not_found(app, mocker, ce_factory):
+    log_mock = mocker.patch("strr_email.resources.email_listener.logger")
     ce = ce_factory(applicationNumber="A-404", emailType="HOST_DECLINED")
     mocker.patch.object(gcp_queue, "get_simple_cloud_event", return_value=ce)
     mocker.patch("strr_email.resources.email_listener.Path.read_text", return_value="# x\n")
@@ -145,9 +149,13 @@ def test_worker_application_not_found(app, mocker, ce_factory):
     )
     with app.test_request_context("/", method="POST", data=b"{}"):
         assert worker()[1] == HTTPStatus.NOT_FOUND
+    log_mock.error.assert_called_once_with(
+        "Error: application %s not found (event_id=%s)", "A-404", "e1"
+    )
 
 
 def test_worker_registration_not_found(app, mocker, ce_factory):
+    log_mock = mocker.patch("strr_email.resources.email_listener.logger")
     ce = ce_factory(registrationNumber="R-404", emailType="HOST_RENEWAL_REMINDER")
     mocker.patch.object(gcp_queue, "get_simple_cloud_event", return_value=ce)
     mocker.patch("strr_email.resources.email_listener.Path.read_text", return_value="# x\n")
@@ -160,6 +168,9 @@ def test_worker_registration_not_found(app, mocker, ce_factory):
     )
     with app.test_request_context("/", method="POST", data=b"{}"):
         assert worker()[1] == HTTPStatus.NOT_FOUND
+    log_mock.error.assert_called_once_with(
+        "Error: Registration %s not found (event_id=%s)", "R-404", "e1"
+    )
 
 
 @pytest.mark.parametrize(
@@ -189,6 +200,7 @@ def test_worker_registration_branch_returns_empty_ok(
 
 
 def test_worker_renewal_dispatch_success(app, mocker, ce_factory):
+    log_mock = mocker.patch("strr_email.resources.email_listener.logger")
     ce = ce_factory(registrationNumber="H1", emailType="HOST_RENEWAL_REMINDER")
     reg = _host_reg()
     mocker.patch(
@@ -199,6 +211,7 @@ def test_worker_renewal_dispatch_success(app, mocker, ce_factory):
     with app.test_request_context("/", method="POST", data=b"{}"):
         resp = worker()
     assert resp[1] == HTTPStatus.OK and resp[0].get_json().get("interaction") == "uuid-1"
+    log_mock.info.assert_any_call("completed ce (event_id=%s): %s", "e1", ce)
 
 
 def test_worker_platform_renewal_dispatch_success(app, mocker, ce_factory):
@@ -262,7 +275,8 @@ def test_worker_renewal_dispatch_raises_returns_400(app, mocker, ce_factory):
     assert status == 400
     assert body.get_json()["message"] == "Unable to send renewal reminder email."
     log_mock.exception.assert_called_once_with(
-        "Error dispatching renewal reminder email via InteractionService (ce=%s)",
+        "Error dispatching renewal reminder email via InteractionService (event_id=%s, ce=%s)",
+        "e1",
         ce,
     )
 
@@ -337,6 +351,7 @@ def _patch_legacy_application_flow(mocker, app_obj, ce):
 )
 @responses.activate
 def test_worker_legacy_notify_status(app, mocker, ce_factory, notify_status, expected_status):
+    log_mock = mocker.patch("strr_email.resources.email_listener.logger")
     ce = ce_factory(applicationNumber="APP-1", emailType="HOST_DECLINED")
     app_obj = MagicMock(
         application_number="APP-1",
@@ -350,3 +365,11 @@ def test_worker_legacy_notify_status(app, mocker, ce_factory, notify_status, exp
     )
     with app.test_request_context("/", method="POST", data=b"{}"):
         assert worker()[1] == expected_status
+    if expected_status == HTTPStatus.OK:
+        log_mock.info.assert_any_call("completed ce (event_id=%s): %s", "e1", ce)
+    else:
+        log_mock.error.assert_called_once()
+        _, *log_args = log_mock.error.call_args.args
+        assert log_args[0] == "e1"
+        assert log_args[1] == notify_status
+        assert log_args[3] == ce


### PR DESCRIPTION
*Issue:* https://github.com/bcgov/strr/issues/1623

*Description of changes:*

- Renewal reminder path: log failures with `logger.exception` (traceback + `ce` for correlation).
- Return `{"message": "Unable to send renewal reminder email."}` on **400** instead of the notify-api wording.
- Unit test covers status, JSON message, and `logger.exception` call.

### Notes for the deployer

**Scope:** `strr-email` only; no migrations or config changes.

**Test:** `cd queue_services/strr-email && poetry run pytest tests/unit/test_email_listener_worker.py -q --no-cov`

**Deploy check:** On dispatch failure, logs should show `Error dispatching renewal reminder email via InteractionService` with traceback. Clients seeing **400** get the new `message` string above—update any automation that asserted the old text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License