### PR TITLE
fix(ui): 1639 fixed provisionally approved with decider not showing

### DIFF
--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -280,6 +280,10 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
         approvalMethods.add(ApplicationStatus.PROVISIONAL_REVIEW)
       } else if (subStatus === APPROVED_SUB_STATUS) {
         hasApprovedSubStatus = true
+        // "Approved" includes auto/full approvals and provisionals that were
+        // reviewed by an examiner.
+        approvalMethods.add(ApplicationStatus.PROVISIONALLY_APPROVED)
+        approvalMethods.add(ApplicationStatus.PROVISIONAL_REVIEW)
         approvalMethods.add(ApplicationStatus.AUTO_APPROVED)
         approvalMethods.add(ApplicationStatus.FULL_REVIEW_APPROVED)
       } else if (NOC_ATTR.has(subStatus)) {
@@ -291,7 +295,11 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
       }
     }
 
-    const examinerReviewed = (hasReviewSubStatus && !hasApprovedSubStatus) ? false : undefined
+    const examinerReviewed = hasReviewSubStatus && !hasApprovedSubStatus
+      ? false
+      : hasApprovedSubStatus && !hasReviewSubStatus
+        ? true
+        : undefined
 
     return {
       approvalMethods: [...approvalMethods],

--- a/strr-examiner-web/app/stores/examiner.ts
+++ b/strr-examiner-web/app/stores/examiner.ts
@@ -295,11 +295,14 @@ export const useExaminerStore = defineStore('strr/examiner-store', () => {
       }
     }
 
-    const examinerReviewed = hasReviewSubStatus && !hasApprovedSubStatus
-      ? false
-      : hasApprovedSubStatus && !hasReviewSubStatus
-        ? true
-        : undefined
+    let examinerReviewed: boolean | undefined
+    if (hasReviewSubStatus && !hasApprovedSubStatus) {
+      examinerReviewed = false
+    } else if (hasApprovedSubStatus && !hasReviewSubStatus) {
+      examinerReviewed = true
+    } else {
+      examinerReviewed = undefined
+    }
 
     return {
       approvalMethods: [...approvalMethods],

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.39c",
+  "version": "0.2.39d",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/store-examiner.spec.ts
+++ b/strr-examiner-web/tests/unit/store-examiner.spec.ts
@@ -323,6 +323,25 @@ describe('Store - Examiner', () => {
     }))
   })
 
+  it('should include examinerReviewed=true when filtering by Approved sub-status', async () => {
+    const store = useExaminerStore()
+
+    store.tableFilters.subStatus = ['APPROVED'] as any
+    await store.fetchRegistrations()
+
+    expect(mockStrrApi).toHaveBeenCalledWith('/registrations/search', expect.objectContaining({
+      query: expect.objectContaining({
+        approvalMethod: [
+          ApplicationStatus.PROVISIONALLY_APPROVED,
+          ApplicationStatus.PROVISIONAL_REVIEW,
+          ApplicationStatus.AUTO_APPROVED,
+          ApplicationStatus.FULL_REVIEW_APPROVED
+        ],
+        examinerReviewed: true
+      })
+    }))
+  })
+
   it('should include all active table filters in the search query', async () => {
     const store = useExaminerStore()
 


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1639

*Description of changes:*
update approved sub-status query mapping so reviewed provisional registrations are included with approved results and filters stay consistent with displayed sub-status

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
