### PR TITLE
fix(ui): display error modal after confirm modal

### DIFF
--- a/strr-host-pm-web/app/composables/useHostPmModals.ts
+++ b/strr-host-pm-web/app/composables/useHostPmModals.ts
@@ -57,23 +57,20 @@ export const useHostPmModals = () => {
 
   function openConfirmProceedToPay (): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
-      const resolveAndClose = (value: boolean) => {
-        resolve(value)
-        close()
-      }
-
+      let confirmed = false
       modal.open(ModalBase, {
         title: t('modal.proceedToPay.title'),
         content: t('modal.proceedToPay.content'),
+        onAfterLeave: () => resolve(confirmed),
         actions: [
           {
             label: t('modal.proceedToPay.closeBtn'),
-            handler: () => resolveAndClose(false),
+            handler: () => { confirmed = false; close() },
             variant: 'outline'
           },
           {
             label: t('modal.proceedToPay.confirmBtn'),
-            handler: () => resolveAndClose(true)
+            handler: () => { confirmed = true; close() }
           }
         ]
       })

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.22",
+  "version": "1.3.23",
   "engines": {
     "node": ">=24"
   },

--- a/strr-host-pm-web/tests/unit/use-host-pm-modals.spec.ts
+++ b/strr-host-pm-web/tests/unit/use-host-pm-modals.spec.ts
@@ -133,6 +133,7 @@ describe('useHostPmModals composable', () => {
       const { openConfirmProceedToPay } = useHostPmModals()
       const promise = openConfirmProceedToPay()
       modal?.props.actions[0].handler() // simulate clicking on first button
+      modal?.props.onAfterLeave()
       await expect(promise).resolves.toBe(false)
       expect(mockModalClose).toHaveBeenCalled()
     })
@@ -141,6 +142,7 @@ describe('useHostPmModals composable', () => {
       const { openConfirmProceedToPay } = useHostPmModals()
       const promise = openConfirmProceedToPay()
       modal?.props.actions[1].handler() // simulate clicking on second button
+      modal?.props.onAfterLeave()
       await expect(promise).resolves.toBe(true)
       expect(mockModalClose).toHaveBeenCalled()
     })


### PR DESCRIPTION
*Description of changes:*
- fix to display error modal after confirm modal

<img width="800" height="481" alt="Screenshot 2026-05-26 at 12 38 29" src="https://github.com/user-attachments/assets/c927cc44-741a-433d-a64a-97b4d28dd04b" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
