### PR TITLE
fix(email): use system git for Poetry installs

### DIFF
--- a/queue_services/strr-email/Dockerfile
+++ b/queue_services/strr-email/Dockerfile
@@ -20,6 +20,7 @@ ENV VCS_REF=${VCS_REF} \
     # Poetry 2.x configurations
     POETRY_VERSION=2.3.2 \
     POETRY_NO_INTERACTION=1 \
+    POETRY_SYSTEM_GIT_CLIENT=true \
     POETRY_VIRTUALENVS_CREATE=false \
     POETRY_CACHE_DIR='/var/cache/pypoetry' \
     POETRY_HOME='/usr/local'


### PR DESCRIPTION
## Summary
- configure the strr-email Docker build to make Poetry use the system git client
- avoids the Dulwich RefFormatError seen while installing git dependencies during the image build

## Testing
- git diff --check
- Not run: docker build --progress=plain -t strr-email-system-git-check queue_services/strr-email (Docker daemon was not reachable in this session)

Note: this same Docker build was validated locally earlier with this environment variable set.