### PR TITLE
fix(strr-api): reject duplicate renewal while a non-terminal renewal exists

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,9 +36,6 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/strr-api/.venv/bin/python",
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestArgs": [
-    "strr-api/tests"
-  ],
   "black-formatter.args": [
     "--config",
     "${workspaceFolder}/strr-api/pyproject.toml"

--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.20"
+version = "0.3.21"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/__init__.py
+++ b/strr-api/src/strr_api/__init__.py
@@ -46,6 +46,7 @@ from flask_migrate import Migrate
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from .common.auth import jwt
+from .common.log_sanitization import install_log_injection_filter
 from .common.run_version import get_run_version
 from .config import Config, Production
 from .models import db
@@ -55,6 +56,7 @@ from .translations import babel
 
 logging.config.fileConfig(fname=os.path.join(os.path.abspath(os.path.dirname(__file__)), "logging.conf"))
 coloredlogs.install()
+install_log_injection_filter()
 logger = logging.getLogger("api")
 
 

--- a/strr-api/src/strr_api/common/log_sanitization.py
+++ b/strr-api/src/strr_api/common/log_sanitization.py
@@ -1,0 +1,87 @@
+# Copyright © 2023 Province of British Columbia
+#
+# Licensed under the BSD 3 Clause License, (the "License");
+# you may not use this file except in compliance with the License.
+# The template for the license can be found here
+#    https://opensource.org/license/bsd-3-clause/
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Mitigate log injection by normalizing log records before handlers emit."""
+
+from __future__ import annotations
+
+import logging
+
+
+def _sanitize_string(s: str) -> str:
+    return s.replace("\r", " ").replace("\n", " ").replace("\x0b", " ")
+
+
+def _sanitize_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _sanitize_string(value)
+    if isinstance(value, dict):
+        return {k: _sanitize_value(v) for k, v in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_sanitize_value(v) for v in value)
+    if isinstance(value, list):
+        return [_sanitize_value(v) for v in value]
+    return _sanitize_string(str(value))
+
+
+class SanitizeLogInjectionFilter(logging.Filter):
+    """Normalize ``msg`` / ``args`` so newline-based log forging is ineffective."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if args:
+            if isinstance(args, dict):
+                record.args = {k: _sanitize_value(v) for k, v in args.items()}
+            else:
+                record.args = tuple(_sanitize_value(v) for v in args)
+        elif isinstance(record.msg, str):
+            record.msg = _sanitize_string(record.msg)
+        record.message = None  # type: ignore[attr-defined]
+        return True
+
+
+def install_log_injection_filter() -> None:
+    """Attach :class:`SanitizeLogInjectionFilter` once per distinct handler on root and ``api`` loggers."""
+    filt = SanitizeLogInjectionFilter()
+    seen: set[int] = set()
+    for log in (logging.getLogger(), logging.getLogger("api")):
+        for handler in log.handlers:
+            hid = id(handler)
+            if hid in seen:
+                continue
+            seen.add(hid)
+            if any(isinstance(f, SanitizeLogInjectionFilter) for f in handler.filters):
+                continue
+            handler.addFilter(filt)

--- a/strr-api/src/strr_api/enums/enum.py
+++ b/strr-api/src/strr_api/enums/enum.py
@@ -192,6 +192,10 @@ class ErrorMessage(Enum):
     REGISTRATION_ID_REQUIRED = "Registration Id is required for renewal applications."
     REGISTRATION_ID_NOT_INTEGER = "Registration Id must be an integer."
     REGISTRATION_RENEWAL_NOT_ALLOWED = "Renewal is not allowed for the current registration status."
+    RENEWAL_APPLICATION_ALREADY_IN_PROGRESS = (
+        "A renewal application is already in progress for this registration. "
+        "Continue with your existing renewal application, or wait until it reaches a final decision."
+    )
     RENEWAL_APPLICATION_NO_REGISTRATION_ID = "Renewal application does not have a linked registration id."
 
 

--- a/strr-api/src/strr_api/exceptions/responses.py
+++ b/strr-api/src/strr_api/exceptions/responses.py
@@ -40,10 +40,16 @@ from .exceptions import BaseExceptionE, ExternalServiceException
 
 
 def error_response(
-    http_status: HTTPStatus = HTTPStatus.BAD_REQUEST, message: str = "Bad request", errors: list[dict[str, str]] = None
+    http_status: HTTPStatus = HTTPStatus.BAD_REQUEST,
+    message: str = "Bad request",
+    errors: list[dict[str, str]] = None,
+    error_code: str | None = None,
 ):
     """Build generic request response with errors."""
-    return jsonify({"message": message, "details": errors or []}), http_status
+    payload: dict = {"message": message, "details": errors or []}
+    if error_code:
+        payload["errorCode"] = error_code
+    return jsonify(payload), http_status
 
 
 def exception_response(exception: BaseExceptionE):

--- a/strr-api/src/strr_api/models/application.py
+++ b/strr-api/src/strr_api/models/application.py
@@ -262,6 +262,27 @@ class Application(BaseModel):
         return cls.query.filter_by(registration_id=registration_id).all()
 
     @classmethod
+    def find_non_terminal_renewal_for_payment_account(
+        cls,
+        payment_account: str | int | None,
+        registration_id: int,
+        terminal_status_values: tuple[str, ...],
+    ) -> Application | None:
+        """Return a renewal for this account+registration that is not in a terminal status, if any."""
+        if payment_account is None:
+            return None
+        return (
+            cls.query.filter(
+                cls.type == ApplicationType.RENEWAL.value,
+                cls.registration_id == registration_id,
+                cls.payment_account == str(payment_account),
+                ~cls.status.in_(terminal_status_values),
+            )
+            .order_by(cls.id.desc())
+            .first()
+        )
+
+    @classmethod
     def _filter_by_application_registration_number(cls, search_term: str, query: Query) -> Query:
         """Filter query by application or registration number."""
         if not search_term:

--- a/strr-api/src/strr_api/resources/__init__.py
+++ b/strr-api/src/strr_api/resources/__init__.py
@@ -127,7 +127,12 @@ def register_endpoints(app: Flask):
         "specs_route": "/",
         "uiversion": 3,
         "securityDefinitions": {
-            "Bearer": {"type": "apiKey", "in": "header", "name": "Authorization"},
+            "Bearer": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "Authorization",
+                "description": "JWT access token. Send as `Bearer <token>` (include the `Bearer ` prefix).",
+            },
         },
         "security": [{"Bearer": []}],
     }

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -100,19 +100,43 @@ def create_application(application_number: Optional[str] = None):
     tags:
       - application
     parameters:
+      - in: header
+        name: Account-Id
+        required: true
+        type: string
+        description: SBC account id (string). Required for applicant application create and update; must match the account that owns the registration / application rows.
+        default: "1500014996"
       - in: body
         name: body
+        required: true
+        description: >
+          Registration or renewal JSON. For `renewal`, set `header.applicationType` to `renewal` and
+          include `header.registrationId`. Final (non-draft) submits require a full payload consistent
+          with `tests/mocks/json/host_registration.json` (or the equivalent platform/strata fixture).
         schema:
           type: object
+          example:
+            header:
+              applicationType: renewal
+              registrationId: 15000
+              paymentMethod: DIRECT_PAY
     responses:
       200:
-        description:
+        description: Application created or updated; JSON body is serialized application.
       400:
-        description:
+        description: Validation or business rule failure (e.g. missing registrationId for renewal).
       401:
-        description:
+        description: Unauthorized.
+      404:
+        description: Application not found (when path includes application_number).
+      409:
+        description: >
+          Renewal conflict — pathless POST /applications for renewal when a non-terminal renewal
+          already exists for the same registration and Account-Id (errorCode RENEWAL_ALREADY_IN_PROGRESS).
+      402:
+        description: Payment required (e.g. invoice creation failed on final submit).
       502:
-        description:
+        description: Bad gateway / external service failure.
     """
 
     try:
@@ -171,6 +195,29 @@ def create_application(application_number: Optional[str] = None):
                     message=ErrorMessage.REGISTRATION_RENEWAL_NOT_ALLOWED.value,
                     http_status=HTTPStatus.BAD_REQUEST,
                 )
+
+            if application is None:
+                terminal_status_values = tuple(s.value for s in APPLICATION_TERMINAL_STATES)
+                conflicting = ApplicationModel.find_non_terminal_renewal_for_payment_account(
+                    account_id, registration_id, terminal_status_values
+                )
+                if conflicting:
+                    logger.info(
+                        "STRR renewal create returned 409: a non-terminal renewal already exists for this "
+                        "registration and payment account. "
+                        "registration_id=%s payment_account=%s existing_renewal_id=%s "
+                        "existing_application_number=%s existing_renewal_status=%s error_code=RENEWAL_ALREADY_IN_PROGRESS",
+                        registration_id,
+                        account_id,
+                        conflicting.id,
+                        conflicting.application_number,
+                        conflicting.status,
+                    )
+                    return error_response(
+                        message=ErrorMessage.RENEWAL_APPLICATION_ALREADY_IN_PROGRESS.value,
+                        http_status=HTTPStatus.CONFLICT,
+                        error_code="RENEWAL_ALREADY_IN_PROGRESS",
+                    )
 
         # Validate only the final submissions
         if not is_draft:

--- a/strr-api/tests/integration/application_seed.py
+++ b/strr-api/tests/integration/application_seed.py
@@ -88,6 +88,94 @@ def seed_draft_application(
     }
 
 
+def host_renewal_application_json(
+    registration_id: int,
+    *,
+    base_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Full ``POST /applications`` JSON for a HOST renewal (draft or final).
+
+    Used by integration and unit tests to avoid repeating header + host body wiring.
+    ``base_json`` is deep-copied when provided (e.g. an already-loaded registration fixture).
+    """
+    body = copy.deepcopy(base_json) if base_json is not None else load_mock_json("host_registration.json")
+    body["header"] = {
+        "applicationType": ApplicationType.RENEWAL.value,
+        "registrationId": registration_id,
+    }
+    return body
+
+
+def count_renewal_applications_for_account_registration(
+    session: Session,
+    *,
+    account_id: int,
+    registration_id: int,
+) -> int:
+    """Count renewal applications for this account + registration (duplicate-guard scope)."""
+    return (
+        session.query(Application)
+        .filter(
+            Application.registration_id == registration_id,
+            Application.type == ApplicationType.RENEWAL.value,
+            Application.payment_account == str(account_id),
+        )
+        .count()
+    )
+
+
+def seed_flushed_host_renewal_draft(
+    session: Session,
+    *,
+    account_id: int,
+    submitter_user_id: int,
+    registration_id: int,
+    application_number: str | None = None,
+    application_json: dict[str, Any] | None = None,
+) -> str:
+    """Insert a HOST renewal DRAFT and ``flush``. Returns the ``application_number`` used."""
+    num = application_number or generate_application_number()
+    seed_draft_application(
+        session,
+        account_id=account_id,
+        submitter_user_id=submitter_user_id,
+        registration_id=registration_id,
+        application_number=num,
+        application_type=ApplicationType.RENEWAL.value,
+        application_json=application_json,
+    )
+    session.flush()
+    return num
+
+
+def seed_terminal_host_renewal(
+    session: Session,
+    *,
+    account_id: int,
+    submitter_user_id: int,
+    registration_id: int,
+    application_number: str | None = None,
+    application_json: dict[str, Any] | None = None,
+) -> str:
+    """Insert a terminal (``FULL_REVIEW_APPROVED``) HOST renewal row and ``flush``; returns ``application_number``."""
+    num = application_number or generate_application_number()
+    body = host_renewal_application_json(registration_id, base_json=application_json)
+    terminal_app = Application(
+        application_number=num,
+        application_json=body,
+        type=ApplicationType.RENEWAL.value,
+        registration_type=Registration.RegistrationType.HOST,
+        status=Application.Status.FULL_REVIEW_APPROVED.value,
+        registration_id=registration_id,
+        submitter_id=submitter_user_id,
+        payment_account=str(account_id),
+    )
+    session.add(terminal_app)
+    session.flush()
+    return num
+
+
 def seed_applicant_visible_application_event(
     session: Session,
     application_id: int,

--- a/strr-api/tests/integration/resources/test_applications_api.py
+++ b/strr-api/tests/integration/resources/test_applications_api.py
@@ -1,16 +1,21 @@
 """Integration tests for public/account ``/applications`` paths and auth smoke."""
 
+import copy
 from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
 
-from strr_api.enums.enum import ApplicationType, ErrorMessage
+from strr_api.enums.enum import ErrorMessage
 from tests.integration.application_seed import (
+    count_renewal_applications_for_account_registration,
     generate_application_number,
+    host_renewal_application_json,
     seed_applicant_visible_application_event,
     seed_draft_application,
+    seed_flushed_host_renewal_draft,
     seed_listable_application,
+    seed_terminal_host_renewal,
 )
 from tests.integration.helpers import (
     assert_json_keys,
@@ -18,6 +23,7 @@ from tests.integration.helpers import (
     assert_unauthenticated_returns_401_for_protected_prefix,
     load_mock_json,
 )
+from tests.integration.registration_seed import seed_serializable_host_registration
 
 
 def test_applications_routes_require_auth_without_bearer(client, app):
@@ -242,6 +248,187 @@ def test_post_draft_application_with_is_draft_does_not_call_invoice(
     assert body["header"]["applicationNumber"] == num
 
 
+def test_post_second_renewal_without_path_returns_conflict_when_seeded_non_terminal_exists(
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+):
+    """``POST /applications`` must not create a second renewal row while one is already non-terminal."""
+    rid = serializable_host_registration["registration_id"]
+    uid = serializable_host_registration["user_id"]
+    seed_flushed_host_renewal_draft(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=uid,
+        registration_id=rid,
+    )
+    before = count_renewal_applications_for_account_registration(
+        session, account_id=integration_account_id, registration_id=rid
+    )
+    assert before == 1
+
+    payload = host_renewal_application_json(rid)
+    headers = headers_public_user(integration_account_id)
+    headers["isDraft"] = "true"
+    rv = client.post("/applications", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.CONFLICT)
+    body = rv.get_json()
+    assert body is not None
+    assert body.get("message") == ErrorMessage.RENEWAL_APPLICATION_ALREADY_IN_PROGRESS.value
+    assert body.get("errorCode") == "RENEWAL_ALREADY_IN_PROGRESS"
+    after = count_renewal_applications_for_account_registration(
+        session, account_id=integration_account_id, registration_id=rid
+    )
+    assert after == before
+
+
+@pytest.mark.parametrize("is_draft", ["true", "false"])
+@patch("strr_api.services.strr_pay.create_invoice")
+def test_post_second_renewal_conflict_for_draft_and_final_attempt(
+    mock_invoice,
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+    mock_invoice_response,
+    is_draft,
+):
+    """Duplicate renewal is rejected before save whether or not ``isDraft`` is set; invoice is never created."""
+    rid = serializable_host_registration["registration_id"]
+    uid = serializable_host_registration["user_id"]
+    seed_flushed_host_renewal_draft(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=uid,
+        registration_id=rid,
+    )
+    before = count_renewal_applications_for_account_registration(
+        session, account_id=integration_account_id, registration_id=rid
+    )
+
+    payload = host_renewal_application_json(rid)
+    headers = headers_public_user(integration_account_id)
+    if is_draft == "true":
+        headers["isDraft"] = "true"
+    else:
+        mock_invoice.return_value = mock_invoice_response
+
+    rv = client.post("/applications", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.CONFLICT)
+    mock_invoice.assert_not_called()
+    assert (
+        count_renewal_applications_for_account_registration(
+            session, account_id=integration_account_id, registration_id=rid
+        )
+        == before
+    )
+
+
+def test_put_renewal_draft_succeeds_after_duplicate_post_returns_conflict(
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+):
+    """Client can still update the existing renewal draft via ``PUT`` after a duplicate ``POST`` is rejected."""
+    rid = serializable_host_registration["registration_id"]
+    uid = serializable_host_registration["user_id"]
+    existing_num = seed_flushed_host_renewal_draft(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=uid,
+        registration_id=rid,
+    )
+
+    payload = host_renewal_application_json(rid)
+    dup_headers = headers_public_user(integration_account_id)
+    dup_headers["isDraft"] = "true"
+    rv_dup = client.post("/applications", json=payload, headers=dup_headers)
+    assert_status(rv_dup, HTTPStatus.CONFLICT)
+
+    put_headers = headers_public_user(integration_account_id)
+    put_headers["isDraft"] = "true"
+    updated = copy.deepcopy(payload)
+    updated["header"]["applicationNumber"] = existing_num
+    rv_put = client.put(f"/applications/{existing_num}", json=updated, headers=put_headers)
+    assert_status(rv_put, HTTPStatus.OK)
+    assert rv_put.get_json()["header"]["applicationNumber"] == existing_num
+
+
+def test_post_renewal_succeeds_when_prior_renewal_on_same_registration_is_terminal(
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    serializable_host_registration,
+):
+    """After a terminal renewal exists for the registration, a new ``POST`` may create another renewal."""
+    rid = serializable_host_registration["registration_id"]
+    uid = serializable_host_registration["user_id"]
+    terminal_num = seed_terminal_host_renewal(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=uid,
+        registration_id=rid,
+    )
+
+    payload = host_renewal_application_json(rid)
+    headers = headers_public_user(integration_account_id)
+    headers["isDraft"] = "true"
+    rv = client.post("/applications", json=payload, headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    new_num = rv.get_json()["header"]["applicationNumber"]
+    assert new_num != terminal_num
+    assert (
+        count_renewal_applications_for_account_registration(
+            session, account_id=integration_account_id, registration_id=rid
+        )
+        == 2
+    )
+
+
+def test_post_renewal_for_different_registration_succeeds_when_first_registration_has_open_renewal(
+    client,
+    session,
+    headers_public_user,
+    integration_account_id,
+    random_string,
+):
+    """Open renewal on registration A must not block a new renewal draft for registration B (same account)."""
+
+    suffix_a = random_string(10).upper().replace("-", "")[:10]
+    suffix_b = random_string(10).upper().replace("-", "")[:10]
+    reg_a = seed_serializable_host_registration(
+        session,
+        account_id=integration_account_id,
+        registration_number=f"INTA{suffix_a}",
+    )
+    reg_b = seed_serializable_host_registration(
+        session,
+        account_id=integration_account_id,
+        registration_number=f"INTB{suffix_b}",
+    )
+    session.flush()
+
+    seed_flushed_host_renewal_draft(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=reg_a["user_id"],
+        registration_id=reg_a["registration_id"],
+    )
+
+    payload_b = host_renewal_application_json(reg_b["registration_id"])
+    headers = headers_public_user(integration_account_id)
+    headers["isDraft"] = "true"
+    rv = client.post("/applications", json=payload_b, headers=headers)
+    assert_status(rv, HTTPStatus.OK)
+    assert rv.get_json()["header"]["applicationNumber"] is not None
+
+
 def test_put_renewal_draft_registration_id_mismatch_returns_bad_request(
     client,
     session,
@@ -250,18 +437,13 @@ def test_put_renewal_draft_registration_id_mismatch_returns_bad_request(
     serializable_host_registration,
 ):
     rid = serializable_host_registration["registration_id"]
-    num = generate_application_number()
-    seed_draft_application(
+    num = seed_flushed_host_renewal_draft(
         session,
         account_id=integration_account_id,
         submitter_user_id=serializable_host_registration["user_id"],
         registration_id=rid,
-        application_number=num,
-        application_type=ApplicationType.RENEWAL.value,
     )
-    session.flush()
-    payload = load_mock_json("host_registration.json")
-    payload.setdefault("header", {})["applicationType"] = ApplicationType.RENEWAL.value
+    payload = host_renewal_application_json(rid)
     payload["header"]["registrationId"] = rid + 987654321  # differs from draft row
     headers = headers_public_user()
     headers["isDraft"] = "true"
@@ -285,21 +467,13 @@ def test_put_renewal_draft_final_submit_with_invoice_mock(
 ):
     """Non-draft PUT on a renewal draft runs validation, invoice, and status update (SBC pay mocked)."""
     rid = serializable_host_registration["registration_id"]
-    num = generate_application_number()
-    seed_draft_application(
+    num = seed_flushed_host_renewal_draft(
         session,
         account_id=integration_account_id,
         submitter_user_id=serializable_host_registration["user_id"],
         registration_id=rid,
-        application_number=num,
-        application_type=ApplicationType.RENEWAL.value,
     )
-    session.flush()
-    payload = load_mock_json("host_registration.json")
-    payload["header"] = {
-        "applicationType": ApplicationType.RENEWAL.value,
-        "registrationId": rid,
-    }
+    payload = host_renewal_application_json(rid)
     mock_invoice.return_value = mock_invoice_response
     rv = client.put(f"/applications/{num}", json=payload, headers=headers_public_user())
     assert rv.status_code in (HTTPStatus.OK, HTTPStatus.CREATED), rv.get_data(as_text=True)

--- a/strr-api/tests/unit/resources/test_renewal_applications.py
+++ b/strr-api/tests/unit/resources/test_renewal_applications.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 from datetime import datetime, timedelta, timezone
@@ -7,10 +8,18 @@ from unittest.mock import patch
 import pytest
 from dateutil.relativedelta import relativedelta
 
-from strr_api.enums.enum import ApplicationType, ErrorMessage, PaymentStatus, RegistrationStatus
+from strr_api.enums.enum import ErrorMessage, PaymentStatus, RegistrationStatus
 from strr_api.models import Application, Events
 from strr_api.services import ApprovalService, RegistrationService
+from tests.integration.application_seed import (
+    count_renewal_applications_for_account_registration,
+    host_renewal_application_json,
+)
 from tests.shared_test_constants import ACCOUNT_ID, MOCK_INVOICE_RESPONSE
+from tests.unit.utils.application_flow_helpers import (
+    assign_examiner_and_full_review_approve,
+    set_application_ready_for_examiner_review,
+)
 from tests.unit.utils.auth_helpers import PUBLIC_USER, STRR_EXAMINER, create_header
 
 CREATE_HOST_REGISTRATION_REQUEST = os.path.join(
@@ -56,24 +65,13 @@ def test_host_renewal_application_submission(session, client, jwt, request_json,
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, staff_headers = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
         assert response_json.get("header").get("registrationNumber") is not None
 
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         rv = client.post("/applications", json=json_data, headers=headers)
         response_json = rv.json
         renewal_application_number = response_json.get("header").get("applicationNumber")
@@ -115,18 +113,8 @@ def test_examiner_approve_host_registration__renewal_application(
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, staff_headers = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
         assert response_json.get("header").get("registrationNumber") is not None
@@ -136,8 +124,7 @@ def test_examiner_approve_host_registration__renewal_application(
         prev_registration.save()
         prev_expiry_date = prev_registration.expiry_date
 
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         json_data["registration"]["unitAddress"]["nickname"] = "My Rental Property renewal"
         rv = client.post("/applications", json=json_data, headers=headers)
         response_json = rv.json
@@ -147,18 +134,8 @@ def test_examiner_approve_host_registration__renewal_application(
         assert application.registration_id == registration_id
         assert application.type == "renewal"
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, staff_headers = assign_examiner_and_full_review_approve(client, jwt, application_number)
         assert response_json.get("header").get("status") == Application.Status.FULL_REVIEW_APPROVED
         assert response_json.get("header").get("assignee").get("username") is not None
         assert response_json.get("header").get("registrationId") == registration_id
@@ -185,22 +162,13 @@ def test_renewal_application_registration_id(session, client, jwt):
         registration_payload = json.load(f)
 
     def _complete_registration(app_number: str) -> int:
-        application = Application.find_by_application_number(application_number=app_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
+        set_application_ready_for_examiner_review(app_number)
+        data, _ = assign_examiner_and_full_review_approve(client, jwt, app_number)
+        return data.get("header").get("registrationId")
 
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv_assign = client.put(f"/applications/{app_number}/assign", headers=staff_headers)
-        assert rv_assign.status_code == HTTPStatus.OK
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv_status = client.put(
-            f"/applications/{app_number}/status",
-            json=status_update_request,
-            headers=staff_headers,
-        )
-        assert rv_status.status_code == HTTPStatus.OK
-        return rv_status.json.get("header").get("registrationId")
+    def _complete_renewal_to_terminal(renewal_app_number: str) -> None:
+        set_application_ready_for_examiner_review(renewal_app_number)
+        assign_examiner_and_full_review_approve(client, jwt, renewal_app_number)
 
     rv = client.post("/applications", json=registration_payload, headers=headers)
     assert rv.status_code == HTTPStatus.OK
@@ -208,21 +176,19 @@ def test_renewal_application_registration_id(session, client, jwt):
     registration_id = _complete_registration(application_number)
 
     # Successful renewal application creation
-    renewal_payload = json.loads(json.dumps(registration_payload))
-    renewal_payload["header"] = {
-        "applicationType": "renewal",
-        "registrationId": registration_id,
-    }
+    renewal_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
 
     rv = client.post("/applications", json=renewal_payload, headers=headers)
     assert rv.status_code == HTTPStatus.OK
+    first_renewal_application_number = rv.json.get("header").get("applicationNumber")
+    _complete_renewal_to_terminal(first_renewal_application_number)
 
     # Successful renewal draft application creation
     draft_headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
     draft_headers["Account-Id"] = ACCOUNT_ID
     draft_headers["isDraft"] = True
 
-    draft_payload = json.loads(json.dumps(renewal_payload))
+    draft_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
     rv = client.post("/applications", json=draft_payload, headers=draft_headers)
     assert rv.status_code == HTTPStatus.OK
     draft_application_number = rv.json.get("header").get("applicationNumber")
@@ -281,6 +247,112 @@ def test_renewal_application_registration_id(session, client, jwt):
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_second_renewal_create_without_application_number_returns_conflict(session, client, jwt):
+    """A second POST /applications renewal for the same registration must not create a duplicate row."""
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        registration_payload = json.load(f)
+
+    rv = client.post("/applications", json=registration_payload, headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+    app_no = rv.json.get("header").get("applicationNumber")
+    set_application_ready_for_examiner_review(app_no)
+    rv_done_json, _ = assign_examiner_and_full_review_approve(client, jwt, app_no)
+    registration_id = rv_done_json.get("header").get("registrationId")
+
+    renewal_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
+    draft_headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    draft_headers["Account-Id"] = ACCOUNT_ID
+    draft_headers["isDraft"] = True
+
+    rv_first = client.post("/applications", json=renewal_payload, headers=draft_headers)
+    assert rv_first.status_code == HTTPStatus.OK
+    renewal_count = count_renewal_applications_for_account_registration(
+        session, account_id=ACCOUNT_ID, registration_id=registration_id
+    )
+
+    rv_dup = client.post("/applications", json=renewal_payload, headers=draft_headers)
+    assert rv_dup.status_code == HTTPStatus.CONFLICT
+    assert rv_dup.json.get("message") == ErrorMessage.RENEWAL_APPLICATION_ALREADY_IN_PROGRESS.value
+    assert rv_dup.json.get("errorCode") == "RENEWAL_ALREADY_IN_PROGRESS"
+    assert (
+        count_renewal_applications_for_account_registration(
+            session, account_id=ACCOUNT_ID, registration_id=registration_id
+        )
+        == renewal_count
+    )
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_put_renewal_draft_allowed_when_second_create_rejected(session, client, jwt):
+    """After a duplicate renewal POST returns 409, the client can still update the existing draft via PUT."""
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        registration_payload = json.load(f)
+
+    rv = client.post("/applications", json=registration_payload, headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+    app_no = rv.json.get("header").get("applicationNumber")
+    set_application_ready_for_examiner_review(app_no)
+    rv_done_json, _ = assign_examiner_and_full_review_approve(client, jwt, app_no)
+    registration_id = rv_done_json.get("header").get("registrationId")
+
+    renewal_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
+    draft_headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    draft_headers["Account-Id"] = ACCOUNT_ID
+    draft_headers["isDraft"] = True
+
+    rv_first = client.post("/applications", json=renewal_payload, headers=draft_headers)
+    assert rv_first.status_code == HTTPStatus.OK
+    draft_application_number = rv_first.json.get("header").get("applicationNumber")
+
+    rv_dup = client.post("/applications", json=renewal_payload, headers=draft_headers)
+    assert rv_dup.status_code == HTTPStatus.CONFLICT
+
+    updated = copy.deepcopy(renewal_payload)
+    updated["header"]["applicationNumber"] = draft_application_number
+    rv_put = client.put(
+        f"/applications/{draft_application_number}",
+        json=updated,
+        headers=draft_headers,
+    )
+    assert rv_put.status_code == HTTPStatus.OK
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_new_renewal_create_succeeds_when_prior_renewal_is_terminal(session, client, jwt):
+    """After the only renewal for a registration reaches a terminal status, a new renewal may be created."""
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        registration_payload = json.load(f)
+
+    rv = client.post("/applications", json=registration_payload, headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+    app_no = rv.json.get("header").get("applicationNumber")
+    set_application_ready_for_examiner_review(app_no)
+    rv_done_json, _ = assign_examiner_and_full_review_approve(client, jwt, app_no)
+    registration_id = rv_done_json.get("header").get("registrationId")
+
+    renewal_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
+
+    rv_first = client.post("/applications", json=renewal_payload, headers=headers)
+    assert rv_first.status_code == HTTPStatus.OK
+    first_renewal_no = rv_first.json.get("header").get("applicationNumber")
+    set_application_ready_for_examiner_review(first_renewal_no)
+    assign_examiner_and_full_review_approve(client, jwt, first_renewal_no)
+
+    draft_headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+    draft_headers["Account-Id"] = ACCOUNT_ID
+    draft_headers["isDraft"] = True
+    rv_second = client.post("/applications", json=renewal_payload, headers=draft_headers)
+    assert rv_second.status_code == HTTPStatus.OK
+    assert rv_second.json.get("header").get("applicationNumber") != first_renewal_no
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
 def test_cancelled_registration_cannot_create_renewal_application(session, client, jwt):
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
         headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
@@ -291,31 +363,15 @@ def test_cancelled_registration_cannot_create_renewal_application(session, clien
     assert rv.status_code == HTTPStatus.OK
     application_number = rv.json.get("header").get("applicationNumber")
 
-    application = Application.find_by_application_number(application_number=application_number)
-    application.payment_status = PaymentStatus.COMPLETED.value
-    application.status = Application.Status.FULL_REVIEW
-    application.save()
-
-    staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-    rv_assign = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-    assert rv_assign.status_code == HTTPStatus.OK
-    rv_status = client.put(
-        f"/applications/{application_number}/status",
-        json={"status": Application.Status.FULL_REVIEW_APPROVED},
-        headers=staff_headers,
-    )
-    assert rv_status.status_code == HTTPStatus.OK
-    registration_id = rv_status.json.get("header").get("registrationId")
+    set_application_ready_for_examiner_review(application_number)
+    rv_status_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
+    registration_id = rv_status_json.get("header").get("registrationId")
 
     registration = RegistrationService.get_registration_by_id(registration_id)
     registration.status = RegistrationStatus.CANCELLED
     registration.save()
 
-    renewal_payload = json.loads(json.dumps(registration_payload))
-    renewal_payload["header"] = {
-        "applicationType": ApplicationType.RENEWAL.value,
-        "registrationId": registration_id,
-    }
+    renewal_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
     rv = client.post("/applications", json=renewal_payload, headers=headers)
     assert rv.status_code == HTTPStatus.BAD_REQUEST
     assert rv.json.get("message") == ErrorMessage.REGISTRATION_RENEWAL_NOT_ALLOWED.value
@@ -332,40 +388,22 @@ def test_cancelled_registration_cannot_be_renewed_on_approval(session, client, j
     assert rv.status_code == HTTPStatus.OK
     application_number = rv.json.get("header").get("applicationNumber")
 
-    application = Application.find_by_application_number(application_number=application_number)
-    application.payment_status = PaymentStatus.COMPLETED.value
-    application.status = Application.Status.FULL_REVIEW
-    application.save()
+    set_application_ready_for_examiner_review(application_number)
+    rv_status_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
+    registration_id = rv_status_json.get("header").get("registrationId")
 
-    staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-    rv_assign = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-    assert rv_assign.status_code == HTTPStatus.OK
-    rv_status = client.put(
-        f"/applications/{application_number}/status",
-        json={"status": Application.Status.FULL_REVIEW_APPROVED},
-        headers=staff_headers,
-    )
-    assert rv_status.status_code == HTTPStatus.OK
-    registration_id = rv_status.json.get("header").get("registrationId")
-
-    renewal_payload = json.loads(json.dumps(registration_payload))
-    renewal_payload["header"] = {
-        "applicationType": ApplicationType.RENEWAL.value,
-        "registrationId": registration_id,
-    }
+    renewal_payload = host_renewal_application_json(registration_id, base_json=registration_payload)
     rv = client.post("/applications", json=renewal_payload, headers=headers)
     assert rv.status_code == HTTPStatus.OK
     renewal_application_number = rv.json.get("header").get("applicationNumber")
 
-    renewal_application = Application.find_by_application_number(application_number=renewal_application_number)
-    renewal_application.payment_status = PaymentStatus.COMPLETED.value
-    renewal_application.status = Application.Status.FULL_REVIEW
-    renewal_application.save()
+    set_application_ready_for_examiner_review(renewal_application_number)
 
     registration = RegistrationService.get_registration_by_id(registration_id)
     registration.status = RegistrationStatus.CANCELLED
     registration.save()
 
+    staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
     rv_assign = client.put(f"/applications/{renewal_application_number}/assign", headers=staff_headers)
     assert rv_assign.status_code == HTTPStatus.OK
     rv_status = client.put(
@@ -388,24 +426,13 @@ def test_platform_renewal_application_submission(session, client, jwt):
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
         assert response_json.get("header").get("registrationNumber") is not None
 
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         rv = client.post("/applications", json=json_data, headers=headers)
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
@@ -426,25 +453,14 @@ def test_examiner_approve_platform_registration__renewal_application(session, cl
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         registration_number = response_json.get("header").get("registrationNumber")
         assert registration_id is not None
         assert registration_number is not None
 
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         json_data["registration"]["businessDetails"]["legalName"] = "Updated Platform Legal Name"
         json_data["registration"]["platformDetails"]["listingSize"] = "BETWEEN_250_AND_999"
 
@@ -456,16 +472,8 @@ def test_examiner_approve_platform_registration__renewal_application(session, cl
         assert application.registration_id == registration_id
         assert application.type == "renewal"
 
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         assert response_json.get("header").get("status") == Application.Status.FULL_REVIEW_APPROVED
         assert response_json.get("header").get("assignee").get("username") is not None
         assert response_json.get("header").get("registrationId") == registration_id
@@ -491,24 +499,13 @@ def test_strata_hotel_renewal_application_submission(session, client, jwt):
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
         assert response_json.get("header").get("registrationNumber") is not None
 
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         rv = client.post("/applications", json=json_data, headers=headers)
         assert HTTPStatus.OK == rv.status_code
         response_json = rv.json
@@ -531,25 +528,14 @@ def test_examiner_approve_strata_hotel_registration__renewal_application(session
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         registration_number = response_json.get("header").get("registrationNumber")
         assert registration_id is not None
         assert registration_number is not None
 
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         json_data["registration"]["businessDetails"]["legalName"] = "Updated Strata Hotel Legal Name"
         json_data["registration"]["strataHotelDetails"]["numberOfUnits"] = 75
 
@@ -562,16 +548,8 @@ def test_examiner_approve_strata_hotel_registration__renewal_application(session
         assert application.registration_id == registration_id
         assert application.type == "renewal"
 
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         assert response_json.get("header").get("status") == Application.Status.FULL_REVIEW_APPROVED
         assert response_json.get("header").get("assignee").get("username") is not None
         assert response_json.get("header").get("registrationId") == registration_id
@@ -600,19 +578,8 @@ def test_host_renewal_provisional_then_manual_full_approval_single_extension(moc
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, staff_headers = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
 
@@ -620,8 +587,7 @@ def test_host_renewal_provisional_then_manual_full_approval_single_extension(moc
         prev_expiry_date = prev_registration.expiry_date
 
         # Create renewal application for same registration
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         rv = client.post("/applications", json=json_data, headers=headers)
         assert HTTPStatus.OK == rv.status_code
         response_json = rv.json
@@ -675,19 +641,8 @@ def test_host_renewal_manual_full_approval_set_aside_then_full_approval_single_e
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, staff_headers = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
 
@@ -695,28 +650,14 @@ def test_host_renewal_manual_full_approval_set_aside_then_full_approval_single_e
         initial_expiry_date = initial_registration.expiry_date
 
         # Create renewal application for same registration
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         rv = client.post("/applications", json=json_data, headers=headers)
         assert HTTPStatus.OK == rv.status_code
         response_json = rv.json
         renewal_application_number = response_json.get("header").get("applicationNumber")
 
-        renewal_application = Application.find_by_application_number(application_number=renewal_application_number)
-        renewal_application.payment_status = PaymentStatus.COMPLETED.value
-        renewal_application.status = Application.Status.FULL_REVIEW
-        renewal_application.save()
-
-        # First manual FULL_REVIEW_APPROVED for the renewal
-        rv = client.put(f"/applications/{renewal_application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(
-            f"/applications/{renewal_application_number}/status",
-            json=status_update_request,
-            headers=staff_headers,
-        )
-        assert HTTPStatus.OK == rv.status_code
+        set_application_ready_for_examiner_review(renewal_application_number)
+        _, staff_headers = assign_examiner_and_full_review_approve(client, jwt, renewal_application_number)
 
         registration_after_first_approval = RegistrationService.get_registration_by_id(registration_id)
         first_approval_expiry_date = registration_after_first_approval.expiry_date
@@ -758,22 +699,8 @@ def test_renewal_of_expired_registration_sets_expiry_to_today_plus_365_days(mock
         response_json = rv.json
         application_number = response_json.get("header").get("applicationNumber")
 
-        application = Application.find_by_application_number(application_number=application_number)
-        application.payment_status = PaymentStatus.COMPLETED.value
-        application.status = Application.Status.FULL_REVIEW
-        application.save()
-
-        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
-        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
-        rv = client.put(
-            f"/applications/{application_number}/status",
-            json=status_update_request,
-            headers=staff_headers,
-        )
-        assert HTTPStatus.OK == rv.status_code
-        response_json = rv.json
+        set_application_ready_for_examiner_review(application_number)
+        response_json, _ = assign_examiner_and_full_review_approve(client, jwt, application_number)
         registration_id = response_json.get("header").get("registrationId")
         assert registration_id is not None
 
@@ -785,26 +712,14 @@ def test_renewal_of_expired_registration_sets_expiry_to_today_plus_365_days(mock
         expired_registration.save()
 
         # Submit renewal and approve
-        renewal_header_json = {"registrationId": registration_id, "applicationType": "renewal"}
-        json_data["header"] = renewal_header_json
+        json_data = host_renewal_application_json(registration_id, base_json=json_data)
         rv = client.post("/applications", json=json_data, headers=headers)
         assert HTTPStatus.OK == rv.status_code
         response_json = rv.json
         renewal_application_number = response_json.get("header").get("applicationNumber")
 
-        renewal_application = Application.find_by_application_number(application_number=renewal_application_number)
-        renewal_application.payment_status = PaymentStatus.COMPLETED.value
-        renewal_application.status = Application.Status.FULL_REVIEW
-        renewal_application.save()
-
-        rv = client.put(f"/applications/{renewal_application_number}/assign", headers=staff_headers)
-        assert HTTPStatus.OK == rv.status_code
-        rv = client.put(
-            f"/applications/{renewal_application_number}/status",
-            json={"status": Application.Status.FULL_REVIEW_APPROVED},
-            headers=staff_headers,
-        )
-        assert HTTPStatus.OK == rv.status_code
+        set_application_ready_for_examiner_review(renewal_application_number)
+        assign_examiner_and_full_review_approve(client, jwt, renewal_application_number)
 
         registration = RegistrationService.get_registration_by_id(registration_id)
         new_expiry = registration.expiry_date

--- a/strr-api/tests/unit/utils/application_flow_helpers.py
+++ b/strr-api/tests/unit/utils/application_flow_helpers.py
@@ -1,0 +1,42 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the BSD 3 Clause License, (the "License");
+# you may not use this file except in compliance with the License.
+"""Shared Flask-client steps for application resource tests."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+from strr_api.enums.enum import PaymentStatus
+from strr_api.models import Application
+from tests.unit.utils.auth_helpers import STRR_EXAMINER, create_header
+
+
+def set_application_ready_for_examiner_review(application_number: str) -> None:
+    """Set payment completed and FULL_REVIEW so staff can assign and approve."""
+    application = Application.find_by_application_number(application_number=application_number)
+    application.payment_status = PaymentStatus.COMPLETED.value
+    application.status = Application.Status.FULL_REVIEW
+    application.save()
+
+
+def assign_examiner_and_full_review_approve(
+    client, jwt, application_number: str
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """
+    Assign STRR examiner and approve FULL_REVIEW_APPROVED.
+
+    Returns ``(response_json, staff_headers)`` so callers can reuse headers for follow-up calls.
+    """
+    staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+    rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
+    assert rv.status_code == HTTPStatus.OK
+    rv = client.put(
+        f"/applications/{application_number}/status",
+        json={"status": Application.Status.FULL_REVIEW_APPROVED},
+        headers=staff_headers,
+    )
+    assert rv.status_code == HTTPStatus.OK
+    return rv.json, staff_headers


### PR DESCRIPTION
### Issue: #1541

### Description of changes:
- Prevent duplicate renewal applications for the same registration when one already exists in a non-terminal status.
- Impelemented a global log filter as a defense mechanism 

### Testing

### Manual: duplicate renewal → **409**

**1. Find an `ACTIVE` registration that already has a non-terminal HOST renewal**

Use the same terminal statuses as `APPLICATION_TERMINAL_STATES` in `strr-api/src/strr_api/services/application_service.py`:

```sql
SELECT
  a.id                    AS renewal_application_id,
  a.application_number    AS existing_renewal_application_number,
  a.status                AS renewal_status,
  a.registration_id,
  a.payment_account,
  r.sbc_account_id        AS use_this_for_account_id_header,
  r.registration_number,
  r.status::text          AS registration_status
FROM application a
JOIN registrations r ON r.id = a.registration_id
WHERE a.type = 'renewal'
  AND a.registration_type::text = 'HOST'
  AND a.status NOT IN (
    'FULL_REVIEW_APPROVED',
    'PROVISIONALLY_APPROVED',
    'AUTO_APPROVED',
    'DECLINED',
    'PROVISIONALLY_DECLINED'
  )
  AND r.status::text = 'ACTIVE'
  AND r.registration_type = 'HOST'
ORDER BY a.id DESC
LIMIT 10;
```

Pick a row and set:

- `REGISTRATION_ID` = `registration_id`
- `ACCOUNT_ID` = `payment_account` from the row (must equal `sbc_account_id` as a string — same value you send as **`Account-Id`**)
- Use a JWT for a user allowed to act for that account.

**2. Pathless renewal `POST` (draft) — expect `409`**

Minimal body (draft avoids invoice / full validation in many setups):

```bash
export API_BASE='http://localhost:8080'   # or your strr-api URL
export TOKEN='<JWT>'
export ACCOUNT_ID='<payment_account from query>'
export REGISTRATION_ID='<registration_id from query>'

curl -sS -w "\nHTTP %{http_code}\n" -X POST "${API_BASE}/applications" \
  -H "Authorization: Bearer ${TOKEN}" \
  -H "Account-Id: ${ACCOUNT_ID}" \
  -H "Content-Type: application/json" \
  -H "isDraft: true" \
  -d "{
    \"header\": {
      \"applicationType\": \"renewal\",
      \"registrationId\": ${REGISTRATION_ID},
      \"paymentMethod\": \"DIRECT_PAY\"
    },
    \"registration\": {
      \"registrationType\": \"HOST\"
    }
  }"
```

**Expected:** HTTP **409**, JSON includes **`errorCode`** `RENEWAL_ALREADY_IN_PROGRESS` and the renewal-in-progress **`message`**.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
