### PR TITLE
fix(api): carry review renewal filter hotfix into main

### DIFF
--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from sql_versioning import Versioned
-from sqlalchemy import Boolean, Enum
+from sqlalchemy import Boolean, Enum, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy_utils.types.ts_vector import TSVectorType
@@ -198,17 +198,12 @@ class Registration(Versioned, BaseModel):
         return sub_status_conditions
 
     @classmethod
-    def _latest_application_field_subquery(cls, application_field):
+    def _latest_application_field_subquery(cls, application_model, application_field):
         """Select a field from the latest application for each registration."""
-        # pylint: disable=import-outside-toplevel
-        from sqlalchemy import select
-
-        from strr_api.models.application import Application
-
         return (
             select(application_field)
-            .where(Application.registration_id == Registration.id)
-            .order_by(Application.application_date.desc())
+            .where(application_model.registration_id == Registration.id)
+            .order_by(application_model.application_date.desc())
             .limit(1)
             .scalar_subquery()
         )
@@ -495,13 +490,13 @@ class Registration(Versioned, BaseModel):
         # For each registration, evaluate only the latest application (same ordering
         # used by the dashboard payload). This keeps filtering aligned with what users
         # see in the Sub-Status column.
-        latest_app_status_subq = cls._latest_application_field_subquery(Application.status)
+        latest_app_status_subq = cls._latest_application_field_subquery(Application, Application.status)
         approval_status_condition = latest_app_status_subq.in_(approval_methods)
         if examiner_reviewed is None:
             # Backward-compatible behavior: only filter by approval method/status.
             return approval_status_condition
 
-        latest_app_decider_subq = cls._latest_application_field_subquery(Application.decider_id)
+        latest_app_decider_subq = cls._latest_application_field_subquery(Application, Application.decider_id)
 
         # Review state can be represented by either:
         # - registration level decision (newer flow)
@@ -538,7 +533,7 @@ class Registration(Versioned, BaseModel):
             Application.Status.PROVISIONALLY_APPROVED.value,
             Application.Status.PROVISIONAL_REVIEW.value,
         ]
-        latest_app_decider_subq = cls._latest_application_field_subquery(Application.decider_id)
+        latest_app_decider_subq = cls._latest_application_field_subquery(Application, Application.decider_id)
         return db.and_(
             cls._has_renewal_filed_condition(),
             Registration.decider_id.is_(None),

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -198,6 +198,22 @@ class Registration(Versioned, BaseModel):
         return sub_status_conditions
 
     @classmethod
+    def _latest_application_field_subquery(cls, application_field):
+        """Select a field from the latest application for each registration."""
+        # pylint: disable=import-outside-toplevel
+        from sqlalchemy import select
+
+        from strr_api.models.application import Application
+
+        return (
+            select(application_field)
+            .where(Application.registration_id == Registration.id)
+            .order_by(Application.application_date.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+
+    @classmethod
     def _host_condition_bl_or_pr(cls, application_model):
         """BL+PR selected: records with BL true or PR true."""
         bl_true = (
@@ -472,40 +488,28 @@ class Registration(Versioned, BaseModel):
         return query
 
     @classmethod
-    def _latest_application_status_subq(cls):
-        """Return correlated scalar subquery for the latest application's status.
-
-        Backed by the composite index ``ix_application_registration_id_date``
-        on ``application (registration_id, application_date DESC)`` so the
-        per-row lookup is an index seek rather than a sequential scan. Keep
-        the (registration_id, ORDER BY application_date DESC LIMIT 1) shape
-        in sync with that index - changing the ORDER BY direction or adding
-        another sort column will break the index match.
-        """
-        # pylint: disable=import-outside-toplevel
-        from sqlalchemy import select
-
-        from strr_api.models.application import Application
-
-        return (
-            select(Application.status)
-            .where(Application.registration_id == Registration.id)
-            .order_by(Application.application_date.desc())
-            .limit(1)
-            .scalar_subquery()
-        )
-
-    @classmethod
     def _approval_method_condition(cls, approval_methods: list[str], examiner_reviewed: bool | None = None):
         """Build SQL condition for filtering by latest application status and review state."""
-        approval_status_condition = cls._latest_application_status_subq().in_(approval_methods)
+        from strr_api.models.application import Application
+
+        # For each registration, evaluate only the latest application (same ordering
+        # used by the dashboard payload). This keeps filtering aligned with what users
+        # see in the Sub-Status column.
+        latest_app_status_subq = cls._latest_application_field_subquery(Application.status)
+        approval_status_condition = latest_app_status_subq.in_(approval_methods)
         if examiner_reviewed is None:
             # Backward-compatible behavior: only filter by approval method/status.
             return approval_status_condition
 
-        # Per examiner workflow, review state for registrations is represented by
-        # the registration level decider.
-        reviewed_condition = Registration.decider_id.isnot(None)
+        latest_app_decider_subq = cls._latest_application_field_subquery(Application.decider_id)
+
+        # Review state can be represented by either:
+        # - registration level decision (newer flow)
+        # - latest application level decision (legacy flow)
+        reviewed_condition = db.or_(
+            Registration.decider_id.isnot(None),
+            latest_app_decider_subq.isnot(None),
+        )
 
         # examinerReviewed=false -> "review queue" (not yet examiner decided, no renewal filed)
         # examinerReviewed=true  -> already reviewed by an examiner
@@ -525,19 +529,20 @@ class Registration(Versioned, BaseModel):
 
         A registration matches when all are true:
         - a renewal is filed
-        - no registration-level decision exists yet
+        - no registration level or latest application decision exists yet
         - latest application is still in provisional review queue
         """
-        # pylint: disable=import-outside-toplevel
         from strr_api.models.application import Application
 
         provisional_statuses = [
             Application.Status.PROVISIONALLY_APPROVED.value,
             Application.Status.PROVISIONAL_REVIEW.value,
         ]
+        latest_app_decider_subq = cls._latest_application_field_subquery(Application.decider_id)
         return db.and_(
             cls._has_renewal_filed_condition(),
             Registration.decider_id.is_(None),
+            latest_app_decider_subq.is_(None),
             cls._approval_method_condition(provisional_statuses),
         )
 

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -1039,7 +1039,7 @@ def search_registrations():
       - in: query
         name: examinerReviewed
         type: boolean
-        description: When provided with approvalMethod, filter provisional records by whether an examiner decision exists at the registration level.
+        description: When provided with approvalMethod, filter provisional records by whether an examiner decision exists at either registration level or latest application level.
       - in: query
         name: nocStatus
         type: array
@@ -1058,7 +1058,7 @@ def search_registrations():
       - in: query
         name: reviewRenew
         type: boolean
-        description: When true, only return registrations with a filed renewal, no registration-level decider, and latest application status in PROVISIONALLY_APPROVED/PROVISIONAL_REVIEW.
+        description: When true, only return registrations with a filed renewal, no registration-level or latest-application decider, and latest application status in PROVISIONALLY_APPROVED/PROVISIONAL_REVIEW.
     responses:
       200:
         description:

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -2676,6 +2676,35 @@ def test_search_registrations_approval_method_uses_most_recent_application_only(
         found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
         assert found, "Record should match examinerReviewed=true due registration decider"
 
+        # Legacy path: registration decider is empty but latest application decider exists.
+        registration.decider_id = None
+        renewal_app.decider_id = application.reviewer_id
+        session.commit()
+
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
+                f"&examinerReviewed=false&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert not found, "Record should not match examinerReviewed=false when latest app decider is present"
+
+        rv = client.get(
+            (
+                f"/registrations/search?approvalMethod=PROVISIONALLY_APPROVED"
+                f"&examinerReviewed=true&status={RegistrationStatus.ACTIVE.value}"
+            ),
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        found = any(r.get("registrationNumber") == registration_number for r in registrations.get("registrations"))
+        assert found, "Record should match examinerReviewed=true due latest application decider"
+
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
 def test_search_registrations_review_renew_includes_registration_with_filed_renewal_and_no_registration_decider(
@@ -2735,6 +2764,17 @@ def test_search_registrations_review_renew_includes_registration_with_filed_rene
         registrations = rv.json
         assert len(registrations.get("registrations")) == 1
         assert registrations.get("registrations")[0].get("registrationNumber") == registration_number
+
+        # Once latest renewal has a decider, it should no longer appear in reviewRenew.
+        renewal_app.decider_id = application.reviewer_id
+        session.commit()
+        rv = client.get(
+            f"/registrations/search?reviewRenew=true&recordNumber={registration_number}&status={RegistrationStatus.ACTIVE.value}",
+            headers=staff_headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        registrations = rv.json
+        assert len(registrations.get("registrations")) == 0
 
         # reviewRenew=false behaves as no extra filter (same as omitting reviewRenew).
         rv = client.get(


### PR DESCRIPTION
## Summary
- carries the TEST-only review/review renewal substatus filter hotfix from PR #1656 onto current main
- keeps main's newer strr-api version while preserving the behavior fix
- unblocks deploying API logging enhancements from #1640 to TEST without losing the current TEST hotfix

## Testing
- git diff --check
- Attempted: poetry run pytest tests/unit/resources/test_registrations.py
