### PR TITLE
fix(strr-email): log traceback on renewal dispatch failure

### DIFF
--- a/queue_services/strr-email/src/strr_email/resources/email_listener.py
+++ b/queue_services/strr-email/src/strr_email/resources/email_listener.py
@@ -32,13 +32,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # pylint: disable=R0911, R0912
-"""This Module processes and sends email messages via the notify-api.
-"""
+"""This Module processes and sends email messages via the notify-api."""
 from dataclasses import dataclass
 from datetime import datetime
 from http import HTTPStatus
 from pathlib import Path
 import re
+import traceback
 from zoneinfo import ZoneInfo
 
 from flask import Blueprint
@@ -199,11 +199,12 @@ def worker():
             return jsonify({"interaction": resp.interaction_uuid}), HTTPStatus.OK
 
         except Exception:
-            logger.exception(
+            logger.error(
                 "Error dispatching renewal reminder email via InteractionService "
-                "(event_id=%s, ce=%s)",
+                "(event_id=%s, ce=%s)\n%s",
                 event_id,
                 ce,
+                traceback.format_exc(),
             )
             return jsonify({"message": "Unable to send renewal reminder email."}), 400
 

--- a/queue_services/strr-email/tests/unit/test_email_listener_worker.py
+++ b/queue_services/strr-email/tests/unit/test_email_listener_worker.py
@@ -274,11 +274,14 @@ def test_worker_renewal_dispatch_raises_returns_400(app, mocker, ce_factory):
         body, status = worker()
     assert status == 400
     assert body.get_json()["message"] == "Unable to send renewal reminder email."
-    log_mock.exception.assert_called_once_with(
-        "Error dispatching renewal reminder email via InteractionService (event_id=%s, ce=%s)",
-        "e1",
-        ce,
+    log_mock.error.assert_called_once()
+    call = log_mock.error.call_args
+    assert call[0][0].startswith(
+        "Error dispatching renewal reminder email via InteractionService (event_id=%s, ce=%s)\n"
     )
+    assert call[0][1] == "e1"
+    assert call[0][2] is ce
+    assert "RuntimeError: notify down" in call[0][3]
 
 
 def _minimal_app_dict():


### PR DESCRIPTION
*Issue:* #1623

*Description of changes:*
Added traceback to the exception thrown in renewal reminders to help with debugging


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
