### PR TITLE
fix(host-pm-web): prevent duplicate renewal draft applications

### DIFF
--- a/strr-base-web/app/components/connect/ButtonControl.vue
+++ b/strr-base-web/app/components/connect/ButtonControl.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import type { ConnectBtnControl } from '#imports'
-
-const buttonControl = computed(() => useRoute().meta.buttonControl as ConnectBtnControl)
+const { getButtonControl } = useButtonControl()
+const buttonControl = computed(() => getButtonControl())
 const leftButtons = computed(() => buttonControl.value?.leftButtons || [])
 const rightButtons = computed(() => buttonControl.value?.rightButtons || [])
 

--- a/strr-base-web/app/components/modal/error/ApplicationSubmit.vue
+++ b/strr-base-web/app/components/modal/error/ApplicationSubmit.vue
@@ -3,25 +3,41 @@ const props = defineProps<{
   error: unknown
 }>()
 
-const getErrorKey = () => {
-  const error = props.error
+type ApplicationSubmitErrorKey =
+  | 'renewalAlreadyInProgress'
+  | 'badRequest'
+  | 'internal'
+  | 'unknown'
 
-  if (error && typeof error === 'object') {
-    const hasStatusCode = 'statusCode' in error
-
-    if (hasStatusCode) {
-      const code = error.statusCode as number
-      if (code > 399 && code < 500) {
-        return 'badRequest'
-      } else if (code >= 500) {
-        return 'internal'
-      }
-    }
+function resolveApplicationSubmitErrorKey (error: unknown): ApplicationSubmitErrorKey {
+  if (!error || typeof error !== 'object') {
+    return 'unknown'
   }
+
+  const statusCode = 'statusCode' in error
+    ? (error as { statusCode?: number }).statusCode
+    : undefined
+  const data = 'data' in error ? (error as { data?: unknown }).data : undefined
+  const errorCode = data && typeof data === 'object' && 'errorCode' in data
+    ? String((data as { errorCode?: unknown }).errorCode)
+    : undefined
+
+  if (statusCode === 409 && errorCode === 'RENEWAL_ALREADY_IN_PROGRESS') {
+    return 'renewalAlreadyInProgress'
+  }
+
+  if (statusCode !== undefined && statusCode > 399 && statusCode < 500) {
+    return 'badRequest'
+  }
+
+  if (statusCode !== undefined && statusCode >= 500) {
+    return 'internal'
+  }
+
   return 'unknown'
 }
 
-const errorKey = getErrorKey()
+const errorKey = computed(() => resolveApplicationSubmitErrorKey(props.error))
 </script>
 <template>
   <ModalBase>

--- a/strr-base-web/app/composables/useButtonControl.ts
+++ b/strr-base-web/app/composables/useButtonControl.ts
@@ -1,14 +1,14 @@
 import type { ConnectBtnControl } from '#imports'
 
 export const useButtonControl = () => {
-  const route = useRoute()
+  const buttonControlState = useState<ConnectBtnControl | undefined>('connect-button-control', () => undefined)
 
   function setButtonControl (buttonControl: ConnectBtnControl) {
-    route.meta.buttonControl = buttonControl
+    buttonControlState.value = buttonControl
   }
 
-  function getButtonControl (): ConnectBtnControl {
-    return route.meta.buttonControl as ConnectBtnControl
+  function getButtonControl (): ConnectBtnControl | undefined {
+    return buttonControlState.value
   }
 
   function handleButtonLoading (reset: boolean, buttonGrp?: 'left' | 'right', buttonIndex?: number) {
@@ -25,10 +25,13 @@ export const useButtonControl = () => {
       }
     }
     const buttonControl = getButtonControl()
+    if (!buttonControl) {
+      return
+    }
     // update left buttons with loading / disabled as required
-    updateButtonGrp(buttonControl.leftButtons, 'left')
+    updateButtonGrp(buttonControl.leftButtons ?? [], 'left')
     // update right buttons with loading / disabled as required
-    updateButtonGrp(buttonControl.rightButtons, 'right')
+    updateButtonGrp(buttonControl.rightButtons ?? [], 'right')
   }
 
   return {

--- a/strr-base-web/i18n/locales/en-CA.ts
+++ b/strr-base-web/i18n/locales/en-CA.ts
@@ -330,7 +330,7 @@ export default {
       applicationSubmit: {
         renewalAlreadyInProgress: {
           title: 'Renewal Already in Progress',
-          content: 'A renewal application is already in progress for this registration. Go to your dashboard and continue your existing renewal application. If it has already been submitted, wait until it reaches a final decision before starting another renewal.'
+          content: 'A renewal application is already in progress for this registration. Go to your dashboard and continue it. If it has already been submitted, wait until it reaches a final decision before starting another renewal.'
         },
         badRequest: {
           title: 'Invalid Request',

--- a/strr-base-web/i18n/locales/en-CA.ts
+++ b/strr-base-web/i18n/locales/en-CA.ts
@@ -328,6 +328,10 @@ export default {
     },
     error: {
       applicationSubmit: {
+        renewalAlreadyInProgress: {
+          title: 'Renewal Already in Progress',
+          content: 'A renewal application is already in progress for this registration. Go to your dashboard and continue your existing renewal application. If it has already been submitted, wait until it reaches a final decision before starting another renewal.'
+        },
         badRequest: {
           title: 'Invalid Request',
           content: 'There was an issue with the information submitted. Please review your input and try again.'

--- a/strr-host-pm-web/app/composables/useDashboardTodos.ts
+++ b/strr-host-pm-web/app/composables/useDashboardTodos.ts
@@ -8,7 +8,6 @@ export const useDashboardTodos = () => {
   const {
     registration,
     permitDetails,
-    renewalRegId,
     needsBusinessLicenseDocumentUpload
   } = storeToRefs(permitStore)
 
@@ -130,7 +129,7 @@ export const useDashboardTodos = () => {
           buttons: [{
             label: t('btn.renew'),
             action: async () => {
-              renewalRegId.value = registration.value?.id.toString()
+              permitStore.setRenewalRegistrationContext(registration.value!.id)
               await navigateTo({
                 path: localePath('/application'),
                 query: { renew: 'true' }
@@ -148,7 +147,7 @@ export const useDashboardTodos = () => {
             {
               label: t('todos.renewalDraft.resumeButton'),
               action: async () => {
-                renewalRegId.value = undefined // reset renewal id, so the draft app is loaded instead of registration
+                permitStore.clearRenewalRegistrationContext()
                 await navigateTo({
                   path: localePath('/application'),
                   query: { renew: 'true', applicationId: renewalDraftId.value }

--- a/strr-host-pm-web/app/composables/useHostApplicationDraft.ts
+++ b/strr-host-pm-web/app/composables/useHostApplicationDraft.ts
@@ -74,7 +74,11 @@ export function useHostApplicationDraft () {
    */
   async function loadInitialPermitData () {
     if (isRegRenewalFlow.value) {
-      await permitStore.loadHostRegistrationData(effectiveRegistrationId.value!, true)
+      const registrationId = effectiveRegistrationId.value
+      if (!registrationId) {
+        return
+      }
+      await permitStore.loadHostRegistrationData(registrationId, true)
       isRegistrationRenewal.value = true
       await resumeRenewalDraftFromTodosIfNeeded()
     } else if (isRenewal.value && applicationId.value) {

--- a/strr-host-pm-web/app/composables/useHostApplicationDraft.ts
+++ b/strr-host-pm-web/app/composables/useHostApplicationDraft.ts
@@ -14,7 +14,6 @@ export function useHostApplicationDraft () {
   } = storeToRefs(permitStore)
 
   const draftApplicationId = ref<string | undefined>(undefined)
-  const inFlightSubmit = shallowRef<Promise<unknown> | null>(null)
 
   const isRegRenewalFlow = computed(
     () => isRenewal.value && !!effectiveRegistrationId.value
@@ -92,27 +91,11 @@ export function useHostApplicationDraft () {
     }
   }
 
-  /**
-   * Coalesce concurrent submit/save attempts by returning the in-flight promise.
-   * Prevents duplicate API calls from rapid clicks or competing triggers.
-   */
-  function runWithSubmitLock<T> (fn: () => Promise<T>): Promise<T | undefined> {
-    if (inFlightSubmit.value) {
-      return inFlightSubmit.value as Promise<T | undefined>
-    }
-    const submitPromise = fn().finally(() => {
-      inFlightSubmit.value = null
-    })
-    inFlightSubmit.value = submitPromise
-    return submitPromise
-  }
-
   return {
     draftApplicationId,
     isRegRenewalFlow,
     effectiveApplicationNumber,
     persistDraftApplicationId,
-    loadInitialPermitData,
-    runWithSubmitLock
+    loadInitialPermitData
   }
 }

--- a/strr-host-pm-web/app/composables/useHostApplicationDraft.ts
+++ b/strr-host-pm-web/app/composables/useHostApplicationDraft.ts
@@ -1,0 +1,114 @@
+/**
+ * Draft save/submit identity and renewal draft resume for the host application wizard.
+ */
+export function useHostApplicationDraft () {
+  const route = useRoute()
+  const router = useRouter()
+  const { applicationId, isRenewal } = useRouterParams()
+  const permitStore = useHostPermitStore()
+  const {
+    application,
+    registration,
+    isRegistrationRenewal,
+    effectiveRegistrationId
+  } = storeToRefs(permitStore)
+
+  const draftApplicationId = ref<string | undefined>(undefined)
+  const inFlightSubmit = shallowRef<Promise<unknown> | null>(null)
+
+  const isRegRenewalFlow = computed(
+    () => isRenewal.value && !!effectiveRegistrationId.value
+  )
+
+  /**
+   * Current best application id for save/submit.
+   * Prefer the locally persisted draft id, then loaded header id, then query id.
+   */
+  const effectiveApplicationNumber = computed((): string | undefined =>
+    draftApplicationId.value ??
+      application.value?.header?.applicationNumber ??
+      (applicationId.value || undefined)
+  )
+
+  /**
+   * Keep URL query in sync with the latest draft id without adding history entries.
+   */
+  async function syncApplicationIdToQuery (applicationNumber: string) {
+    await router.replace({
+      path: route.path,
+      query: {
+        ...route.query,
+        applicationId: applicationNumber
+      }
+    })
+  }
+
+  async function persistDraftApplicationId (applicationNumber: string) {
+    draftApplicationId.value = applicationNumber
+    await syncApplicationIdToQuery(applicationNumber)
+    const regId = registration.value?.id ?? effectiveRegistrationId.value
+    if (regId) {
+      permitStore.persistSelectedRegistrationId(regId)
+    }
+  }
+
+  async function resumeRenewalDraftFromTodosIfNeeded () {
+    const regId = registration.value?.id
+    // If query already contains an application id, we are opening a known draft/application path.
+    if (!regId || applicationId.value) {
+      return
+    }
+
+    const { renewalDraftId } = await getTodoRegistration(regId)
+    if (!renewalDraftId || typeof renewalDraftId !== 'string') {
+      return
+    }
+
+    await persistDraftApplicationId(renewalDraftId)
+    await permitStore.loadHostData(renewalDraftId, true)
+    isRegistrationRenewal.value = true
+  }
+
+  /**
+   * Load initial renewal/application context from registration flow, query id, or existing application.
+   */
+  async function loadInitialPermitData () {
+    if (isRegRenewalFlow.value) {
+      await permitStore.loadHostRegistrationData(effectiveRegistrationId.value!, true)
+      isRegistrationRenewal.value = true
+      await resumeRenewalDraftFromTodosIfNeeded()
+    } else if (isRenewal.value && applicationId.value) {
+      await permitStore.loadHostData(applicationId.value, true)
+      isRegistrationRenewal.value = true
+    } else if (applicationId.value) {
+      await permitStore.loadHostData(applicationId.value, true)
+      if (application.value?.header.applicationType === 'renewal') {
+        isRegistrationRenewal.value = true
+      }
+    }
+  }
+
+  /**
+   * Coalesce concurrent submit/save attempts by returning the in-flight promise.
+   * Prevents duplicate API calls from rapid clicks or competing triggers.
+   */
+  function runWithSubmitLock<T> (fn: () => Promise<T>): Promise<T | undefined> {
+    if (inFlightSubmit.value) {
+      return inFlightSubmit.value as Promise<T | undefined>
+    }
+    const submitPromise = fn().finally(() => {
+      inFlightSubmit.value = null
+    })
+    inFlightSubmit.value = submitPromise
+    return submitPromise
+  }
+
+  return {
+    draftApplicationId,
+    isRegRenewalFlow,
+    effectiveApplicationNumber,
+    persistDraftApplicationId,
+    loadInitialPermitData,
+    runWithSubmitLock
+  }
+}

--- a/strr-host-pm-web/app/composables/useRenewals.ts
+++ b/strr-host-pm-web/app/composables/useRenewals.ts
@@ -2,7 +2,6 @@ import { DateTime } from 'luxon'
 
 // Registration Renewals composable
 export const useRenewals = () => {
-  const { getRegistrationToDos } = useStrrApi()
   const { registration } = storeToRefs(useHostPermitStore())
 
   const isEligibleForRenewal = ref(false)
@@ -40,25 +39,19 @@ export const useRenewals = () => {
       return
     }
 
-    const { todos } = await getRegistrationToDos(registration.value.id)
-    // check if todos have a renewable registration
-    isEligibleForRenewal.value = todos.some(todo => todo?.task?.type === RegistrationTodoType.REGISTRATION_RENEWAL)
-    // check if todos have a renewable registration draft
-    hasRegistrationRenewalDraft.value =
-      todos.some(todo => todo?.task?.type === RegistrationTodoType.REGISTRATION_RENEWAL_DRAFT)
-    // check if todos have a payment pending renewal
-    hasRegistrationRenewalPaymentPending.value =
-      todos.some(todo => todo?.task?.type === RegistrationTodoType.REGISTRATION_RENEWAL_PAYMENT_PENDING)
+    const {
+      hasRenewalTodo,
+      hasRenewalDraft,
+      hasRenewalPaymentPending,
+      renewalDraftId: draftId,
+      renewalPaymentPendingId: paymentPendingId
+    } = await getTodoRegistration(registration.value.id)
 
-    if (hasRegistrationRenewalDraft.value) {
-      renewalDraftId.value = todos
-        .find(todo => todo?.task?.type === RegistrationTodoType.REGISTRATION_RENEWAL_DRAFT)?.task?.detail
-    }
-
-    if (hasRegistrationRenewalPaymentPending.value) {
-      renewalPaymentPendingId.value = todos
-        .find(todo => todo?.task?.type === RegistrationTodoType.REGISTRATION_RENEWAL_PAYMENT_PENDING)?.task?.detail
-    }
+    isEligibleForRenewal.value = hasRenewalTodo
+    hasRegistrationRenewalDraft.value = hasRenewalDraft
+    hasRegistrationRenewalPaymentPending.value = hasRenewalPaymentPending
+    renewalDraftId.value = draftId ?? ''
+    renewalPaymentPendingId.value = paymentPendingId ?? ''
   }
 
   watch(registration, async () => {

--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -26,8 +26,7 @@ const { isRenewal } = useRouterParams()
 const {
   effectiveApplicationNumber,
   persistDraftApplicationId,
-  loadInitialPermitData,
-  runWithSubmitLock
+  loadInitialPermitData
 } = useHostApplicationDraft()
 const { isSaveDraftEnabled, isNewDashboardEnabled } = useHostFeatureFlags()
 const { fetchStrrFees, getApplicationFee } = useHostApplicationFee()
@@ -159,36 +158,31 @@ const stepperRef = shallowRef<InstanceType<typeof ConnectStepper> | null>(null)
 const reviewFormRef = shallowRef<InstanceType<typeof FormReview> | null>(null)
 
 const saveApplication = async (resumeLater = false) => {
-  const result = await runWithSubmitLock(async () => {
-    handleButtonLoading(false, 'left', resumeLater ? 1 : 2)
-    // prevent flicker of buttons by waiting half a second
-    try {
-      const submitResult = await Promise.all([
-        new Promise(resolve => setTimeout(resolve, 500)),
-        submitApplication(true, effectiveApplicationNumber.value)
-      ])
-      const { filingId } = submitResult[1] as Awaited<ReturnType<typeof submitApplication>>
-      await persistDraftApplicationId(filingId)
-      if (resumeLater) {
-        await navigateTo(localePath('/dashboard'))
-      } else {
+  handleButtonLoading(false, 'left', resumeLater ? 1 : 2)
+  // prevent flicker of buttons by waiting half a second
+  try {
+    const submitResult = await Promise.all([
+      new Promise(resolve => setTimeout(resolve, 500)),
+      submitApplication(true, effectiveApplicationNumber.value)
+    ])
+    const { filingId } = submitResult[1] as Awaited<ReturnType<typeof submitApplication>>
+    await persistDraftApplicationId(filingId)
+    if (resumeLater) {
+      await navigateTo(localePath('/dashboard'))
+    } else {
+      shouldSkipConfirmModal = true
+      setOnBeforeSessionExpired(() => {
         shouldSkipConfirmModal = true
-        setOnBeforeSessionExpired(() => {
-          shouldSkipConfirmModal = true
-          return submitApplication(true, effectiveApplicationNumber.value)
-        })
-      }
-      return { filingId }
-    } catch (e) {
-      logFetchError(e, 'Error saving host application')
-      strrModal.openAppSubmitError(e)
-      throw e
-    } finally {
-      handleButtonLoading(true)
+        return submitApplication(true, effectiveApplicationNumber.value)
+      })
     }
-  })
-  if (result === undefined) {
-    return false
+    return { filingId }
+  } catch (e) {
+    logFetchError(e, 'Error saving host application')
+    strrModal.openAppSubmitError(e)
+    throw e
+  } finally {
+    handleButtonLoading(true)
   }
 }
 
@@ -270,12 +264,7 @@ const handleSubmit = async () => {
     }
 
     shouldSkipConfirmModal = true
-    const result = await runWithSubmitLock(() =>
-      submitApplication(false, effectiveApplicationNumber.value)
-    )
-    if (result === undefined) {
-      return
-    }
+    const result = await submitApplication(false, effectiveApplicationNumber.value)
     await finalizeSuccessfulSubmit(result)
   } catch (e) {
     logFetchError(e, 'Error creating host application')

--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ConnectStepper, FormReview } from '#components'
+
 const { t } = useNuxtApp().$i18n
 const localePath = useLocalePath()
 const strrModal = useStrrModals()
@@ -19,9 +20,15 @@ const {
   $reset: applicationReset
 } = useHostApplicationStore()
 const permitStore = useHostPermitStore()
-const { renewalRegId, application, isRegistrationRenewal } = storeToRefs(permitStore)
+const { isRegistrationRenewal } = storeToRefs(permitStore)
 
-const { applicationId, isRenewal } = useRouterParams()
+const { isRenewal } = useRouterParams()
+const {
+  effectiveApplicationNumber,
+  persistDraftApplicationId,
+  loadInitialPermitData,
+  runWithSubmitLock
+} = useHostApplicationDraft()
 const { isSaveDraftEnabled, isNewDashboardEnabled } = useHostFeatureFlags()
 const { fetchStrrFees, getApplicationFee } = useHostApplicationFee()
 const loading = ref(false)
@@ -42,7 +49,6 @@ const hostFee2 = ref<ConnectFeeItem | undefined>(undefined)
 const hostFee3 = ref<ConnectFeeItem | undefined>(undefined)
 const hostFee4 = ref<ConnectFeeItem | undefined>(undefined)
 
-const isRegRenewalFlow = computed(() => isRenewal.value && !!renewalRegId.value)
 let shouldSkipConfirmModal = false
 
 // show default confirm modal when closing or refreshing the tab while in renewal flow
@@ -66,19 +72,7 @@ onMounted(async () => {
   applicationReset()
   permitStore.$reset()
 
-  if (isRegRenewalFlow.value) {
-    await permitStore.loadHostRegistrationData(renewalRegId.value!, true)
-    isRegistrationRenewal.value = true
-  } else if (isRenewal.value && applicationId.value) {
-    await permitStore.loadHostData(applicationId.value, true)
-    isRegistrationRenewal.value = true
-  } else if (applicationId.value) {
-    await permitStore.loadHostData(applicationId.value, true)
-    // for renewals draft keep the flag on
-    if (application.value?.header.applicationType === 'renewal') {
-      isRegistrationRenewal.value = true
-    }
-  }
+  await loadInitialPermitData()
 
   const { fee1, fee2, fee3 } = await fetchStrrFees()
 
@@ -160,37 +154,41 @@ const steps = ref<Step[]>([
   }
 ])
 const activeStepIndex = ref<number>(0)
-const draftApplicationId = ref<string | undefined>(undefined)
 const activeStep = ref<Step>(steps.value[activeStepIndex.value] as Step)
 const stepperRef = shallowRef<InstanceType<typeof ConnectStepper> | null>(null)
 const reviewFormRef = shallowRef<InstanceType<typeof FormReview> | null>(null)
 
 const saveApplication = async (resumeLater = false) => {
-  handleButtonLoading(false, 'left', resumeLater ? 1 : 2)
-  // prevent flicker of buttons by waiting half a second
-  try {
-    let appId = applicationId.value
-    if (draftApplicationId.value) {
-      appId = draftApplicationId.value
+  const result = await runWithSubmitLock(async () => {
+    handleButtonLoading(false, 'left', resumeLater ? 1 : 2)
+    // prevent flicker of buttons by waiting half a second
+    try {
+      const submitResult = await Promise.all([
+        new Promise(resolve => setTimeout(resolve, 500)),
+        submitApplication(true, effectiveApplicationNumber.value)
+      ])
+      const { filingId } = submitResult[1] as Awaited<ReturnType<typeof submitApplication>>
+      await persistDraftApplicationId(filingId)
+      if (resumeLater) {
+        await navigateTo(localePath('/dashboard'))
+      } else {
+        shouldSkipConfirmModal = true
+        setOnBeforeSessionExpired(() => {
+          shouldSkipConfirmModal = true
+          return submitApplication(true, effectiveApplicationNumber.value)
+        })
+      }
+      return { filingId }
+    } catch (e) {
+      logFetchError(e, 'Error saving host application')
+      strrModal.openAppSubmitError(e)
+      throw e
+    } finally {
+      handleButtonLoading(true)
     }
-    const [, { filingId }] = await Promise.all([
-      new Promise(resolve => setTimeout(resolve, 500)),
-      submitApplication(true, appId)
-    ])
-    draftApplicationId.value = filingId
-    applicationId.value = filingId
-    if (resumeLater) {
-      await navigateTo(localePath('/dashboard'))
-    } else {
-      shouldSkipConfirmModal = true
-      // update route meta to save application before session expires with new application id
-      setOnBeforeSessionExpired(() => submitApplication(true, filingId))
-    }
-  } catch (e) {
-    logFetchError(e, 'Error saving host application')
-    strrModal.openAppSubmitError(e)
-  } finally {
-    handleButtonLoading(true)
+  })
+  if (result === undefined) {
+    return false
   }
 }
 
@@ -236,13 +234,19 @@ const handleSubmit = async () => {
       return
     }
 
-    // show confirmation modal only when application is valid
     const confirmed = await openConfirmProceedToPay()
     if (!confirmed) {
       shouldSkipConfirmModal = false
-      return // user clicked 'Go back' or closed modal
+      return
     }
 
+    shouldSkipConfirmModal = true
+    const res = await runWithSubmitLock(() =>
+      submitApplication(false, effectiveApplicationNumber.value)
+    )
+    if (res === undefined) {
+      return
+    }
     const {
       paymentToken,
       filingId,
@@ -250,15 +254,12 @@ const handleSubmit = async () => {
       registrationId,
       registrationNumber,
       applicationType
-    } = await submitApplication(false, applicationId.value)
+    } = res
 
-    // Determine redirect path based on feature flag and application type
     let redirectPath: string
     if (isNewDashboardEnabled.value) {
       if (applicationType === 'renewal' && registrationId && registrationNumber) {
-        permitStore.selectedRegistrationId = String(registrationId)
-        // Persist to sessionStorage to survive external payment redirect
-        sessionStorage.setItem('selectedRegistrationId', String(registrationId))
+        permitStore.persistSelectedRegistrationId(registrationId)
         sessionStorage.setItem('renewalApplicationNumber', filingId)
         redirectPath = `/dashboard/registration/${registrationNumber}`
       } else {
@@ -282,8 +283,7 @@ const handleSubmit = async () => {
   }
 }
 
-// TODO: musing - should we move this into the stepper component and add button items to the 'Step' object
-watch([activeStepIndex, isRegistrationRenewal], () => {
+function updateButtonControl () {
   const buttons: ConnectBtnControlItem[] = []
   if (activeStepIndex.value !== 0) {
     buttons.push({
@@ -323,7 +323,16 @@ watch([activeStepIndex, isRegistrationRenewal], () => {
     leftButtons: isSaveDraftEnabled.value ? leftActionButtons : [],
     rightButtons: buttons
   })
-}, { immediate: true })
+}
+
+async function handleStepperNewStep () {
+  // Ensure button control reflects the latest active step model/index after step transition.
+  await nextTick()
+  updateButtonControl()
+}
+
+// TODO: musing - should we move this into the stepper component and add button items to the 'Step' object
+watch([activeStepIndex, isRegistrationRenewal], updateButtonControl, { immediate: true, flush: 'sync' })
 
 // remove unnecessary docs when/if exemption options change
 watch(() => prRequirements.value.prExemptionReason, async (newVal) => {
@@ -396,7 +405,7 @@ definePageMeta({
 // save application before session expires
 setOnBeforeSessionExpired(() => {
   shouldSkipConfirmModal = true
-  submitApplication(true, applicationId.value)
+  return submitApplication(true, effectiveApplicationNumber.value)
 })
 </script>
 <template>
@@ -415,6 +424,7 @@ setOnBeforeSessionExpired(() => {
       v-model:active-step-index="activeStepIndex"
       v-model:active-step="activeStep"
       :stepper-label="$t('strr.step.stepperLabel')"
+      @new-step="handleStepperNewStep"
     />
     <div v-if="activeStepIndex === 0" key="define-your-rental">
       <FormDefineYourRental :is-complete="activeStep.complete" />

--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -192,9 +192,61 @@ const saveApplication = async (resumeLater = false) => {
   }
 }
 
+type SubmitApplicationResult = Awaited<ReturnType<typeof submitApplication>>
+
+async function collectValidationErrors (): Promise<MultiFormValidationResult> {
+  // TODO: use common fn for here and ReviewConfirm.vue
+  const validations = [
+    propertyStore.validateBusinessLicense(),
+    propertyStore.validateUnitAddress(),
+    propertyStore.validateUnitDetails(),
+    validateOwners(),
+    validateUserConfirmation(),
+    propertyReqStore.validateBlExemption(),
+    propertyReqStore.validatePrRequirements()
+  ]
+
+  const validationResults = await Promise.all(validations)
+  const formErrors = validationResults.flatMap(result => result as MultiFormValidationResult)
+
+  if (documentsStore.validateRequiredDocuments().length > 0) {
+    formErrors.push({
+      formId: 'supporting-documents',
+      success: false,
+      errors: []
+    })
+  }
+
+  return formErrors
+}
+
+function buildPostSubmitRedirect (result: SubmitApplicationResult): string {
+  const { applicationType, registrationId, registrationNumber, filingId } = result
+
+  if (!isNewDashboardEnabled.value) {
+    return `/dashboard/${filingId}`
+  }
+
+  if (applicationType === 'renewal' && registrationId && registrationNumber) {
+    permitStore.persistSelectedRegistrationId(registrationId)
+    sessionStorage.setItem('renewalApplicationNumber', filingId)
+    return `/dashboard/registration/${registrationNumber}`
+  }
+
+  return `/dashboard/application/${filingId}`
+}
+
+async function finalizeSuccessfulSubmit (result: SubmitApplicationResult) {
+  const redirectPath = buildPostSubmitRedirect(result)
+  if (result.applicationStatus === ApplicationStatus.PAYMENT_DUE) {
+    handlePaymentRedirect(result.paymentToken, redirectPath)
+    return
+  }
+  await navigateTo(localePath(redirectPath))
+}
+
 // need to cleanup the setButtonControl somehow
 const handleSubmit = async () => {
-  let formErrors: MultiFormValidationResult = []
   shouldSkipConfirmModal = true
   try {
     // set buttons to loading state
@@ -202,30 +254,7 @@ const handleSubmit = async () => {
 
     activeStep.value.complete = true // set final review step as active before validation
     reviewFormRef.value?.validateConfirmation() // validate confirmation checkboxes on submit
-
-    // TODO: use common fn for here and ReviewConfirm.vue
-    // all step validations
-    const validations = [
-      propertyStore.validateBusinessLicense(),
-      propertyStore.validateUnitAddress(),
-      propertyStore.validateUnitDetails(),
-      validateOwners(),
-      validateUserConfirmation(),
-      propertyReqStore.validateBlExemption(),
-      propertyReqStore.validatePrRequirements()
-    ]
-
-    const validationResults = await Promise.all(validations)
-    formErrors = validationResults.flatMap(result => result as MultiFormValidationResult)
-    // add documents section error if applicable
-    if (documentsStore.validateRequiredDocuments().length > 0) {
-      formErrors.push({
-        formId: 'supporting-documents',
-        success: false,
-        errors: []
-      })
-    }
-
+    const formErrors = await collectValidationErrors()
     const isApplicationValid = formErrors.every(result => result.success === true)
 
     if (!isApplicationValid) {
@@ -241,39 +270,13 @@ const handleSubmit = async () => {
     }
 
     shouldSkipConfirmModal = true
-    const res = await runWithSubmitLock(() =>
+    const result = await runWithSubmitLock(() =>
       submitApplication(false, effectiveApplicationNumber.value)
     )
-    if (res === undefined) {
+    if (result === undefined) {
       return
     }
-    const {
-      paymentToken,
-      filingId,
-      applicationStatus,
-      registrationId,
-      registrationNumber,
-      applicationType
-    } = res
-
-    let redirectPath: string
-    if (isNewDashboardEnabled.value) {
-      if (applicationType === 'renewal' && registrationId && registrationNumber) {
-        permitStore.persistSelectedRegistrationId(registrationId)
-        sessionStorage.setItem('renewalApplicationNumber', filingId)
-        redirectPath = `/dashboard/registration/${registrationNumber}`
-      } else {
-        redirectPath = `/dashboard/application/${filingId}`
-      }
-    } else {
-      redirectPath = `/dashboard/${filingId}`
-    }
-
-    if (applicationStatus === ApplicationStatus.PAYMENT_DUE) {
-      handlePaymentRedirect(paymentToken, redirectPath)
-    } else {
-      await navigateTo(localePath(redirectPath))
-    }
+    await finalizeSuccessfulSubmit(result)
   } catch (e) {
     logFetchError(e, 'Error creating host application')
     strrModal.openAppSubmitError(e)

--- a/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
+++ b/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
@@ -15,7 +15,6 @@ const {
   application,
   registration,
   permitDetails,
-  renewalRegId,
   isPaidApplication,
   showPermitDetails,
   needsBusinessLicenseDocumentUpload
@@ -201,7 +200,7 @@ watch([isRenewalsEnabled,
       buttons: [{
         label: t('btn.renew'),
         action: async () => {
-          renewalRegId.value = registration.value?.id.toString()
+          permitStore.setRenewalRegistrationContext(registration.value!.id)
           await navigateTo({
             path: localePath('/application'),
             query: { renew: 'true' }
@@ -219,7 +218,7 @@ watch([isRenewalsEnabled,
         {
           label: t('todos.renewalDraft.resumeButton'),
           action: async () => {
-            renewalRegId.value = undefined // reset renewal id, so the draft app is loaded instead of registration
+            permitStore.clearRenewalRegistrationContext()
             await navigateTo({
               path: localePath('/application'),
               query: { renew: 'true', applicationId: renewalDraftId.value }

--- a/strr-host-pm-web/app/pages/dashboard/registration/[registrationNumber].vue
+++ b/strr-host-pm-web/app/pages/dashboard/registration/[registrationNumber].vue
@@ -41,11 +41,11 @@ onMounted(async () => {
   // If not in store, try sessionStorage (survives external payment redirect)
   let returningFromPayment = false
   if (!selectedRegistrationId.value) {
-    const storedId = sessionStorage.getItem('selectedRegistrationId')
+    const storedId = permitStore.readStoredSelectedRegistrationId()
     if (storedId) {
       selectedRegistrationId.value = storedId
       returningFromPayment = true
-      sessionStorage.removeItem('selectedRegistrationId') // Clean up after use
+      permitStore.clearStoredSelectedRegistrationId()
     }
   }
 

--- a/strr-host-pm-web/app/stores/hostPermit.ts
+++ b/strr-host-pm-web/app/stores/hostPermit.ts
@@ -48,10 +48,7 @@ export const useHostPermitStore = defineStore('host/permit', () => {
     if (selectedRegistrationId.value) {
       return selectedRegistrationId.value
     }
-    if (import.meta.client) {
-      return sessionStorage.getItem(SELECTED_REGISTRATION_ID_KEY) ?? undefined
-    }
-    return undefined
+    return sessionStorage.getItem(SELECTED_REGISTRATION_ID_KEY) ?? undefined
   })
 
   const setRenewalRegistrationContext = (registrationId: string | number) => {
@@ -67,22 +64,15 @@ export const useHostPermitStore = defineStore('host/permit', () => {
   const persistSelectedRegistrationId = (registrationId: string | number) => {
     const id = String(registrationId)
     selectedRegistrationId.value = id
-    if (import.meta.client) {
-      sessionStorage.setItem(SELECTED_REGISTRATION_ID_KEY, id)
-    }
+    sessionStorage.setItem(SELECTED_REGISTRATION_ID_KEY, id)
   }
 
   const readStoredSelectedRegistrationId = (): string | undefined => {
-    if (!import.meta.client) {
-      return undefined
-    }
     return sessionStorage.getItem(SELECTED_REGISTRATION_ID_KEY) ?? undefined
   }
 
   const clearStoredSelectedRegistrationId = () => {
-    if (import.meta.client) {
-      sessionStorage.removeItem(SELECTED_REGISTRATION_ID_KEY)
-    }
+    sessionStorage.removeItem(SELECTED_REGISTRATION_ID_KEY)
   }
 
   const needsBusinessLicenseDocumentUpload = computed(() => {

--- a/strr-host-pm-web/app/stores/hostPermit.ts
+++ b/strr-host-pm-web/app/stores/hostPermit.ts
@@ -38,6 +38,53 @@ export const useHostPermitStore = defineStore('host/permit', () => {
   const isRegistrationRenewal = ref(false)
   const selectedRegistrationId = ref<string | undefined>(undefined)
 
+  const SELECTED_REGISTRATION_ID_KEY = 'selectedRegistrationId'
+
+  /** Registration id for renewal entry: in-flight renew context, dashboard selection, or payment return. */
+  const effectiveRegistrationId = computed((): string | undefined => {
+    if (renewalRegId.value) {
+      return renewalRegId.value
+    }
+    if (selectedRegistrationId.value) {
+      return selectedRegistrationId.value
+    }
+    if (import.meta.client) {
+      return sessionStorage.getItem(SELECTED_REGISTRATION_ID_KEY) ?? undefined
+    }
+    return undefined
+  })
+
+  const setRenewalRegistrationContext = (registrationId: string | number) => {
+    const id = String(registrationId)
+    renewalRegId.value = id
+    selectedRegistrationId.value = id
+  }
+
+  const clearRenewalRegistrationContext = () => {
+    renewalRegId.value = undefined
+  }
+
+  const persistSelectedRegistrationId = (registrationId: string | number) => {
+    const id = String(registrationId)
+    selectedRegistrationId.value = id
+    if (import.meta.client) {
+      sessionStorage.setItem(SELECTED_REGISTRATION_ID_KEY, id)
+    }
+  }
+
+  const readStoredSelectedRegistrationId = (): string | undefined => {
+    if (!import.meta.client) {
+      return undefined
+    }
+    return sessionStorage.getItem(SELECTED_REGISTRATION_ID_KEY) ?? undefined
+  }
+
+  const clearStoredSelectedRegistrationId = () => {
+    if (import.meta.client) {
+      sessionStorage.removeItem(SELECTED_REGISTRATION_ID_KEY)
+    }
+  }
+
   const needsBusinessLicenseDocumentUpload = computed(() => {
     if (!isBusinessLicenseDocumentUploadEnabled.value || !registration.value) {
       return false
@@ -157,6 +204,12 @@ export const useHostPermitStore = defineStore('host/permit', () => {
     renewalRegId,
     isRegistrationRenewal,
     selectedRegistrationId,
+    effectiveRegistrationId,
+    setRenewalRegistrationContext,
+    clearRenewalRegistrationContext,
+    persistSelectedRegistrationId,
+    readStoredSelectedRegistrationId,
+    clearStoredSelectedRegistrationId,
     needsBusinessLicenseDocumentUpload,
     checkBusinessLicenseRequirement,
     downloadApplicationReceipt,

--- a/strr-host-pm-web/tests/unit/application-dashboard.spec.ts
+++ b/strr-host-pm-web/tests/unit/application-dashboard.spec.ts
@@ -1,6 +1,5 @@
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
-import { describe, it, expect, vi, beforeAll } from 'vitest'
-import { DateTime } from 'luxon'
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import { baseEnI18n } from '../mocks/i18n'
 import { mockApplication, mockHostOwner, mockHostRegistration } from '../mocks/mockedData'
 import ApplicationDashboard from '~/pages/dashboard/[applicationId].vue'
@@ -12,10 +11,19 @@ import {
   UButton
 } from '#components'
 
+const {
+  mockIsEligibleForRenewal
+} = vi.hoisted(() => {
+  return {
+    mockIsEligibleForRenewal: { value: true }
+  }
+})
+
 vi.mock('@/stores/hostPermit', () => ({
   useHostPermitStore: () => ({
     loadHostData: vi.fn(),
     downloadApplicationReceipt: vi.fn(),
+    deleteApplication: vi.fn().mockResolvedValue(undefined),
     permitDetails: ref({
       unitAddress: mockApplication.registration.unitAddress,
       documents: [],
@@ -25,7 +33,9 @@ vi.mock('@/stores/hostPermit', () => ({
     showPermitDetails: ref(true),
     application: ref(mockApplication),
     registration: ref(mockApplication.registration),
-    needsBusinessLicenseDocumentUpload: ref(false)
+    needsBusinessLicenseDocumentUpload: ref(false),
+    setRenewalRegistrationContext: vi.fn(),
+    clearRenewalRegistrationContext: vi.fn()
   })
 }))
 
@@ -61,15 +71,26 @@ vi.mock('@/stores/hostProperty', () => ({
   })
 }))
 
-vi.mock('@/composables/useRenewals', () => ({
-  useRenewals: () => ({
-    isEligibleForRenewal: ref(true),
-    renewalDueDate: computed(() =>
-      DateTime.fromISO(mockHostRegistration.expiryDate).setZone('America/Vancouver').toLocaleString(DateTime.DATE_MED)),
-    renewalDateCounter: computed(() => 20),
-    isRenewalPeriodClosed: ref(false),
-    isRenewalsEnabled: ref(true)
-    // getRegistrationRenewalTodos: vi.fn()
+vi.mock('@/composables/useRenewals', () => {
+  return {
+    useRenewals: () => ({
+      isEligibleForRenewal: mockIsEligibleForRenewal,
+      hasRegistrationRenewalDraft: { value: false },
+      hasRegistrationRenewalPaymentPending: { value: false },
+      renewalDraftId: { value: '' },
+      renewalPaymentPendingId: { value: '' },
+      renewalDueDate: { value: 'Dec 31, 2025' },
+      renewalDateCounter: { value: 20 },
+      isRenewalPeriodClosed: { value: false },
+      getRegistrationRenewalTodos: vi.fn().mockResolvedValue(undefined)
+    })
+  }
+})
+
+vi.mock('@/composables/useHostFeatureFlags', () => ({
+  useHostFeatureFlags: () => ({
+    isRenewalsEnabled: ref(true),
+    isNewDashboardEnabled: ref(false)
   })
 }))
 
@@ -91,6 +112,11 @@ vi.mock('@/composables/useStrrApi', () => ({
 
 describe('Dashboard Application Page', () => {
   let wrapper: any
+
+  beforeEach(() => {
+    mockIsEligibleForRenewal.value = true
+    vi.clearAllMocks()
+  })
 
   beforeAll(async () => {
     wrapper = await mountSuspended(ApplicationDashboard, {

--- a/strr-host-pm-web/tests/unit/composable-use-host-application-draft.spec.ts
+++ b/strr-host-pm-web/tests/unit/composable-use-host-application-draft.spec.ts
@@ -1,0 +1,197 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, computed, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { emptyTodoRegistration } from './helpers/renewal-test-utils'
+
+const replaceMock = vi.fn().mockResolvedValue(undefined)
+const mockRoute = {
+  path: '/en-CA/application',
+  query: { renew: 'true' } as Record<string, string>,
+  meta: {} as Record<string, unknown>
+}
+
+mockNuxtImport('useRouter', () => () => ({ replace: replaceMock }))
+mockNuxtImport('useRoute', () => () => mockRoute)
+
+vi.mock('@/composables/useRouterParams', () => ({
+  useRouterParams: () => ({
+    applicationId: computed(() => mockRoute.query.applicationId),
+    isRenewal: computed(() => mockRoute.query.renew === 'true')
+  })
+}))
+
+const getTodoRegistrationMock = vi.fn()
+
+vi.mock('#baseWeb/utils/todoItems', () => ({
+  getTodoRegistration: (...args: unknown[]) => getTodoRegistrationMock(...args)
+}))
+
+const registrationRef = ref<{ id: number } | undefined>({ id: 7 })
+const applicationRef = ref<{ header: { applicationNumber: string, applicationType?: string } } | undefined>()
+const effectiveRegistrationIdRef = ref<string | undefined>('42')
+const isRegistrationRenewalRef = ref(false)
+const loadHostDataMock = vi.fn()
+const loadHostRegistrationDataMock = vi.fn()
+const persistSelectedRegistrationIdMock = vi.fn()
+
+vi.mock('@/stores/hostPermit', () => ({
+  useHostPermitStore: () => ({
+    loadHostRegistrationData: loadHostRegistrationDataMock,
+    loadHostData: loadHostDataMock,
+    application: applicationRef,
+    registration: registrationRef,
+    isRegistrationRenewal: isRegistrationRenewalRef,
+    effectiveRegistrationId: effectiveRegistrationIdRef,
+    persistSelectedRegistrationId: persistSelectedRegistrationIdMock
+  })
+}))
+
+async function useDraft () {
+  const { useHostApplicationDraft } = await import('@/composables/useHostApplicationDraft')
+  return useHostApplicationDraft()
+}
+
+function resetDraftState () {
+  mockRoute.query = { renew: 'true' }
+  registrationRef.value = { id: 7 }
+  applicationRef.value = undefined
+  effectiveRegistrationIdRef.value = '42'
+  isRegistrationRenewalRef.value = false
+  getTodoRegistrationMock.mockResolvedValue({
+    ...emptyTodoRegistration,
+    hasRenewalDraft: true,
+    renewalDraftId: 'DRAFT-APP-123'
+  })
+}
+
+describe('useHostApplicationDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDraftState()
+  })
+
+  describe('effectiveApplicationNumber', () => {
+    it('prefers draftApplicationId over application header and query', async () => {
+      mockRoute.query = { renew: 'true', applicationId: 'QUERY-ID' }
+      applicationRef.value = { header: { applicationNumber: 'HEADER-ID' } }
+      const { effectiveApplicationNumber, draftApplicationId } = await useDraft()
+      draftApplicationId.value = 'DRAFT-LOCAL'
+      expect(effectiveApplicationNumber.value).toBe('DRAFT-LOCAL')
+    })
+  })
+
+  describe('persistDraftApplicationId', () => {
+    it('syncs query and persists registration id from registration', async () => {
+      const { persistDraftApplicationId, draftApplicationId } = await useDraft()
+      await persistDraftApplicationId('APP-999')
+      expect(draftApplicationId.value).toBe('APP-999')
+      expect(replaceMock).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.objectContaining({ applicationId: 'APP-999' }) })
+      )
+      expect(persistSelectedRegistrationIdMock).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe('resumeRenewalDraftFromTodosIfNeeded', () => {
+    it('resumes renewal draft from todos and syncs applicationId to the query', async () => {
+      await (await useDraft()).loadInitialPermitData()
+      await flushPromises()
+
+      expect(getTodoRegistrationMock).toHaveBeenCalledWith(7)
+      expect(replaceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ renew: 'true', applicationId: 'DRAFT-APP-123' })
+        })
+      )
+      expect(loadHostDataMock).toHaveBeenCalledWith('DRAFT-APP-123', true)
+      expect(isRegistrationRenewalRef.value).toBe(true)
+    })
+
+    it.each([
+      ['applicationId is in the query', { query: { renew: 'true', applicationId: 'EXISTING' } }]
+    ])('does not fetch todos when %s', async (_label, setup) => {
+      if ('query' in setup && setup.query) {
+        mockRoute.query = setup.query
+      }
+      await (await useDraft()).loadInitialPermitData()
+      await flushPromises()
+      expect(getTodoRegistrationMock).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['todos have no renewal draft id', emptyTodoRegistration]
+    ])('does not load draft when %s', async (_label, todoResponse) => {
+      getTodoRegistrationMock.mockResolvedValue(todoResponse)
+      await (await useDraft()).loadInitialPermitData()
+      await flushPromises()
+      expect(getTodoRegistrationMock).toHaveBeenCalledWith(7)
+      expect(loadHostDataMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('loadInitialPermitData', () => {
+    it.each([
+      [
+        'renew flow with applicationId in query',
+        { query: { renew: 'true', applicationId: 'RENEW-APP' }, effectiveId: undefined },
+        { loadReg: false, loadApp: ['RENEW-APP', true], renewal: true }
+      ],
+      [
+        'applicationId with renewal type',
+        {
+          query: { applicationId: 'APP-RENEWAL-TYPE' },
+          effectiveId: undefined,
+          application: { header: { applicationNumber: 'APP-RENEWAL-TYPE', applicationType: 'renewal' } }
+        },
+        { loadReg: false, loadApp: ['APP-RENEWAL-TYPE', true], renewal: true }
+      ],
+      [
+        'no renewal flow and no applicationId',
+        { query: {}, effectiveId: undefined },
+        { loadReg: false, loadApp: null, renewal: false }
+      ]
+    ])('%s', async (_label, setup, expected) => {
+      mockRoute.query = setup.query
+      effectiveRegistrationIdRef.value = setup.effectiveId
+      if ('application' in setup && setup.application) {
+        applicationRef.value = setup.application
+      } else {
+        applicationRef.value = undefined
+      }
+
+      await (await useDraft()).loadInitialPermitData()
+
+      if (expected.loadReg) {
+        expect(loadHostRegistrationDataMock).toHaveBeenCalled()
+      } else {
+        expect(loadHostRegistrationDataMock).not.toHaveBeenCalled()
+      }
+      if (expected.loadApp) {
+        expect(loadHostDataMock).toHaveBeenCalledWith(...expected.loadApp)
+      } else {
+        expect(loadHostDataMock).not.toHaveBeenCalled()
+      }
+      expect(isRegistrationRenewalRef.value).toBe(expected.renewal)
+    })
+  })
+
+  describe('runWithSubmitLock', () => {
+    it('coalesces a second call while the first is in flight', async () => {
+      const { runWithSubmitLock } = await useDraft()
+      let resolveFirst!: (value: string) => void
+      const firstFn = vi.fn(() => new Promise<string>((resolve) => { resolveFirst = resolve }))
+      const secondFn = vi.fn(() => Promise.resolve('second'))
+
+      const firstResult = runWithSubmitLock(firstFn)
+      await nextTick()
+      const secondResult = runWithSubmitLock(secondFn)
+      expect(secondFn).not.toHaveBeenCalled()
+
+      resolveFirst('first')
+      await expect(firstResult).resolves.toBe('first')
+      await expect(secondResult).resolves.toBe('first')
+      await flushPromises()
+    })
+  })
+})

--- a/strr-host-pm-web/tests/unit/composable-use-host-application-draft.spec.ts
+++ b/strr-host-pm-web/tests/unit/composable-use-host-application-draft.spec.ts
@@ -1,6 +1,6 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 import { emptyTodoRegistration } from './helpers/renewal-test-utils'
 
@@ -173,25 +173,6 @@ describe('useHostApplicationDraft', () => {
         expect(loadHostDataMock).not.toHaveBeenCalled()
       }
       expect(isRegistrationRenewalRef.value).toBe(expected.renewal)
-    })
-  })
-
-  describe('runWithSubmitLock', () => {
-    it('coalesces a second call while the first is in flight', async () => {
-      const { runWithSubmitLock } = await useDraft()
-      let resolveFirst!: (value: string) => void
-      const firstFn = vi.fn(() => new Promise<string>((resolve) => { resolveFirst = resolve }))
-      const secondFn = vi.fn(() => Promise.resolve('second'))
-
-      const firstResult = runWithSubmitLock(firstFn)
-      await nextTick()
-      const secondResult = runWithSubmitLock(secondFn)
-      expect(secondFn).not.toHaveBeenCalled()
-
-      resolveFirst('first')
-      await expect(firstResult).resolves.toBe('first')
-      await expect(secondResult).resolves.toBe('first')
-      await flushPromises()
     })
   })
 })

--- a/strr-host-pm-web/tests/unit/composable-use-renewals.spec.ts
+++ b/strr-host-pm-web/tests/unit/composable-use-renewals.spec.ts
@@ -3,6 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 import { DateTime } from 'luxon'
 import { mockHostRegistration } from '../mocks/mockedData'
+import { emptyTodoRegistration } from './helpers/renewal-test-utils'
 
 const mockRegistration = ref<HostRegistrationResp | null>(null)
 
@@ -12,18 +13,16 @@ vi.mock('@/stores/hostPermit', () => ({
   useHostPermitStore: vi.fn(() => ({}))
 }))
 
-const mockGetRegistrationToDos = vi.fn()
+const mockGetTodoRegistration = vi.fn()
 
-mockNuxtImport('useStrrApi', () => () => ({
-  getRegistrationToDos: mockGetRegistrationToDos
+vi.mock('#baseWeb/utils/todoItems', () => ({
+  getTodoRegistration: (...args: unknown[]) => mockGetTodoRegistration(...args)
 }))
-
-const setupTodo = (type: RegistrationTodoType, detail?: string) => ({ task: { type, detail } })
 
 function resetState () {
   mockRegistration.value = null
-  mockGetRegistrationToDos.mockClear()
-  mockGetRegistrationToDos.mockResolvedValue({ todos: [] })
+  mockGetTodoRegistration.mockClear()
+  mockGetTodoRegistration.mockResolvedValue(emptyTodoRegistration)
 }
 
 describe('Computed Properties in Renewals', () => {
@@ -95,7 +94,7 @@ describe('Registration Renewal Todo', () => {
     mockRegistration.value = null
     const { isEligibleForRenewal, hasRegistrationRenewalDraft, hasRegistrationRenewalPaymentPending } = useRenewals()
     await flushPromises()
-    expect(mockGetRegistrationToDos).not.toHaveBeenCalled()
+    expect(mockGetTodoRegistration).not.toHaveBeenCalled()
     expect(isEligibleForRenewal.value).toBe(false)
     expect(hasRegistrationRenewalDraft.value).toBe(false)
     expect(hasRegistrationRenewalPaymentPending.value).toBe(false)
@@ -103,19 +102,27 @@ describe('Registration Renewal Todo', () => {
 
   it('set isEligibleForRenewal when REGISTRATION_RENEWAL todo is present', async () => {
     mockRegistration.value = { ...mockHostRegistration }
-    mockGetRegistrationToDos.mockResolvedValue({
-      todos: [setupTodo(RegistrationTodoType.REGISTRATION_RENEWAL)]
+    mockGetTodoRegistration.mockResolvedValue({
+      hasRenewalTodo: true,
+      hasRenewalDraft: false,
+      hasRenewalPaymentPending: false,
+      renewalDraftId: null,
+      renewalPaymentPendingId: null
     })
     const { isEligibleForRenewal } = useRenewals()
     await flushPromises()
-    expect(mockGetRegistrationToDos).toHaveBeenCalledWith(mockHostRegistration.id)
+    expect(mockGetTodoRegistration).toHaveBeenCalledWith(mockHostRegistration.id)
     expect(isEligibleForRenewal.value).toBe(true)
   })
 
   it('set hasRegistrationRenewalDraft and renewalDraftId for renewal draft', async () => {
     mockRegistration.value = { ...mockHostRegistration }
-    mockGetRegistrationToDos.mockResolvedValue({
-      todos: [setupTodo(RegistrationTodoType.REGISTRATION_RENEWAL_DRAFT, '0987654321')]
+    mockGetTodoRegistration.mockResolvedValue({
+      hasRenewalTodo: false,
+      hasRenewalDraft: true,
+      hasRenewalPaymentPending: false,
+      renewalDraftId: '0987654321',
+      renewalPaymentPendingId: null
     })
     const { hasRegistrationRenewalDraft, renewalDraftId } = useRenewals()
     await flushPromises()
@@ -125,8 +132,12 @@ describe('Registration Renewal Todo', () => {
 
   it('set hasRegistrationRenewalPaymentPending and renewalPaymentPendingId for payment pending todo', async () => {
     mockRegistration.value = { ...mockHostRegistration }
-    mockGetRegistrationToDos.mockResolvedValue({
-      todos: [setupTodo(RegistrationTodoType.REGISTRATION_RENEWAL_PAYMENT_PENDING, '12345')]
+    mockGetTodoRegistration.mockResolvedValue({
+      hasRenewalTodo: false,
+      hasRenewalDraft: false,
+      hasRenewalPaymentPending: true,
+      renewalDraftId: null,
+      renewalPaymentPendingId: '12345'
     })
     const { hasRegistrationRenewalPaymentPending, renewalPaymentPendingId } = useRenewals()
     await flushPromises()

--- a/strr-host-pm-web/tests/unit/helpers/renewal-test-utils.ts
+++ b/strr-host-pm-web/tests/unit/helpers/renewal-test-utils.ts
@@ -1,0 +1,38 @@
+/** Shared constants and mount options for renewal-related unit tests. */
+
+export const emptyTodoRegistration = {
+  hasRenewalTodo: false,
+  hasRenewalDraft: false,
+  hasRenewalPaymentPending: false,
+  renewalDraftId: null,
+  renewalPaymentPendingId: null
+} as const
+
+export const applicationPageStubs = {
+  ConnectSpinner: true,
+  ConnectTypographyH1: true,
+  ModalGroupHelpAndInfo: true,
+  FormDefineYourRental: true,
+  FormAddOwners: true,
+  FormAddDocuments: true,
+  FormReview: true,
+  ConnectStepper: true
+} as const
+
+export const registrationDashboardStubs = {
+  DashboardTodoSection: true,
+  DashboardRentalSection: true,
+  DashboardSupportingInfoSection: true,
+  ConnectDashboardSection: true,
+  DashboardSidebar: true,
+  RegistrationSubmittedApplications: true
+} as const
+
+export function renewalNavigatePayload (applicationId?: string) {
+  return {
+    path: '/application',
+    query: applicationId
+      ? { renew: 'true', applicationId }
+      : { renew: 'true' }
+  }
+}

--- a/strr-host-pm-web/tests/unit/registration-dashboard.spec.ts
+++ b/strr-host-pm-web/tests/unit/registration-dashboard.spec.ts
@@ -16,7 +16,7 @@ const {
   navigateTo
 } = vi.hoisted(() => {
   return {
-    selectedRegistrationId: { value: undefined } as Ref<string | undefined>,
+    selectedRegistrationId: { value: undefined, __v_isRef: true } as unknown as Ref<string | undefined>,
     loadHostRegistrationData: vi.fn().mockResolvedValue(undefined),
     readStoredSelectedRegistrationId: vi.fn(),
     clearStoredSelectedRegistrationId: vi.fn(),

--- a/strr-host-pm-web/tests/unit/registration-dashboard.spec.ts
+++ b/strr-host-pm-web/tests/unit/registration-dashboard.spec.ts
@@ -1,0 +1,119 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, type Ref } from 'vue'
+import { baseEnI18n } from '../mocks/i18n'
+import { mockHostRegistration } from '../mocks/mockedData'
+import { registrationDashboardStubs } from './helpers/renewal-test-utils'
+import RegistrationDashboard from '~/pages/dashboard/registration/[registrationNumber].vue'
+
+const {
+  selectedRegistrationId,
+  loadHostRegistrationData,
+  readStoredSelectedRegistrationId,
+  clearStoredSelectedRegistrationId,
+  updatePaymentDetails,
+  navigateTo
+} = vi.hoisted(() => {
+  return {
+    selectedRegistrationId: { value: undefined } as Ref<string | undefined>,
+    loadHostRegistrationData: vi.fn().mockResolvedValue(undefined),
+    readStoredSelectedRegistrationId: vi.fn(),
+    clearStoredSelectedRegistrationId: vi.fn(),
+    updatePaymentDetails: vi.fn().mockResolvedValue(undefined),
+    navigateTo: vi.fn().mockResolvedValue(undefined)
+  }
+})
+
+vi.mock('@/stores/hostPermit', () => ({
+  useHostPermitStore: () => ({
+    selectedRegistrationId,
+    registration: ref(mockHostRegistration),
+    permitDetails: ref({ unitAddress: { nickname: 'Unit' } }),
+    showPermitDetails: ref(true),
+    needsBusinessLicenseDocumentUpload: ref(false),
+    readStoredSelectedRegistrationId,
+    clearStoredSelectedRegistrationId,
+    loadHostRegistrationData
+  })
+}))
+
+vi.mock('@/stores/connectDetailsHeader', () => ({
+  useConnectDetailsHeaderStore: () => ({
+    loading: ref(false),
+    title: ref(''),
+    subtitles: ref([])
+  })
+}))
+
+vi.mock('@/stores/hostProperty', () => ({
+  useHostPropertyStore: () => ({
+    unitAddress: ref({ address: mockHostRegistration.unitAddress })
+  })
+}))
+
+vi.mock('@/composables/useDashboardTodos', () => ({
+  useDashboardTodos: () => ({
+    todos: ref([]),
+    hasPendingRenewalProcessing: ref(false),
+    addNocTodo: vi.fn(),
+    addBusinessLicenseTodo: vi.fn(),
+    setupRenewalTodosWatch: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useDashboardPage', () => ({
+  useDashboardPage: () => ({
+    owners: ref([]),
+    setupBreadcrumbs: vi.fn(),
+    setupOwners: vi.fn()
+  })
+}))
+
+mockNuxtImport('useStrrApi', () => () => ({ updatePaymentDetails }))
+mockNuxtImport('navigateTo', () => navigateTo)
+mockNuxtImport('useLocalePath', () => () => (path: string) => path)
+
+const mountRegistrationDashboard = () =>
+  mountSuspended(RegistrationDashboard, {
+    global: { plugins: [baseEnI18n], stubs: registrationDashboardStubs }
+  })
+
+describe('Registration dashboard page', () => {
+  beforeEach(() => {
+    selectedRegistrationId.value = undefined
+    sessionStorage.clear()
+    vi.clearAllMocks()
+    readStoredSelectedRegistrationId.mockReturnValue(undefined)
+  })
+
+  it('redirects to dashboard-new when no registration id is available', async () => {
+    await mountRegistrationDashboard()
+    await flushPromises()
+    expect(navigateTo).toHaveBeenCalledWith('/dashboard-new')
+    expect(loadHostRegistrationData).not.toHaveBeenCalled()
+  })
+
+  it('restores registration id from sessionStorage after payment return and syncs payment', async () => {
+    readStoredSelectedRegistrationId.mockReturnValue('308')
+    sessionStorage.setItem('renewalApplicationNumber', 'APP-999')
+
+    await mountRegistrationDashboard()
+    await flushPromises()
+
+    expect(selectedRegistrationId.value).toBe('308')
+    expect(clearStoredSelectedRegistrationId).toHaveBeenCalled()
+    expect(updatePaymentDetails).toHaveBeenCalledWith('APP-999')
+    expect(sessionStorage.getItem('renewalApplicationNumber')).toBeNull()
+    expect(loadHostRegistrationData).toHaveBeenCalledWith('308')
+  })
+
+  it('loads registration when selectedRegistrationId is already set', async () => {
+    selectedRegistrationId.value = '42'
+    await mountRegistrationDashboard()
+    await flushPromises()
+    expect(readStoredSelectedRegistrationId).not.toHaveBeenCalled()
+    expect(loadHostRegistrationData).toHaveBeenCalledWith('42')
+    expect(updatePaymentDetails).not.toHaveBeenCalled()
+  })
+})

--- a/strr-host-pm-web/tests/unit/registration-renewal.spec.ts
+++ b/strr-host-pm-web/tests/unit/registration-renewal.spec.ts
@@ -21,10 +21,10 @@ const {
   isRegistrationRenewalRef
 } = vi.hoisted(() => {
   return {
-    renewalRegId: { value: '12345' } as Ref<string>,
-    registrationRef: { value: { id: 12345 } } as Ref<{ id: number } | undefined>,
-    applicationRef: { value: undefined } as Ref<unknown>,
-    isRegistrationRenewalRef: { value: true } as Ref<boolean>
+    renewalRegId: { value: '12345', __v_isRef: true } as unknown as Ref<string>,
+    registrationRef: { value: { id: 12345 }, __v_isRef: true } as unknown as Ref<{ id: number } | undefined>,
+    applicationRef: { value: undefined, __v_isRef: true } as unknown as Ref<unknown>,
+    isRegistrationRenewalRef: { value: true, __v_isRef: true } as unknown as Ref<boolean>
   }
 })
 
@@ -150,7 +150,9 @@ const mountRenewalApplication = () =>
   mountSuspended(Application, { global: { plugins: [baseEnI18n], stubs: draftSaveStubs } })
 
 async function clickSaveDraft () {
-  await lastButtonControl!.leftButtons![2]!.action()
+  const saveAction = lastButtonControl?.leftButtons?.[2]?.action
+  expect(saveAction).toBeTypeOf('function')
+  await saveAction?.()
   await flushPromises()
 }
 

--- a/strr-host-pm-web/tests/unit/registration-renewal.spec.ts
+++ b/strr-host-pm-web/tests/unit/registration-renewal.spec.ts
@@ -1,48 +1,202 @@
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, it, expect, vi, beforeAll } from 'vitest'
-import { useRoute } from 'vue-router'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, type Ref } from 'vue'
 import { baseEnI18n } from '../mocks/i18n'
+import { mockApplication } from '../mocks/mockedData'
+import { applicationPageStubs } from './helpers/renewal-test-utils'
 import Application from '~/pages/application.vue'
 
-vi.mock('vue-router', () => ({
-  useRoute: vi.fn().mockImplementation(() => ({
-    name: 'application',
-    path: '/application',
-    query: {
-      renew: 'true'
-    }
-  })),
-  onBeforeRouteLeave: vi.fn()
-}))
+const replaceMock = vi.fn().mockResolvedValue(undefined)
+const mockRoute = {
+  path: '/application',
+  query: { renew: 'true' } as Record<string, string>,
+  meta: {} as Record<string, unknown>
+}
 
-vi.mock('@/stores/hostPermit', () => {
+const {
+  renewalRegId,
+  registrationRef,
+  applicationRef,
+  isRegistrationRenewalRef
+} = vi.hoisted(() => {
   return {
-    useHostPermitStore: () => ({
-      loadHostRegistrationData: vi.fn(),
-      renewalRegId: ref('12345'),
-      $reset: vi.fn(),
-      isRegistrationRenewal: ref(true)
-    })
+    renewalRegId: { value: '12345' } as Ref<string>,
+    registrationRef: { value: { id: 12345 } } as Ref<{ id: number } | undefined>,
+    applicationRef: { value: undefined } as Ref<unknown>,
+    isRegistrationRenewalRef: { value: true } as Ref<boolean>
   }
 })
 
-describe('Registration Renewal Application Page', () => {
-  let wrapper: any
+const submitApplicationMock = vi.fn()
+let lastButtonControl: { leftButtons: { action: () => void | Promise<void> }[] } | null = null
 
-  beforeAll(async () => {
-    wrapper = await mountSuspended(Application, {
-      global: { plugins: [baseEnI18n] }
+mockNuxtImport('useRouter', () => () => ({ replace: replaceMock }))
+mockNuxtImport('useRoute', () => () => mockRoute)
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => mockRoute),
+  useRouter: () => ({ replace: replaceMock }),
+  onBeforeRouteLeave: vi.fn()
+}))
+
+vi.mock('#baseWeb/utils/todoItems', () => ({
+  getTodoRegistration: vi.fn().mockResolvedValue({
+    hasRenewalTodo: false,
+    hasRenewalDraft: false,
+    hasRenewalPaymentPending: false,
+    renewalDraftId: null,
+    renewalPaymentPendingId: null
+  })
+}))
+
+vi.mock('@/stores/hostPermit', () => ({
+  useHostPermitStore: () => ({
+    loadHostRegistrationData: vi.fn(() => {
+      registrationRef.value = { id: 7 }
+    }),
+    loadHostData: vi.fn(),
+    renewalRegId,
+    effectiveRegistrationId: renewalRegId,
+    registration: registrationRef,
+    application: applicationRef,
+    isRegistrationRenewal: isRegistrationRenewalRef,
+    persistSelectedRegistrationId: vi.fn(),
+    $reset: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/hostProperty', () => ({
+  useHostPropertyStore: () => ({
+    unitAddress: { address: mockApplication.registration.unitAddress },
+    unitDetails: ref(mockApplication.registration.unitDetails),
+    blInfo: ref({ businessLicense: '', businessLicenseExpiryDate: '' }),
+    validateUnitAddress: () => true,
+    validateUnitDetails: () => true,
+    validateBusinessLicense: () => true,
+    $reset: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/propertyRequirements', () => ({
+  usePropertyReqStore: () => ({
+    showUnitDetailsForm: ref(true),
+    prRequirements: ref({ isPropertyPrExempt: false, prExemptionReason: undefined }),
+    propertyReqs: ref({}),
+    validateBlExemption: () => true,
+    validatePrRequirements: () => true,
+    $reset: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/hostOwner', () => ({
+  useHostOwnerStore: () => ({ validateOwners: () => true, $reset: vi.fn() })
+}))
+
+vi.mock('@/stores/document', () => ({
+  useDocumentStore: () => ({
+    validateRequiredDocuments: () => [],
+    storedDocuments: ref([]),
+    removeDocumentsByType: vi.fn(),
+    $reset: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/hostApplication', () => ({
+  useHostApplicationStore: () => ({
+    submitApplication: submitApplicationMock,
+    validateUserConfirmation: () => true,
+    $reset: vi.fn()
+  })
+}))
+
+mockNuxtImport('useButtonControl', () => () => ({
+  setButtonControl: (c: typeof lastButtonControl) => { lastButtonControl = c },
+  handleButtonLoading: vi.fn()
+}))
+
+mockNuxtImport('useHostFeatureFlags', () => () => ({
+  isSaveDraftEnabled: ref(true),
+  isNewDashboardEnabled: ref(false),
+  isEnhancedDocumentUploadEnabled: ref(false)
+}))
+
+vi.mock('@/composables/useHostApplicationFee', () => ({
+  useHostApplicationFee: () => ({
+    fetchStrrFees: vi.fn().mockResolvedValue({
+      fee1: { amount: 100, feeCode: 'STR_HOST_1', serviceFees: [] },
+      fee2: { amount: 450, feeCode: 'STR_HOST_2' },
+      fee3: { amount: 100, feeCode: 'STR_HOST_3' }
+    }),
+    getApplicationFee: vi.fn().mockReturnValue({ amount: 100, feeCode: 'STR_HOST_1' })
+  })
+}))
+
+vi.mock('@/composables/useStrrModals', () => ({
+  useStrrModals: () => ({ openAppSubmitError: vi.fn() })
+}))
+
+vi.mock('@/composables/useConnectNav', () => ({
+  useConnectNav: () => ({ handlePaymentRedirect: vi.fn() })
+}))
+
+vi.mock('@/composables/useHostPmModals', () => ({
+  useHostPmModals: () => ({ openConfirmUnsavedChanges: vi.fn().mockResolvedValue(true) })
+}))
+
+const draftSaveStubs = applicationPageStubs
+
+const mountRenewalApplication = () =>
+  mountSuspended(Application, { global: { plugins: [baseEnI18n], stubs: draftSaveStubs } })
+
+async function clickSaveDraft () {
+  await lastButtonControl!.leftButtons![2]!.action()
+  await flushPromises()
+}
+
+describe('Application page — renewal draft save', () => {
+  beforeEach(() => {
+    mockRoute.meta = {}
+    lastButtonControl = null
+    replaceMock.mockClear()
+    mockRoute.query = { renew: 'true' }
+    renewalRegId.value = '42'
+    registrationRef.value = undefined
+    isRegistrationRenewalRef.value = false
+    submitApplicationMock.mockReset()
+    submitApplicationMock.mockResolvedValue({
+      paymentToken: '',
+      filingId: 'NEW-DRAFT-ID',
+      applicationStatus: 'DRAFT',
+      applicationType: 'renewal'
     })
   })
 
-  it('renders the Application page in Registration Renewal state', async () => {
+  it('first save POSTs without id and syncs applicationId to query', async () => {
+    await mountRenewalApplication()
     await flushPromises()
-    expect(useRoute().query).toEqual({ renew: 'true' })
-    expect(wrapper.exists()).toBe(true)
-    expect(wrapper.vm.isRenewal).toBe(true)
-    expect(wrapper.exists()).toBe(true)
-    expect(wrapper.find('H1').text()).toBe('Short-Term Rental Registration Renewal')
-    expect(wrapper.find('[data-testid="alert-renewal-address-change"]').exists()).toBe(true)
-  })
+    await clickSaveDraft()
+    expect(submitApplicationMock).toHaveBeenCalledWith(true, undefined)
+    expect(replaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ applicationId: 'NEW-DRAFT-ID' }) })
+    )
+  }, 10000)
+
+  it('second save PUTs with filing id from first save', async () => {
+    await mountRenewalApplication()
+    await flushPromises()
+    await clickSaveDraft()
+    submitApplicationMock.mockClear()
+    await clickSaveDraft()
+    expect(submitApplicationMock).toHaveBeenCalledWith(true, 'NEW-DRAFT-ID')
+  }, 10000)
+
+  it('session expiry handler reuses effective application number after draft save', async () => {
+    await mountRenewalApplication()
+    await flushPromises()
+    await clickSaveDraft()
+    submitApplicationMock.mockClear()
+    await (mockRoute.meta.onBeforeSessionExpired as () => Promise<unknown>)()
+    expect(submitApplicationMock).toHaveBeenCalledWith(true, 'NEW-DRAFT-ID')
+  }, 10000)
 })

--- a/strr-host-pm-web/tests/unit/registration-renewal.spec.ts
+++ b/strr-host-pm-web/tests/unit/registration-renewal.spec.ts
@@ -29,7 +29,16 @@ const {
 })
 
 const submitApplicationMock = vi.fn()
+const openAppSubmitErrorMock = vi.fn()
 let lastButtonControl: { leftButtons: { action: () => void | Promise<void> }[] } | null = null
+
+const duplicateRenewalError = {
+  statusCode: 409,
+  data: {
+    message: 'A renewal application is already in progress for this registration.',
+    errorCode: 'RENEWAL_ALREADY_IN_PROGRESS'
+  }
+}
 
 mockNuxtImport('useRouter', () => () => ({ replace: replaceMock }))
 mockNuxtImport('useRoute', () => () => mockRoute)
@@ -132,8 +141,8 @@ vi.mock('@/composables/useHostApplicationFee', () => ({
   })
 }))
 
-vi.mock('@/composables/useStrrModals', () => ({
-  useStrrModals: () => ({ openAppSubmitError: vi.fn() })
+mockNuxtImport('useStrrModals', () => () => ({
+  openAppSubmitError: openAppSubmitErrorMock
 }))
 
 vi.mock('@/composables/useConnectNav', () => ({
@@ -166,6 +175,7 @@ describe('Application page — renewal draft save', () => {
     registrationRef.value = undefined
     isRegistrationRenewalRef.value = false
     submitApplicationMock.mockReset()
+    openAppSubmitErrorMock.mockReset()
     submitApplicationMock.mockResolvedValue({
       paymentToken: '',
       filingId: 'NEW-DRAFT-ID',
@@ -200,5 +210,22 @@ describe('Application page — renewal draft save', () => {
     submitApplicationMock.mockClear()
     await (mockRoute.meta.onBeforeSessionExpired as () => Promise<unknown>)()
     expect(submitApplicationMock).toHaveBeenCalledWith(true, 'NEW-DRAFT-ID')
+  }, 10000)
+
+  it('opens submit error modal when duplicate renewal POST returns 409', async () => {
+    submitApplicationMock.mockRejectedValue(duplicateRenewalError)
+
+    await mountRenewalApplication()
+    await flushPromises()
+
+    const saveAction = lastButtonControl?.leftButtons?.[2]?.action
+    expect(saveAction).toBeTypeOf('function')
+    replaceMock.mockClear()
+    await expect(saveAction?.()).rejects.toEqual(duplicateRenewalError)
+    await flushPromises()
+
+    expect(submitApplicationMock).toHaveBeenCalledWith(true, undefined)
+    expect(openAppSubmitErrorMock).toHaveBeenCalledWith(duplicateRenewalError)
+    expect(replaceMock).not.toHaveBeenCalled()
   }, 10000)
 })

--- a/strr-host-pm-web/tests/unit/store-host-permit.spec.ts
+++ b/strr-host-pm-web/tests/unit/store-host-permit.spec.ts
@@ -324,3 +324,63 @@ describe('useHostPermitStore - loading host data', () => {
     expect(storedDocuments.value).toHaveLength(0)
   })
 })
+
+describe('useHostPermitStore - renewal registration context', () => {
+  const storageKey = 'selectedRegistrationId'
+
+  beforeEach(() => {
+    resetAllState()
+    sessionStorage.clear()
+    const store = useHostPermitStore()
+    store.renewalRegId = undefined
+    store.selectedRegistrationId = undefined
+  })
+
+  it('effectiveRegistrationId prefers renewalRegId, then selectedRegistrationId, then sessionStorage', () => {
+    const store = useHostPermitStore()
+    expect(store.effectiveRegistrationId).toBeUndefined()
+
+    store.selectedRegistrationId = '99'
+    expect(store.effectiveRegistrationId).toBe('99')
+
+    store.setRenewalRegistrationContext(42)
+    expect(store.effectiveRegistrationId).toBe('42')
+
+    store.clearRenewalRegistrationContext()
+    expect(store.effectiveRegistrationId).toBe('42')
+
+    store.selectedRegistrationId = undefined
+    sessionStorage.setItem(storageKey, '88')
+    expect(store.effectiveRegistrationId).toBe('88')
+  })
+
+  it('setRenewalRegistrationContext sets renewalRegId and selectedRegistrationId', () => {
+    const store = useHostPermitStore()
+    store.setRenewalRegistrationContext(123)
+    expect(store.renewalRegId).toBe('123')
+    expect(store.selectedRegistrationId).toBe('123')
+  })
+
+  it('clearRenewalRegistrationContext clears renewalRegId only', () => {
+    const store = useHostPermitStore()
+    store.setRenewalRegistrationContext(123)
+    store.clearRenewalRegistrationContext()
+    expect(store.renewalRegId).toBeUndefined()
+    expect(store.selectedRegistrationId).toBe('123')
+  })
+
+  it('persistSelectedRegistrationId updates store and sessionStorage', () => {
+    const store = useHostPermitStore()
+    store.persistSelectedRegistrationId(456)
+    expect(store.selectedRegistrationId).toBe('456')
+    expect(sessionStorage.getItem(storageKey)).toBe('456')
+  })
+
+  it('readStoredSelectedRegistrationId and clearStoredSelectedRegistrationId', () => {
+    sessionStorage.setItem(storageKey, '777')
+    const store = useHostPermitStore()
+    expect(store.readStoredSelectedRegistrationId()).toBe('777')
+    store.clearStoredSelectedRegistrationId()
+    expect(sessionStorage.getItem(storageKey)).toBeNull()
+  })
+})

--- a/strr-host-pm-web/tests/unit/use-dashboard-todos.spec.ts
+++ b/strr-host-pm-web/tests/unit/use-dashboard-todos.spec.ts
@@ -3,6 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { nextTick } from 'vue'
 import { mockApplicationHeader, mockHostRegistration } from '../mocks/mockedData'
 import { baseEnI18n } from '../mocks/i18n'
+import { renewalNavigatePayload } from './helpers/renewal-test-utils'
 
 const $t = baseEnI18n.global.t
 
@@ -19,7 +20,14 @@ mockNuxtImport('storeToRefs', () => (_store: any) => ({
 }))
 
 vi.mock('@/stores/hostPermit', () => ({
-  useHostPermitStore: vi.fn(() => ({}))
+  useHostPermitStore: vi.fn(() => ({
+    setRenewalRegistrationContext: (id: string | number) => {
+      mockRenewalRegId.value = String(id)
+    },
+    clearRenewalRegistrationContext: () => {
+      mockRenewalRegId.value = undefined
+    }
+  }))
 }))
 
 const mockIsEligibleForRenewal = ref(false)
@@ -352,7 +360,7 @@ describe('Renewal Todos buttons', () => {
     expect(mockNavigateTo).toHaveBeenCalledWith({ path: '/application', query: { renew: 'true' } })
   })
 
-  it('resume draft button clears renewalRegId and navigates with draft applicationId', async () => {
+  it('resume draft button clears renewal context and navigates with draft applicationId', async () => {
     mockHasRegistrationRenewalDraft.value = true
     mockRenewalDraftId.value = '1234567890'
     const { todos, setupRenewalTodosWatch } = useDashboardTodos()
@@ -360,10 +368,7 @@ describe('Renewal Todos buttons', () => {
     const todo = todos.value.find(t => t.id === 'todo-renewal-draft')!
     await todo.buttons![0]!.action()
     expect(mockRenewalRegId.value).toBeUndefined()
-    expect(mockNavigateTo).toHaveBeenCalledWith({
-      path: '/application',
-      query: { renew: 'true', applicationId: '1234567890' }
-    })
+    expect(mockNavigateTo).toHaveBeenCalledWith(renewalNavigatePayload('1234567890'))
   })
 
   it('delete draft button calls deleteApplication, remove draft todo, and reload renewal todos', async () => {


### PR DESCRIPTION
*Issue:* #1542 

*Description of changes:*
Prevents duplicate renewal draft applications in host PM by keeping a single draft identity across save, resume, and payment return flows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
