### PR TITLE
fix(api): fixed review/review renew substatus filter bug

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.17"
+version = "0.3.17c"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -182,6 +182,22 @@ class Registration(Versioned, BaseModel):
         return sub_status_conditions
 
     @classmethod
+    def _latest_application_field_subquery(cls, application_field):
+        """Select a field from the latest application for each registration."""
+        # pylint: disable=import-outside-toplevel
+        from sqlalchemy import select
+
+        from strr_api.models.application import Application
+
+        return (
+            select(application_field)
+            .where(Application.registration_id == Registration.id)
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+
+    @classmethod
     def _host_condition_bl_or_pr(cls, application_model):
         """BL+PR selected: records with BL true or PR true."""
         bl_true = (
@@ -458,32 +474,18 @@ class Registration(Versioned, BaseModel):
     @classmethod
     def _approval_method_condition(cls, approval_methods: list[str], examiner_reviewed: bool | None = None):
         """Build SQL condition for filtering by latest application status and review state."""
-        # pylint: disable=import-outside-toplevel
-        from sqlalchemy import select
-
         from strr_api.models.application import Application
 
         # For each registration, evaluate only the latest application (same ordering
         # used by the dashboard payload). This keeps filtering aligned with what users
         # see in the Sub-Status column.
-        latest_app_status_subq = (
-            select(Application.status)
-            .where(Application.registration_id == Registration.id)
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
-        latest_app_decider_subq = (
-            select(Application.decider_id)
-            .where(Application.registration_id == Registration.id)
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
+        latest_app_status_subq = cls._latest_application_field_subquery(Application.status)
         approval_status_condition = latest_app_status_subq.in_(approval_methods)
         if examiner_reviewed is None:
             # Backward-compatible behavior: only filter by approval method/status.
             return approval_status_condition
+
+        latest_app_decider_subq = cls._latest_application_field_subquery(Application.decider_id)
 
         # Review state can be represented by either:
         # - registration level decision (newer flow)
@@ -514,22 +516,13 @@ class Registration(Versioned, BaseModel):
         - no registration level or latest application decision exists yet
         - latest application is still in provisional review queue
         """
-        # pylint: disable=import-outside-toplevel
-        from sqlalchemy import select
-
         from strr_api.models.application import Application
 
         provisional_statuses = [
             Application.Status.PROVISIONALLY_APPROVED.value,
             Application.Status.PROVISIONAL_REVIEW.value,
         ]
-        latest_app_decider_subq = (
-            select(Application.decider_id)
-            .where(Application.registration_id == Registration.id)
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
+        latest_app_decider_subq = cls._latest_application_field_subquery(Application.decider_id)
         return db.and_(
             cls._has_renewal_filed_condition(),
             Registration.decider_id.is_(None),

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -473,14 +473,25 @@ class Registration(Versioned, BaseModel):
             .limit(1)
             .scalar_subquery()
         )
+        latest_app_decider_subq = (
+            select(Application.decider_id)
+            .where(Application.registration_id == Registration.id)
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
         approval_status_condition = latest_app_status_subq.in_(approval_methods)
         if examiner_reviewed is None:
             # Backward-compatible behavior: only filter by approval method/status.
             return approval_status_condition
 
-        # Per examiner workflow, review state for registrations is represented by
-        # the registration level decider.
-        reviewed_condition = Registration.decider_id.isnot(None)
+        # Review state can be represented by either:
+        # - registration level decision (newer flow)
+        # - latest application level decision (legacy flow)
+        reviewed_condition = db.or_(
+            Registration.decider_id.isnot(None),
+            latest_app_decider_subq.isnot(None),
+        )
 
         # examinerReviewed=false -> "review queue" (not yet examiner decided, no renewal filed)
         # examinerReviewed=true  -> already reviewed by an examiner
@@ -500,19 +511,29 @@ class Registration(Versioned, BaseModel):
 
         A registration matches when all are true:
         - a renewal is filed
-        - no registration-level decision exists yet
+        - no registration level or latest application decision exists yet
         - latest application is still in provisional review queue
         """
         # pylint: disable=import-outside-toplevel
+        from sqlalchemy import select
+
         from strr_api.models.application import Application
 
         provisional_statuses = [
             Application.Status.PROVISIONALLY_APPROVED.value,
             Application.Status.PROVISIONAL_REVIEW.value,
         ]
+        latest_app_decider_subq = (
+            select(Application.decider_id)
+            .where(Application.registration_id == Registration.id)
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
         return db.and_(
             cls._has_renewal_filed_condition(),
             Registration.decider_id.is_(None),
+            latest_app_decider_subq.is_(None),
             cls._approval_method_condition(provisional_statuses),
         )
 

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -1028,7 +1028,7 @@ def search_registrations():
       - in: query
         name: examinerReviewed
         type: boolean
-        description: When provided with approvalMethod, filter provisional records by whether an examiner decision exists at the registration level.
+        description: When provided with approvalMethod, filter provisional records by whether an examiner decision exists at either registration level or latest application level.
       - in: query
         name: nocStatus
         type: array
@@ -1047,7 +1047,7 @@ def search_registrations():
       - in: query
         name: reviewRenew
         type: boolean
-        description: When true, only return registrations with a filed renewal, no registration-level decider, and latest application status in PROVISIONALLY_APPROVED/PROVISIONAL_REVIEW.
+        description: When true, only return registrations with a filed renewal, no registration-level or latest-application decider, and latest application status in PROVISIONALLY_APPROVED/PROVISIONAL_REVIEW.
     responses:
       200:
         description:

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2669,6 +2669,35 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
         assert found, "Record should match examinerReviewed=true due registration decider"
 
+        # Legacy path: registration decider is empty but latest application decider exists.
+        registration.decider_id = None
+        renewal_app.decider_id = application.reviewer_id
+        session.commit()
+
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
+                f"&examinerReviewed=false&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert not found, "Record should not match examinerReviewed=false when latest app decider is present"
+
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
+                f"&examinerReviewed=true&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert found, "Record should match examinerReviewed=true due latest application decider"
+
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
 def test_search_registrations_review_renew_includes_registration_with_filed_renewal_and_no_registration_decider(
@@ -2728,6 +2757,17 @@ def test_search_registrations_review_renew_includes_registration_with_filed_rene
         registrations = rv.json
         assert len(registrations.get("registrations")) == 1
         assert registrations.get("registrations")[0].get("registrationNumber") == registration_number
+
+        # Once latest renewal has a decider, it should no longer appear in reviewRenew.
+        renewal_app.decider_id = application.reviewer_id
+        session.commit()
+        rv = client.get(
+            f"/registrations/search?reviewRenew=true&recordNumber={registration_number}&status={RegistrationStatus.ACTIVE.value}",
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        assert len(registrations.get("registrations")) == 0
 
         # reviewRenew=false behaves as no extra filter (same as omitting reviewRenew).
         rv = client.get(


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1639

*Description of changes:*
There was a gap in my changes. Needed API change as well.

I was testing in TEST, created some data manually, here's what i found:
<img width="1811" height="1026" alt="image" src="https://github.com/user-attachments/assets/9d516018-9174-4757-bb21-c3be4b53c916" />

I was working with registration: H329198221
As you can see, the sub-status now shows approved, but the Review sub-status still showed it. In order to fix that, the API now checks the latest app decider as well per the legacy flow.

Now, while running locally, it doesn't show it anymore:
<img width="1756" height="1017" alt="image" src="https://github.com/user-attachments/assets/e4bb153d-3a12-4c63-b898-39e1d54ea248" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
