### PR TITLE
fix(strr-email): refresh strr-api lock and bump service to 1.2.1

### DIFF
--- a/queue_services/strr-email/poetry.lock
+++ b/queue_services/strr-email/poetry.lock
@@ -3637,10 +3637,10 @@ files = [
 
 [[package]]
 name = "strr-api"
-version = "0.3.12"
+version = "0.3.19"
 description = ""
 optional = false
-python-versions = "^3.11"
+python-versions = "^3.12.2"
 groups = ["main"]
 files = []
 develop = false
@@ -3662,6 +3662,7 @@ google-cloud-storage = "2.14.0"
 gunicorn = "^21.2.0"
 jsonschema = {version = "^4.20.0", extras = ["format"]}
 launchdarkly-server-sdk = "^9.0.1"
+nanoid = "^2.0.0"
 psycopg2-binary = "^2.9.9"
 pycountry = "^23.12.11"
 pydantic = {version = "^2.12.5", extras = ["email"]}
@@ -3677,7 +3678,7 @@ weasyprint = "^62.3"
 type = "git"
 url = "https://github.com/bcgov/STRR.git"
 reference = "main"
-resolved_reference = "35236a0bf2223ca5490c06d23ef10747280f8dcf"
+resolved_reference = "eb6f0b2d3cfa69b9f2455c0803f916921874f5b8"
 subdirectory = "strr-api"
 
 [[package]]

--- a/queue_services/strr-email/pyproject.toml
+++ b/queue_services/strr-email/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-email"
-version = "1.2.0"
+version = "1.2.1"
 description = "BC Registries - strr-email"
 authors = []
 license = "BSD-3-Clause"


### PR DESCRIPTION


*Issue:* #1623

*Description of changes:*
Update poetry.lock so the git dependency resolves to latest strr-api


### Testing
Ttested with hotfix branch on test environment already

GCP log [link](https://console.cloud.google.com/run/detail/northamerica-northeast1/strr-email-test/observability/logs?authuser=1&project=bcrbk9-test)

You can confirm with event id: `4f0579b0-1956-4ae9-9fbe-9e183a1f290e`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
