### PR TITLE
chore(api): transfer Alembic object ownership

### DIFF
--- a/docs/runbooks/strr-api.md
+++ b/docs/runbooks/strr-api.md
@@ -42,6 +42,7 @@ Flask backend for STRR. Source: `strr-api/`.
 - When `POD_NAMESPACE == "migration"`, the app factory registers **only** Flask-Migrate (no normal HTTP routes) (`strr-api/src/strr_api/__init__.py`).
 - **Driver note:** Migrations may use `postgresql+pg8000` while runtime uses `postgresql`/psycopg2. See `config.py` and `migrations/env.py`.
 - Standalone Alembic (no Flask context) uses `DATABASE_URL` with `NullPool` in `migrations/env.py`.
+- Optional ownership handoff: set `DATABASE_OWNER_ROLE` so online Alembic migrations run with that DB role and new objects are owned by it. The migration user must be able to `SET ROLE`, and that role needs schema create privileges.
 
 ## Scaling (prod)
 

--- a/strr-api/.env.sample
+++ b/strr-api/.env.sample
@@ -30,6 +30,9 @@ DATABASE_PASSWORD=postgres
 DATABASE_NAME=postgres
 DATABASE_HOST=localhost
 DATABASE_PORT=15432
+# Optional: Alembic runs migrations with this DB role so new objects are owned by it.
+# For Cloud SQL IAM auth, set this to the service account's Postgres role name.
+DATABASE_OWNER_ROLE=
 
 ## TEST DB
 DATABASE_TEST_USERNAME=postgres

--- a/strr-api/migrations/env.py
+++ b/strr-api/migrations/env.py
@@ -1,8 +1,9 @@
-import os
 import logging
+import os
 from logging.config import fileConfig
-from sqlalchemy import engine_from_config, pool, create_engine
+
 from alembic import context
+from sqlalchemy import create_engine, pool, text
 
 # 1. Passive Detection: Don't create an app, just look for one
 try:
@@ -40,14 +41,22 @@ def get_engine_url():
 def get_metadata():
     return target_metadata
 
+
 config.set_main_option('sqlalchemy.url', get_engine_url())
+
 
 def run_migrations_online():
     connectable = get_engine()
     with connectable.connect() as connection:
+        owner_role = os.getenv("DATABASE_OWNER_ROLE")
+        if owner_role:
+            safe_role = owner_role.replace('"', '""')  # Escape any quotes for SQL safety
+            connection.execute(text(f'SET ROLE "{safe_role}"'))
+            connection.commit()
+
         # Only pull migrate args if Flask is actually present
         extra_args = current_app.extensions['migrate'].configure_args if use_flask else {}
-        
+
         context.configure(
             connection=connection,
             target_metadata=get_metadata(),

--- a/strr-api/tests/integration/test_alembic_ownership.py
+++ b/strr-api/tests/integration/test_alembic_ownership.py
@@ -1,0 +1,66 @@
+"""Integration tests for standalone Alembic migration behavior."""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+from testcontainers.postgres import PostgresContainer
+
+
+def test_alembic_runs_with_configured_owner_role(monkeypatch):
+    """Alembic runs migrations with the configured DB owner role."""
+    api_root = Path(__file__).resolve().parents[2]
+    migrations_path = api_root / "migrations"
+    owner = "sa-api@bcrbk9-test.iam"
+
+    with PostgresContainer("postgres:16-alpine") as postgres:
+        db_url = postgres.get_connection_url()
+        monkeypatch.setenv("DATABASE_URL", db_url)
+        monkeypatch.setenv("DATABASE_OWNER_ROLE", owner)
+
+        engine = create_engine(db_url)
+        with engine.begin() as conn:
+            quoted_owner = conn.dialect.identifier_preparer.quote(owner)
+            conn.execute(text(f"CREATE ROLE {quoted_owner} LOGIN"))
+            conn.execute(text(f"GRANT USAGE, CREATE ON SCHEMA public TO {quoted_owner}"))
+
+        cfg = Config(str(migrations_path / "alembic.ini"))
+        cfg.set_main_option("script_location", str(migrations_path))
+        cfg.set_main_option("sqlalchemy.url", db_url)
+        command.upgrade(cfg, "head")
+
+        with engine.connect() as conn:
+            class_mismatches = conn.execute(
+                text(
+                    """
+                    SELECT c.relkind, n.nspname, c.relname, pg_get_userbyid(c.relowner) AS owner
+                    FROM pg_class c
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                    WHERE n.nspname = 'public'
+                      AND c.relkind IN ('r', 'p', 'S', 'v', 'm', 'f')
+                      AND pg_get_userbyid(c.relowner) != :owner
+                    ORDER BY c.relkind, c.relname
+                    """
+                ),
+                {"owner": owner},
+            ).fetchall()
+            type_mismatches = conn.execute(
+                text(
+                    """
+                    SELECT n.nspname, t.typname, pg_get_userbyid(t.typowner) AS owner
+                    FROM pg_type t
+                    JOIN pg_namespace n ON n.oid = t.typnamespace
+                    WHERE n.nspname = 'public'
+                      AND t.typtype IN ('d', 'e')
+                      AND pg_get_userbyid(t.typowner) != :owner
+                    ORDER BY t.typname
+                    """
+                ),
+                {"owner": owner},
+            ).fetchall()
+            current_role = conn.execute(text("SELECT current_user")).scalar_one()
+
+        assert class_mismatches == []
+        assert type_mismatches == []
+        assert current_role != owner


### PR DESCRIPTION
## Summary
This is an SRE initiative that came from the security team around Cloud SQL IAM/service account ownership.

I lined this up with Andriy's Alembic IAM migration flow from the other apps. The important bit is the same pattern used in PPR/Search: read DATABASE_OWNER_ROLE, escape quotes, run SET ROLE before Alembic runs, then commit so migrations create objects as that DB role.

So the short explanation is: I basically copied the migration ownership approach Andriy used there and adapted it to STRR's standalone env.py.

## What changed
- added DATABASE_OWNER_ROLE support in STRR Alembic env.py
- runs SET ROLE before online migrations when DATABASE_OWNER_ROLE is set
- escapes double quotes in the configured role name before building the SET ROLE statement
- documents that the migration user must be able to SET ROLE and the owner role needs schema create privileges
- added an integration test that runs Alembic against disposable Postgres with an IAM-style role name and verifies object/type ownership

## Testing
- python3 -m py_compile strr-api/migrations/env.py strr-api/tests/integration/test_alembic_ownership.py
- poetry run bandit -r migrations/env.py
- poetry run pytest tests/integration/test_alembic_ownership.py --no-cov
- targeted coverage check for migrations/env.py: 83%

Note: I also reran the full integration suite. The Alembic test passed, but two existing NOC tests failed on nocSentDate being null. I reran those exact two tests and they still failed, so I’m treating that as unrelated to this migration-role change.