### PR TITLE
fix: rely on IANA Vancouver timezone

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.21"
+version = "0.3.22"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/services/application_service.py
+++ b/strr-api/src/strr_api/services/application_service.py
@@ -36,7 +36,6 @@ import copy
 from datetime import datetime, time, timedelta, timezone
 from typing import Optional
 
-import pytz
 from flask import current_app
 
 from strr_api.enums.enum import ApplicationType, PaymentStatus, RegistrationStatus
@@ -49,6 +48,7 @@ from strr_api.services.events_service import EventsService
 from strr_api.services.gcp_storage_service import GCPStorageService
 from strr_api.services.registration_service import RegistrationService
 from strr_api.services.user_service import UserService
+from strr_api.utils.date_util import DateUtil
 
 APPLICATION_TERMINAL_STATES = [
     Application.Status.FULL_REVIEW_APPROVED,
@@ -386,7 +386,7 @@ class ApplicationService:
         notice_of_consideration.content = content
         notice_of_consideration.application_id = application.id
         notice_of_consideration.start_date = datetime.combine(
-            datetime.now(pytz.timezone("America/Vancouver")) + timedelta(days=1), time(0, 1, 0)
+            DateUtil.now_as_legislation_timezone() + timedelta(days=1), time(0, 1, 0)
         )
         days = current_app.config.get("NOC_EXPIRY_DAYS", 8)
         notice_of_consideration.end_date = notice_of_consideration.start_date + timedelta(days=int(days))

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -42,7 +42,6 @@ import random
 import traceback
 from datetime import date, datetime, time, timedelta, timezone
 
-import pytz
 from dateutil.relativedelta import relativedelta
 from flask import current_app, render_template
 from weasyprint import HTML
@@ -85,6 +84,7 @@ from strr_api.services.email_service import EmailService
 from strr_api.services.events_service import EventsService
 from strr_api.services.snapshot_service import SnapshotService
 from strr_api.services.user_service import UserService
+from strr_api.utils.date_util import DateUtil
 
 logger = logging.getLogger("api")
 
@@ -1040,7 +1040,7 @@ class RegistrationService:
         notice_of_consideration.content = content
         notice_of_consideration.registration_id = registration.id
         notice_of_consideration.start_date = datetime.combine(
-            datetime.now(pytz.timezone("America/Vancouver")) + timedelta(days=1), time(0, 1, 0)
+            DateUtil.now_as_legislation_timezone() + timedelta(days=1), time(0, 1, 0)
         )
         days = current_app.config.get("NOC_EXPIRY_DAYS", 8)
         notice_of_consideration.end_date = notice_of_consideration.start_date + timedelta(days=int(days))

--- a/strr-api/src/strr_api/utils/date_util.py
+++ b/strr-api/src/strr_api/utils/date_util.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 """Date utilities."""
 from datetime import datetime
-
-import pytz
+from zoneinfo import ZoneInfo
 
 
 class DateUtil:
@@ -25,7 +24,12 @@ class DateUtil:
     @staticmethod
     def as_legislation_timezone(date_time: datetime) -> datetime:
         """Return a datetime adjusted to the legislation timezone."""
-        return date_time.astimezone(pytz.timezone(DateUtil.LEGISLATIVE_TIMEZONE))
+        return date_time.astimezone(ZoneInfo(DateUtil.LEGISLATIVE_TIMEZONE))
+
+    @staticmethod
+    def now_as_legislation_timezone() -> datetime:
+        """Return the current datetime adjusted to the legislation timezone."""
+        return datetime.now(ZoneInfo(DateUtil.LEGISLATIVE_TIMEZONE))
 
     @staticmethod
     def format_as_string(date_time: datetime) -> str:

--- a/strr-api/tests/unit/utils/test_date_util.py
+++ b/strr-api/tests/unit/utils/test_date_util.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from strr_api.utils.date_util import DateUtil
+
+
+def test_as_legislation_timezone_uses_iana_vancouver_timezone():
+    date_time = datetime(2027, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+    result = DateUtil.as_legislation_timezone(date_time)
+
+    assert result == date_time.astimezone(ZoneInfo("America/Vancouver"))
+    assert result.tzinfo.key == "America/Vancouver"
+
+
+def test_format_as_string_uses_iana_vancouver_timezone():
+    date_time = datetime(2027, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    vancouver_date_time = date_time.astimezone(ZoneInfo("America/Vancouver"))
+    hour = vancouver_date_time.strftime("%I").lstrip("0")
+    am_pm = vancouver_date_time.strftime("%p").lower()
+    expected = vancouver_date_time.strftime(f"%B %-d, %Y at {hour}:%M {am_pm} Pacific time")
+
+    assert DateUtil.format_as_string(date_time) == expected


### PR DESCRIPTION
## Summary
- removes the custom fixed UTC-7/PacT transition logic
- relies on the IANA `America/Vancouver` timezone for legislative Pacific Time handling
- centralizes NOC date calculation through `DateUtil` so API paths use the same timezone helper
- adds regression coverage to make sure the helper delegates to `America/Vancouver`

## Testing
- PYTHONPATH=src /Users/JPHAM/Library/Caches/pypoetry/virtualenvs/strr-api-ETjmZK4t-py3.14/bin/python -m pytest tests/unit/utils/test_date_util.py --no-cov
- /Users/JPHAM/Library/Caches/pypoetry/virtualenvs/strr-api-ETjmZK4t-py3.14/bin/python -m isort . --check -v
- /Users/JPHAM/Library/Caches/pypoetry/virtualenvs/strr-api-ETjmZK4t-py3.14/bin/python -m black . --check
- git diff --check

Closes #1600
