### PR TITLE
feat(ui): 1544 part 2, display fee info to Host app

### DIFF
--- a/strr-host-pm-web/app/app.config.ts
+++ b/strr-host-pm-web/app/app.config.ts
@@ -60,6 +60,9 @@ export default defineAppConfig({
         }
       })
     },
+    feeInfo: {
+      hrefRtcKey: 'hostFeesUrl'
+    },
     sbcWebMsg: {
       enable: true
     }

--- a/strr-host-pm-web/app/composables/useHostApplicationFee.ts
+++ b/strr-host-pm-web/app/composables/useHostApplicationFee.ts
@@ -7,8 +7,21 @@ type FeeMatrix = Partial<
 
 let APPLICATION_FEE_MATRIX: FeeMatrix = {}
 
+const feeMap: Record<RentalUnitSetupOption, FeeInfo> = {
+  [RentalUnitSetupOption.PRIMARY_RESIDENCE_OR_SHARED_SPACE]: FeeInfo.FEE_INFO_1,
+  [RentalUnitSetupOption.SEPARATE_UNIT_SAME_PROPERTY]: FeeInfo.FEE_INFO_2,
+  [RentalUnitSetupOption.DIFFERENT_PROPERTY]: FeeInfo.FEE_INFO_3
+}
+
 export const useHostApplicationFee = () => {
-  const { getFee } = useConnectFeeStore()
+  const { getFee, setFeeInfo } = useConnectFeeStore()
+  const { unitDetails } = storeToRefs(useHostPropertyStore())
+
+  watch(
+    () => unitDetails.value.rentalUnitSetupOption,
+    option => setFeeInfo(option ? feeMap[option] : undefined),
+    { immediate: true }
+  )
 
   /**
    * Fetch three different STRR fees and setup application fee matrix based on the retrieved fees.

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "engines": {
     "node": ">=24"
   },

--- a/strr-host-pm-web/tests/unit/connect-fee-info-amount.spec.ts
+++ b/strr-host-pm-web/tests/unit/connect-fee-info-amount.spec.ts
@@ -1,0 +1,67 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { baseEnI18n } from '../mocks/i18n'
+import { ConnectFeeInfoAmount } from '#components'
+import { FeeInfo } from '#imports'
+
+const $t = baseEnI18n.global.t
+
+const mockFeeItem: ConnectFeeItem = {
+  filingTypeCode: 'STRR',
+  filingType: 'strr',
+  filingFees: 50,
+  total: 50,
+  futureEffectiveFees: 0,
+  priorityFees: 0,
+  processingFees: 0,
+  serviceFees: 0,
+  tax: { gst: 0, pst: 0 }
+}
+
+const mountComponent = () =>
+  mountSuspended(ConnectFeeInfoAmount, {
+    global: { plugins: [baseEnI18n] }
+  })
+
+describe('ConnectFeeInfoAmount', () => {
+  beforeEach(() => {
+    const store = useConnectFeeStore()
+    store.setFeeInfo(undefined)
+    store.addReplaceFee(mockFeeItem)
+  })
+
+  it('should not render component when feeInfo is not set', async () => {
+    const wrapper = await mountComponent()
+    expect(wrapper.find('[data-testid="fee-info-1"]').exists()).toBe(false)
+  })
+
+  it('should render component when feeInfo is set', async () => {
+    useConnectFeeStore().setFeeInfo(FeeInfo.FEE_INFO_1)
+    const wrapper = await mountComponent()
+    expect(wrapper.find('button').text()).toContain($t('ConnectFeeInfo.title'))
+  })
+
+  it('should render info for FEE_INFO_1', async () => {
+    useConnectFeeStore().setFeeInfo(FeeInfo.FEE_INFO_1)
+    const wrapper = await mountComponent()
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('p').text()).toBe($t('ConnectFeeInfo.scenarios.primaryResidence.heading'))
+    expect(wrapper.find('[data-testid="fee-info-1"]').exists()).toBe(true)
+  })
+
+  it('should render info for FEE_INFO_2', async () => {
+    useConnectFeeStore().setFeeInfo(FeeInfo.FEE_INFO_2)
+    const wrapper = await mountComponent()
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('p').text()).toBe($t('ConnectFeeInfo.scenarios.separateUnit.heading'))
+    expect(wrapper.find('[data-testid="fee-info-2"]').exists()).toBe(true)
+  })
+
+  it('should render info for FEE_INFO_3', async () => {
+    useConnectFeeStore().setFeeInfo(FeeInfo.FEE_INFO_3)
+    const wrapper = await mountComponent()
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('p').text()).toBe($t('ConnectFeeInfo.scenarios.differentProperty.heading'))
+    expect(wrapper.find('[data-testid="fee-info-3"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1544

*Description of changes:*
- Set Fee Info to display fee info amount component in Host app
- Add unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
