### PR TITLE
fix(api): 1639 fixed approved substatus

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.18d"
+version = "0.3.19a"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.18c"
+version = "0.3.18d"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -511,17 +511,34 @@ class Registration(Versioned, BaseModel):
             latest_app_decider_subq.isnot(None),
         )
 
-        # examinerReviewed=false -> "review queue" (not yet examiner decided, no renewal filed)
-        # examinerReviewed=true  -> already reviewed by an examiner
-        return (
-            db.and_(approval_status_condition, reviewed_condition)
-            if examiner_reviewed
-            else db.and_(
-                approval_status_condition,
-                db.not_(reviewed_condition),
-                db.not_(cls._has_renewal_filed_condition()),
+        # examinerReviewed only applies to provisional workflow statuses.
+        provisional_statuses = {
+            Application.Status.PROVISIONALLY_APPROVED.value,
+            Application.Status.PROVISIONAL_REVIEW.value,
+        }
+        provisional_approval_methods = [status for status in approval_methods if status in provisional_statuses]
+        terminal_approval_methods = [status for status in approval_methods if status not in provisional_statuses]
+
+        filter_conditions = []
+        if terminal_approval_methods:
+            # AUTO_APPROVED/FULL_REVIEW_APPROVED are approved regardless of decider.
+            filter_conditions.append(latest_app_status_subq.in_(terminal_approval_methods))
+
+        if provisional_approval_methods:
+            provisional_status_condition = latest_app_status_subq.in_(provisional_approval_methods)
+            filter_conditions.append(
+                db.and_(provisional_status_condition, reviewed_condition)
+                if examiner_reviewed
+                else db.and_(
+                    provisional_status_condition,
+                    db.not_(reviewed_condition),
+                    db.not_(cls._has_renewal_filed_condition()),
+                )
             )
-        )
+
+        if not filter_conditions:
+            return db.false()
+        return db.or_(*filter_conditions)
 
     @classmethod
     def _review_renew_condition(cls):

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2700,6 +2700,55 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_search_registrations_approved_filter_includes_auto_approved_without_decider_when_examiner_reviewed_true(
+    mock_create_invoice, session, client, jwt
+):
+    """Approved filters should include AUTO/FULL regardless of decider."""
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        json_data = json.load(f)
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        rv = client.post("/applications", json=json_data, headers=headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        application_number = response_json.get("header").get("applicationNumber")
+
+        application = Application.find_by_application_number(application_number=application_number)
+        application.payment_status = PaymentStatus.COMPLETED.value
+        application.status = Application.Status.FULL_REVIEW
+        application.save()
+
+        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
+        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        registration_number = response_json.get("header").get("registrationNumber")
+        registration = Registration.query.filter_by(registration_number=registration_number).one_or_none()
+
+        # Simulate legacy data with no decider at either level while latest status is AUTO_APPROVED.
+        application.status = Application.Status.AUTO_APPROVED
+        application.decider_id = None
+        registration.decider_id = None
+        session.commit()
+
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod={Application.Status.AUTO_APPROVED.value}"
+                f"&approvalMethod={Application.Status.PROVISIONALLY_APPROVED.value}"
+                f"&examinerReviewed=true&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert found, "AUTO_APPROVED should be included even when decider is missing"
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
 def test_search_registrations_review_renew_includes_registration_with_filed_renewal_and_no_registration_decider(
     mock_create_invoice, session, client, jwt
 ):


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1639

*Description of changes:*
align registration sub-status filtering with dashboard logic by treating latest application level decider as reviewed for provisional records, while keeping auto/full approvals included regardless of decider

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
