### PR TITLE
fix(ui): fixed review renew substatus filter bug

### DIFF
--- a/strr-examiner-web/app/pages/dashboard.vue
+++ b/strr-examiner-web/app/pages/dashboard.vue
@@ -277,9 +277,17 @@ const isProvisionalReviewQueueStatus = (status: ApplicationStatus | undefined): 
   return status === ApplicationStatus.PROVISIONALLY_APPROVED || status === ApplicationStatus.PROVISIONAL_REVIEW
 }
 
-const hasExaminerReview = (reg: HousRegistrationResponse): boolean => {
-  const decider = reg.header?.decider
+const hasDecider = (decider: { username?: string, displayName?: string } | undefined): boolean => {
   return Boolean(decider?.username || decider?.displayName)
+}
+
+const hasExaminerReview = (reg: HousRegistrationResponse): boolean => {
+  if (hasDecider(reg.header?.decider)) {
+    return true
+  }
+
+  // Legacy renewal approvals could set decider on the application entry only.
+  return hasDecider(getLatestRegistrationApplication(reg)?.decider)
 }
 
 const getRequirementsColumn = (app: HousApplicationResponse) => {

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.39b",
+  "version": "0.2.39c",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/dashboard.spec.ts
+++ b/strr-examiner-web/tests/unit/dashboard.spec.ts
@@ -654,6 +654,24 @@ describe('Examiner Dashboard Page', () => {
       expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
     })
 
+    it('returns false when latest renewal application has a decider', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...headerBase,
+          decider: {},
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED,
+              decider: { username: 'examiner' }
+            }
+          ]
+        }
+      }
+      expect(wrapper.vm.shouldShowRenewalBadge(reg)).toBe(false)
+    })
+
     it('returns true when it matches Review Renew predicate', () => {
       const reg = {
         ...mockHostRegistration,
@@ -797,6 +815,25 @@ describe('Examiner Dashboard Page', () => {
               applicationType: 'renewal',
               applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED,
               decider: {}
+            }
+          ]
+        }
+      }
+
+      expect(wrapper.vm.getRegistrationSubStatus(reg)).toBe('Approved')
+    })
+
+    it('shows Approved instead of Review Renew when latest renewal application has a decider', () => {
+      const reg = {
+        ...mockHostRegistration,
+        header: {
+          ...mockHostRegistration.header,
+          decider: {},
+          applications: [
+            {
+              applicationType: 'renewal',
+              applicationStatus: ApplicationStatus.PROVISIONALLY_APPROVED,
+              decider: { username: 'examiner1' }
             }
           ]
         }


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1639

*Description of changes:*
I branched off the hotfix branch that is now in PROD. So basically, 0.2.39b is now in PROD, I branched of that and changed to 0.2.39c.


So after investigation, here's what I found:
For something like this (from prod):
<img width="1344" height="430" alt="image" src="https://github.com/user-attachments/assets/0498e9c9-c157-41c0-bb39-62e3bc6603af" />
<img width="1403" height="657" alt="image" src="https://github.com/user-attachments/assets/49ef6014-5a20-4cd8-9c76-02cc0ab5afe4" />

With a renewal that is provisionally approved with that renewal actually having been also reviewed by staff, the reason why it shows Review Renew instead of approved is the following:
<img width="742" height="495" alt="image" src="https://github.com/user-attachments/assets/dfd29114-18ed-4da3-864c-e96404485590" />

These registrations with this bug all share the same scenario, the decider is actually in the application level, not the registration level. Meaning that i think for old data, when an examiner makes a decision on a renewal application, the decider is set in the application like in the SC. The code ALWAYS checked for the decider on the registration level. In this case, it was showing as Review Renew instead of approved. The PR here fixes that.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
