### PR TITLE
feat(strr-api): new api for examiner notes feature to post and retrieve notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ htmlcov/
 .idea
 .history
 .vscode/tasks.json
+.zed
 
 # bods csvs
 **/bods_csvs/*
@@ -174,4 +175,3 @@ unit-tests.sh
 
 # Poetry.toml
 **/poetry.toml
-

--- a/strr-api/migrations/versions/20260529_1200_c9e8f7a6b5d4_examiner_notes.py
+++ b/strr-api/migrations/versions/20260529_1200_c9e8f7a6b5d4_examiner_notes.py
@@ -5,9 +5,9 @@ Revises: b1a4d5e7c92f
 Create Date: 2026-06-02 08:54:08.000000
 
 """
-from alembic import op
-import sqlalchemy as sa
 
+import sqlalchemy as sa
+from alembic import op
 
 revision = "c9e8f7a6b5d4"
 down_revision = "b1a4d5e7c92f"
@@ -19,7 +19,7 @@ def upgrade() -> None:
     op.create_table(
         "examiner_notes",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
         sa.Column("application_id", sa.Integer(), nullable=True),
         sa.Column("registration_id", sa.Integer(), nullable=True),
         sa.Column("author_user_id", sa.Integer(), nullable=False),
@@ -39,20 +39,16 @@ def upgrade() -> None:
             name="chk_examiner_notes_single_parent",
         ),
     )
-    op.execute(
-        """
+    op.execute("""
         CREATE INDEX ix_examiner_notes_application_id_created_at
             ON examiner_notes (application_id, created_at DESC)
             WHERE application_id IS NOT NULL
-        """
-    )
-    op.execute(
-        """
+        """)
+    op.execute("""
         CREATE INDEX ix_examiner_notes_registration_id_created_at
             ON examiner_notes (registration_id, created_at DESC)
             WHERE registration_id IS NOT NULL
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/strr-api/migrations/versions/20260529_1200_c9e8f7a6b5d4_examiner_notes.py
+++ b/strr-api/migrations/versions/20260529_1200_c9e8f7a6b5d4_examiner_notes.py
@@ -1,0 +1,61 @@
+"""Create examiner_notes table for staff examiner notes on applications/registrations.
+
+Revision ID: c9e8f7a6b5d4
+Revises: b1a4d5e7c92f
+Create Date: 2026-06-02 08:54:08.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c9e8f7a6b5d4"
+down_revision = "b1a4d5e7c92f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "examiner_notes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("application_id", sa.Integer(), nullable=True),
+        sa.Column("registration_id", sa.Integer(), nullable=True),
+        sa.Column("author_user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["application_id"], ["application.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["registration_id"], ["registrations.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["author_user_id"], ["users.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "(application_id IS NOT NULL AND registration_id IS NULL) "
+            "OR (application_id IS NULL AND registration_id IS NOT NULL)",
+            name="chk_examiner_notes_single_parent",
+        ),
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_examiner_notes_application_id_created_at
+            ON examiner_notes (application_id, created_at DESC)
+            WHERE application_id IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_examiner_notes_registration_id_created_at
+            ON examiner_notes (registration_id, created_at DESC)
+            WHERE registration_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_examiner_notes_registration_id_created_at")
+    op.execute("DROP INDEX IF EXISTS ix_examiner_notes_application_id_created_at")
+    op.drop_table("examiner_notes")

--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.25"
+version = "0.3.26"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/enums/enum.py
+++ b/strr-api/src/strr_api/enums/enum.py
@@ -197,8 +197,8 @@ class ErrorMessage(Enum):
         "Continue with your existing renewal application, or wait until it reaches a final decision."
     )
     RENEWAL_APPLICATION_NO_REGISTRATION_ID = "Renewal application does not have a linked registration id."
-    EXAMINER_NOTE_BODY_REQUIRED = "Note body is required."
-    EXAMINER_NOTE_BODY_TOO_LONG = "Note body exceeds maximum length."
+    EXAMINER_NOTE_TEXT_REQUIRED = "Note text is required."
+    EXAMINER_NOTE_TEXT_TOO_LONG = "Note text exceeds maximum length."
     EXAMINER_NOTE_APPLICATION_REGISTERED = (
         "This application is linked to a registration. Add examiner notes on the registration instead."
     )

--- a/strr-api/src/strr_api/enums/enum.py
+++ b/strr-api/src/strr_api/enums/enum.py
@@ -197,6 +197,16 @@ class ErrorMessage(Enum):
         "Continue with your existing renewal application, or wait until it reaches a final decision."
     )
     RENEWAL_APPLICATION_NO_REGISTRATION_ID = "Renewal application does not have a linked registration id."
+    EXAMINER_NOTE_BODY_REQUIRED = "Note body is required."
+    EXAMINER_NOTE_BODY_TOO_LONG = "Note body exceeds maximum length."
+    EXAMINER_NOTE_APPLICATION_REGISTERED = (
+        "This application is linked to a registration. Add examiner notes on the registration instead."
+    )
+    EXAMINER_NOTE_APPLICATION_STATUS_NOT_ALLOWED = (
+        "Cannot add examiner notes while the application status is {status}. "
+        "Notes are only allowed during active examination."
+    )
+    EXAMINER_NOTE_STAFF_ONLY = "Examiner notes are available to STRR staff only."
 
 
 class ApplicationRole(Enum):

--- a/strr-api/src/strr_api/enums/enum.py
+++ b/strr-api/src/strr_api/enums/enum.py
@@ -206,7 +206,6 @@ class ErrorMessage(Enum):
         "Cannot add examiner notes while the application status is {status}. "
         "Notes are only allowed during active examination."
     )
-    EXAMINER_NOTE_STAFF_ONLY = "Examiner notes are available to STRR staff only."
 
 
 class ApplicationRole(Enum):

--- a/strr-api/src/strr_api/models/__init__.py
+++ b/strr-api/src/strr_api/models/__init__.py
@@ -41,6 +41,7 @@ from .certificate import Certificate
 from .conditions_of_approval import ConditionsOfApproval
 from .db import db  # noqa: I001
 from .events import Events
+from .examiner_note import ExaminerNote
 from .interactions import CustomerInteraction
 from .ltsa import LTSARecord
 from .notice_of_consideration import NoticeOfConsideration
@@ -65,6 +66,7 @@ __all__ = (
     "CustomerInteraction",
     "Document",
     "Events",
+    "ExaminerNote",
     "LTSARecord",
     "NoticeOfConsideration",
     "PlatformBrand",

--- a/strr-api/src/strr_api/models/examiner_note.py
+++ b/strr-api/src/strr_api/models/examiner_note.py
@@ -1,0 +1,37 @@
+"""
+ORM mapping for examiner notes on applications and registrations.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from strr_api.models.base_model import SimpleBaseModel
+
+from .db import db
+
+
+class ExaminerNote(SimpleBaseModel):
+    """Staff-only append-only note attached to one application or registration."""
+
+    __tablename__ = "examiner_notes"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    body = db.Column(db.Text, nullable=False)
+
+    application_id = db.Column(db.Integer, db.ForeignKey("application.id"), nullable=True, index=True)
+    registration_id = db.Column(db.Integer, db.ForeignKey("registrations.id"), nullable=True, index=True)
+
+    author_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    created_at = db.Column(db.DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    author = relationship("User", foreign_keys=[author_user_id])
+
+    __table_args__ = (
+        db.CheckConstraint(
+            "(application_id IS NOT NULL AND registration_id IS NULL) "
+            "OR (application_id IS NULL AND registration_id IS NOT NULL)",
+            name="chk_examiner_notes_single_parent",
+        ),
+    )

--- a/strr-api/src/strr_api/models/examiner_note.py
+++ b/strr-api/src/strr_api/models/examiner_note.py
@@ -1,6 +1,7 @@
 """
 ORM mapping for examiner notes on applications and registrations.
 """
+
 from __future__ import annotations
 
 from sqlalchemy.orm import relationship
@@ -17,7 +18,7 @@ class ExaminerNote(SimpleBaseModel):
     __tablename__ = "examiner_notes"
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    body = db.Column(db.Text, nullable=False)
+    text = db.Column(db.Text, nullable=False)
 
     application_id = db.Column(db.Integer, db.ForeignKey("application.id"), nullable=True, index=True)
     registration_id = db.Column(db.Integer, db.ForeignKey("registrations.id"), nullable=True, index=True)

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -45,7 +45,7 @@ from io import BytesIO
 from typing import Optional
 
 from flasgger import swag_from
-from flask import Blueprint, g, jsonify, request, send_file
+from flask import Blueprint, current_app, g, jsonify, request, send_file
 from flask_cors import cross_origin
 from werkzeug.utils import secure_filename
 
@@ -79,6 +79,7 @@ from strr_api.services.application_service import (
     APPLICATION_TERMINAL_STATES,
     APPLICATION_UNPAID_STATES,
 )
+from strr_api.services.examiner_note_service import ExaminerNoteNotAllowedException, ExaminerNoteService
 from strr_api.validators.DocumentUploadValidator import validate_document_upload
 from strr_api.validators.RegistrationRequestValidator import validate_request
 
@@ -638,6 +639,124 @@ def get_application_events(application_number):
     except Exception as exception:
         logger.error(exception)
         return error_response("ErrorMessage.PROCESSING_ERROR.value", HTTPStatus.INTERNAL_SERVER_ERROR)
+
+
+@bp.route("/<application_number>/notes", methods=("GET",))
+@swag_from({"security": [{"Bearer": []}]})
+@cross_origin(origin="*")
+@jwt.requires_auth
+@jwt.has_one_of_roles([Role.STRR_EXAMINER.value, Role.STRR_INVESTIGATOR.value])
+def get_application_notes(application_number):
+    """
+    List examiner notes for an application (staff only).
+    ---
+    tags:
+      - application
+    parameters:
+      - in: path
+        name: application_number
+        type: string
+        required: true
+        description: Application number
+    responses:
+      200:
+        description: applicationNumber, truncated, notes (newest first, max 500)
+      401:
+        description:
+      403:
+        description: Not STRR staff
+      404:
+        description: Application not found
+    """
+    try:
+        application = ApplicationService.get_application(application_number=application_number, account_id=None)
+        if not application:
+            return error_response(HTTPStatus.NOT_FOUND, ErrorMessage.APPLICATION_NOT_FOUND.value)
+        notes, truncated = ExaminerNoteService.list_by_application_id(application.id)
+        logger.info(
+            "Listed %d examiner notes for application_id=%s (number=%s), truncated=%s",
+            len(notes),
+            application.id,
+            application.application_number,
+            truncated,
+        )
+        return (
+            jsonify(ExaminerNoteService.build_application_list_response(application, notes, truncated)),
+            HTTPStatus.OK,
+        )
+    except Exception as exception:
+        logger.exception(exception)
+        return error_response(message=ErrorMessage.PROCESSING_ERROR.value, http_status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+
+@bp.route("/<application_number>/notes", methods=("POST",))
+@swag_from({"security": [{"Bearer": []}]})
+@cross_origin(origin="*")
+@jwt.requires_auth
+@jwt.has_one_of_roles([Role.STRR_EXAMINER.value, Role.STRR_INVESTIGATOR.value])
+def create_application_note(application_number):
+    """
+    Create an examiner note on an application (staff only).
+    ---
+    tags:
+      - application
+    parameters:
+      - in: path
+        name: application_number
+        type: string
+        required: true
+        description: Application number
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              type: string
+              description: Plain-text note (1-4000 characters after trim)
+    responses:
+      201:
+        description: Note created (id, body, authorUserId, authorUsername, createdAt)
+      400:
+        description: Invalid note body
+      401:
+        description:
+      403:
+        description: Not STRR staff
+      404:
+        description: Application not found
+      422:
+        description: Application linked to registration, or status outside active examination
+    """
+    try:
+        user = UserService.get_or_create_user_by_jwt(g.jwt_oidc_token_info)
+        if not user:
+            raise AuthException()
+        application = ApplicationService.get_application(application_number=application_number, account_id=None)
+        if not application:
+            return error_response(HTTPStatus.NOT_FOUND, ErrorMessage.APPLICATION_NOT_FOUND.value)
+        json_input = request.get_json(silent=True) or {}
+        note = ExaminerNoteService.create_application_note(application, user, json_input.get("body"))
+        current_app.logger.info(
+            "Created examiner note id=%s for application_id=%s (number=%s) by user=%s",
+            note.id,
+            application.id,
+            application.application_number,
+            user.username,
+        )
+        return jsonify(ExaminerNoteService.serialize(note)), HTTPStatus.CREATED
+    except ExaminerNoteNotAllowedException as not_allowed:
+        return error_response(http_status=not_allowed.status_code, message=not_allowed.message)
+    except ValidationException as validation_exception:
+        return exception_response(validation_exception)
+    except AuthException as auth_exception:
+        return exception_response(auth_exception)
+    except Exception as exception:
+        logger.exception(exception)
+        return error_response(message=ErrorMessage.PROCESSING_ERROR.value, http_status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @bp.route("/<application_number>/status", methods=("PUT",))

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -716,7 +716,7 @@ def create_application_note(application_number):
           properties:
             text:
               type: string
-              description: Plain-text note (1-4000 characters after trim)
+              description: Plain-text note (1-1000 characters after trim)
     responses:
       201:
         description: Note created (id, text, authorUserId, authorUsername, createdAt)

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -712,16 +712,16 @@ def create_application_note(application_number):
         schema:
           type: object
           required:
-            - body
+            - text
           properties:
-            body:
+            text:
               type: string
               description: Plain-text note (1-4000 characters after trim)
     responses:
       201:
-        description: Note created (id, body, authorUserId, authorUsername, createdAt)
+        description: Note created (id, text, authorUserId, authorUsername, createdAt)
       400:
-        description: Invalid note body
+        description: Invalid note text
       401:
         description:
       403:
@@ -739,7 +739,7 @@ def create_application_note(application_number):
         if not application:
             return error_response(HTTPStatus.NOT_FOUND, ErrorMessage.APPLICATION_NOT_FOUND.value)
         json_input = request.get_json(silent=True) or {}
-        note = ExaminerNoteService.create_application_note(application, user, json_input.get("body"))
+        note = ExaminerNoteService.create_application_note(application, user, json_input.get("text"))
         current_app.logger.info(
             "Created examiner note id=%s for application_id=%s (number=%s) by user=%s",
             note.id,

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -544,16 +544,16 @@ def create_registration_note(registration_id):
         schema:
           type: object
           required:
-            - body
+            - text
           properties:
-            body:
+            text:
               type: string
               description: Plain-text note (1-4000 characters after trim)
     responses:
       201:
-        description: Note created (id, body, authorUserId, authorUsername, createdAt)
+        description: Note created (id, text, authorUserId, authorUsername, createdAt)
       400:
-        description: Invalid note body
+        description: Invalid note text
       401:
         description:
       403:
@@ -569,7 +569,7 @@ def create_registration_note(registration_id):
         if not registration:
             return error_response(http_status=HTTPStatus.NOT_FOUND, message=ErrorMessage.REGISTRATION_NOT_FOUND.value)
         json_input = request.get_json(silent=True) or {}
-        note = ExaminerNoteService.create_registration_note(registration, user, json_input.get("body"))
+        note = ExaminerNoteService.create_registration_note(registration, user, json_input.get("text"))
         current_app.logger.info(
             "Created examiner note id=%s for registration_id=%s (number=%s) by user=%s",
             note.id,

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -548,7 +548,7 @@ def create_registration_note(registration_id):
           properties:
             text:
               type: string
-              description: Plain-text note (1-4000 characters after trim)
+              description: Plain-text note (1-1000 characters after trim)
     responses:
       201:
         description: Note created (id, text, authorUserId, authorUsername, createdAt)

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -45,7 +45,7 @@ from io import BytesIO
 
 from dateutil.relativedelta import relativedelta
 from flasgger import swag_from
-from flask import Blueprint, g, jsonify, request, send_file
+from flask import Blueprint, current_app, g, jsonify, request, send_file
 from flask_cors import cross_origin
 from werkzeug.utils import secure_filename
 
@@ -71,6 +71,7 @@ from strr_api.models.dataclass import RegistrationSearch
 from strr_api.responses import Events
 from strr_api.schemas.utils import validate
 from strr_api.services import DocumentService, EventsService, RegistrationService, SnapshotService, UserService
+from strr_api.services.examiner_note_service import ExaminerNoteNotAllowedException, ExaminerNoteService
 from strr_api.services.registration_service import (
     REGISTRATION_STATES_STAFF_ACTION,
     REGISTRATION_STATES_STAFF_ASSIGNABLE,
@@ -470,6 +471,122 @@ def get_registration_events(registration_id):
         )
     except AuthException as auth_exception:
         return exception_response(auth_exception)
+
+
+@bp.route("/<registration_id>/notes", methods=("GET",))
+@swag_from({"security": [{"Bearer": []}]})
+@cross_origin(origin="*")
+@jwt.requires_auth
+@jwt.has_one_of_roles([Role.STRR_EXAMINER.value, Role.STRR_INVESTIGATOR.value])
+def get_registration_notes(registration_id):
+    """
+    List examiner notes for a registration (staff only).
+    ---
+    tags:
+      - registration
+    parameters:
+      - in: path
+        name: registration_id
+        type: integer
+        required: true
+        description: Registration ID
+    responses:
+      200:
+        description: registrationId, truncated, notes (registration-owned only, max 500)
+      401:
+        description:
+      403:
+        description: Not STRR staff
+      404:
+        description: Registration not found
+    """
+    try:
+        registration = RegistrationService.get_registration(None, registration_id)
+        if not registration:
+            return error_response(http_status=HTTPStatus.NOT_FOUND, message=ErrorMessage.REGISTRATION_NOT_FOUND.value)
+        notes, truncated = ExaminerNoteService.list_by_registration_id(registration_id)
+        logger.info(
+            "Listed %d examiner notes for registration_id=%s (number=%s), truncated=%s",
+            len(notes),
+            registration.id,
+            registration.registration_number,
+            truncated,
+        )
+        return (
+            jsonify(ExaminerNoteService.build_registration_list_response(registration, notes, truncated)),
+            HTTPStatus.OK,
+        )
+    except Exception as exception:
+        logger.exception(exception)
+        return error_response(message=ErrorMessage.PROCESSING_ERROR.value, http_status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+
+@bp.route("/<registration_id>/notes", methods=("POST",))
+@swag_from({"security": [{"Bearer": []}]})
+@cross_origin(origin="*")
+@jwt.requires_auth
+@jwt.has_one_of_roles([Role.STRR_EXAMINER.value, Role.STRR_INVESTIGATOR.value])
+def create_registration_note(registration_id):
+    """
+    Create an examiner note on a registration (staff only).
+    ---
+    tags:
+      - registration
+    parameters:
+      - in: path
+        name: registration_id
+        type: integer
+        required: true
+        description: Registration ID
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - body
+          properties:
+            body:
+              type: string
+              description: Plain-text note (1-4000 characters after trim)
+    responses:
+      201:
+        description: Note created (id, body, authorUserId, authorUsername, createdAt)
+      400:
+        description: Invalid note body
+      401:
+        description:
+      403:
+        description: Not STRR staff
+      404:
+        description: Registration not found
+    """
+    try:
+        user = User.get_or_create_user_by_jwt(g.jwt_oidc_token_info)
+        if not user:
+            raise AuthException()
+        registration = RegistrationService.get_registration(None, registration_id)
+        if not registration:
+            return error_response(http_status=HTTPStatus.NOT_FOUND, message=ErrorMessage.REGISTRATION_NOT_FOUND.value)
+        json_input = request.get_json(silent=True) or {}
+        note = ExaminerNoteService.create_registration_note(registration, user, json_input.get("body"))
+        current_app.logger.info(
+            "Created examiner note id=%s for registration_id=%s (number=%s) by user=%s",
+            note.id,
+            registration.id,
+            registration.registration_number,
+            user.username,
+        )
+        return jsonify(ExaminerNoteService.serialize(note)), HTTPStatus.CREATED
+    except ExaminerNoteNotAllowedException as not_allowed:
+        return error_response(http_status=not_allowed.status_code, message=not_allowed.message)
+    except ValidationException as validation_exception:
+        return exception_response(validation_exception)
+    except AuthException as auth_exception:
+        return exception_response(auth_exception)
+    except Exception as exception:
+        logger.exception(exception)
+        return error_response(message=ErrorMessage.PROCESSING_ERROR.value, http_status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @bp.route("/<registration_id>/status", methods=("PUT",))

--- a/strr-api/src/strr_api/services/examiner_note_service.py
+++ b/strr-api/src/strr_api/services/examiner_note_service.py
@@ -49,7 +49,7 @@ from strr_api.models import Application, ExaminerNote, Registration, User
 logger = logging.getLogger(__name__)
 
 NOTE_LIST_MAX = 500
-NOTE_MAX_BODY_LENGTH = 4000
+NOTE_MAX_TEXT_LENGTH = 4000
 
 # Application statuses where note creation is blocked.
 APPLICATION_NOTE_BLOCKED_STATUSES = frozenset(
@@ -78,22 +78,22 @@ class ExaminerNoteService:
     """Create and list examiner notes."""
 
     @staticmethod
-    def validate_body(body: str | None) -> str:
-        """Trim and validate note body; raises ValidationException on failure."""
-        if body is None:
-            logger.warning("Examiner note validation failed: body is None")
-            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_BODY_REQUIRED.value)
-        trimmed = body.strip()
+    def validate_text(text: str | None) -> str:
+        """Trim and validate note text; raises ValidationException on failure."""
+        if text is None:
+            logger.warning("Examiner note validation failed: text is None")
+            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_TEXT_REQUIRED.value)
+        trimmed = text.strip()
         if not trimmed:
-            logger.warning("Examiner note validation failed: body is empty after trim")
-            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_BODY_REQUIRED.value)
-        if len(trimmed) > NOTE_MAX_BODY_LENGTH:
+            logger.warning("Examiner note validation failed: text is empty after trim")
+            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_TEXT_REQUIRED.value)
+        if len(trimmed) > NOTE_MAX_TEXT_LENGTH:
             logger.warning(
-                "Examiner note validation failed: body length %d exceeds maximum %d",
+                "Examiner note validation failed: text length %d exceeds maximum %d",
                 len(trimmed),
-                NOTE_MAX_BODY_LENGTH,
+                NOTE_MAX_TEXT_LENGTH,
             )
-            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_BODY_TOO_LONG.value)
+            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_TEXT_TOO_LONG.value)
         return trimmed
 
     @staticmethod
@@ -131,9 +131,9 @@ class ExaminerNoteService:
         return rows, truncated
 
     @classmethod
-    def create_application_note(cls, application: Application, user: User, body: str) -> ExaminerNote:
+    def create_application_note(cls, application: Application, user: User, text: str) -> ExaminerNote:
         """Create a note on an application."""
-        validated_body = cls.validate_body(body)
+        validated_text = cls.validate_text(text)
         block_reason = cls.application_note_post_block_reason(application)
         if block_reason:
             logger.warning(
@@ -145,38 +145,38 @@ class ExaminerNoteService:
             )
             raise ExaminerNoteNotAllowedException(block_reason)
         note = ExaminerNote(
-            body=validated_body,
+            text=validated_text,
             application_id=application.id,
             author_user_id=user.id,
         )
         note.save()
         note.author = user
         logger.info(
-            "Created examiner note id=%s for application_id=%s by user=%s (body_length=%d)",
+            "Created examiner note id=%s for application_id=%s by user=%s (text_length=%d)",
             note.id,
             application.id,
             user.username,
-            len(validated_body),
+            len(validated_text),
         )
         return note
 
     @classmethod
-    def create_registration_note(cls, registration: Registration, user: User, body: str) -> ExaminerNote:
+    def create_registration_note(cls, registration: Registration, user: User, text: str) -> ExaminerNote:
         """Create a note on a registration."""
-        validated_body = cls.validate_body(body)
+        validated_text = cls.validate_text(text)
         note = ExaminerNote(
-            body=validated_body,
+            text=validated_text,
             registration_id=registration.id,
             author_user_id=user.id,
         )
         note.save()
         note.author = user
         logger.info(
-            "Created examiner note id=%s for registration_id=%s by user=%s (body_length=%d)",
+            "Created examiner note id=%s for registration_id=%s by user=%s (text_length=%d)",
             note.id,
             registration.id,
             user.username,
-            len(validated_body),
+            len(validated_text),
         )
         return note
 
@@ -188,7 +188,7 @@ class ExaminerNoteService:
             created_at = created_at.replace(tzinfo=timezone.utc)
         return {
             "id": note.id,
-            "body": note.body,
+            "text": note.text,
             "authorUserId": note.author_user_id,
             "authorUsername": note.author.username if note.author else None,
             "createdAt": created_at.isoformat(),

--- a/strr-api/src/strr_api/services/examiner_note_service.py
+++ b/strr-api/src/strr_api/services/examiner_note_service.py
@@ -1,0 +1,215 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the BSD 3 Clause License, (the "License");
+# you may not use this file except in compliance with the License.
+# The template for the license can be found here
+#    https://opensource.org/license/bsd-3-clause/
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Examiner notes service."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timezone
+from http import HTTPStatus
+from typing import Any
+
+from sqlalchemy.orm import joinedload
+
+from strr_api.enums.enum import ErrorMessage
+from strr_api.exceptions import ValidationException
+from strr_api.models import Application, ExaminerNote, Registration, User
+
+logger = logging.getLogger(__name__)
+
+NOTE_LIST_MAX = 500
+NOTE_MAX_BODY_LENGTH = 4000
+
+# Application statuses where note creation is blocked.
+APPLICATION_NOTE_BLOCKED_STATUSES = frozenset(
+    {
+        Application.Status.DRAFT.value,
+        Application.Status.PAYMENT_DUE.value,
+        Application.Status.PAID.value,
+        Application.Status.AUTO_APPROVED.value,
+        Application.Status.PROVISIONALLY_APPROVED.value,
+        Application.Status.FULL_REVIEW_APPROVED.value,
+        Application.Status.ADDITIONAL_INFO_REQUESTED.value,
+    }
+)
+
+
+class ExaminerNoteNotAllowedException(Exception):
+    """Raised when an application note cannot be posted."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+        self.status_code = HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+class ExaminerNoteService:
+    """Create and list examiner notes."""
+
+    @staticmethod
+    def validate_body(body: str | None) -> str:
+        """Trim and validate note body; raises ValidationException on failure."""
+        if body is None:
+            logger.warning("Examiner note validation failed: body is None")
+            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_BODY_REQUIRED.value)
+        trimmed = body.strip()
+        if not trimmed:
+            logger.warning("Examiner note validation failed: body is empty after trim")
+            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_BODY_REQUIRED.value)
+        if len(trimmed) > NOTE_MAX_BODY_LENGTH:
+            logger.warning(
+                "Examiner note validation failed: body length %d exceeds maximum %d",
+                len(trimmed),
+                NOTE_MAX_BODY_LENGTH,
+            )
+            raise ValidationException(message=ErrorMessage.EXAMINER_NOTE_BODY_TOO_LONG.value)
+        return trimmed
+
+    @staticmethod
+    def application_note_post_block_reason(application: Application) -> str | None:
+        """Return a user-facing message when POST is blocked, or None when allowed."""
+        if application.registration_id is not None:
+            return ErrorMessage.EXAMINER_NOTE_APPLICATION_REGISTERED.value
+        status = getattr(application.status, "value", application.status)
+        if status in APPLICATION_NOTE_BLOCKED_STATUSES:
+            return ErrorMessage.EXAMINER_NOTE_APPLICATION_STATUS_NOT_ALLOWED.value.format(status=status)
+        return None
+
+    @classmethod
+    def list_by_application_id(cls, application_id: int) -> tuple[list[ExaminerNote], bool]:
+        """Return notes newest first and whether the list was truncated."""
+        return cls._list_notes(ExaminerNote.application_id == application_id)
+
+    @classmethod
+    def list_by_registration_id(cls, registration_id: int) -> tuple[list[ExaminerNote], bool]:
+        """Return registration-owned notes newest first and whether truncated."""
+        return cls._list_notes(ExaminerNote.registration_id == registration_id)
+
+    @classmethod
+    def _list_notes(cls, filter_clause) -> tuple[list[ExaminerNote], bool]:
+        rows = (
+            ExaminerNote.query.options(joinedload(ExaminerNote.author))
+            .filter(filter_clause)
+            .order_by(ExaminerNote.created_at.desc(), ExaminerNote.id.desc())
+            .limit(NOTE_LIST_MAX + 1)
+            .all()
+        )
+        truncated = len(rows) > NOTE_LIST_MAX
+        if truncated:
+            rows = rows[:NOTE_LIST_MAX]
+        return rows, truncated
+
+    @classmethod
+    def create_application_note(cls, application: Application, user: User, body: str) -> ExaminerNote:
+        """Create a note on an application."""
+        validated_body = cls.validate_body(body)
+        block_reason = cls.application_note_post_block_reason(application)
+        if block_reason:
+            logger.warning(
+                "Blocked examiner note creation for application_id=%s (number=%s) by user=%s: %s",
+                application.id,
+                application.application_number,
+                user.username,
+                block_reason,
+            )
+            raise ExaminerNoteNotAllowedException(block_reason)
+        note = ExaminerNote(
+            body=validated_body,
+            application_id=application.id,
+            author_user_id=user.id,
+        )
+        note.save()
+        note.author = user
+        logger.info(
+            "Created examiner note id=%s for application_id=%s by user=%s (body_length=%d)",
+            note.id,
+            application.id,
+            user.username,
+            len(validated_body),
+        )
+        return note
+
+    @classmethod
+    def create_registration_note(cls, registration: Registration, user: User, body: str) -> ExaminerNote:
+        """Create a note on a registration."""
+        validated_body = cls.validate_body(body)
+        note = ExaminerNote(
+            body=validated_body,
+            registration_id=registration.id,
+            author_user_id=user.id,
+        )
+        note.save()
+        note.author = user
+        logger.info(
+            "Created examiner note id=%s for registration_id=%s by user=%s (body_length=%d)",
+            note.id,
+            registration.id,
+            user.username,
+            len(validated_body),
+        )
+        return note
+
+    @staticmethod
+    def serialize(note: ExaminerNote) -> dict[str, Any]:
+        """Serialize examiner note to API JSON (camelCase)."""
+        created_at = note.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        return {
+            "id": note.id,
+            "body": note.body,
+            "authorUserId": note.author_user_id,
+            "authorUsername": note.author.username if note.author else None,
+            "createdAt": created_at.isoformat(),
+        }
+
+    @classmethod
+    def build_application_list_response(
+        cls, application: Application, notes: list[ExaminerNote], truncated: bool
+    ) -> dict[str, Any]:
+        return {
+            "applicationNumber": application.application_number,
+            "truncated": truncated,
+            "notes": [cls.serialize(n) for n in notes],
+        }
+
+    @classmethod
+    def build_registration_list_response(
+        cls, registration: Registration, notes: list[ExaminerNote], truncated: bool
+    ) -> dict[str, Any]:
+        return {
+            "registrationId": registration.id,
+            "truncated": truncated,
+            "notes": [cls.serialize(n) for n in notes],
+        }

--- a/strr-api/src/strr_api/services/examiner_note_service.py
+++ b/strr-api/src/strr_api/services/examiner_note_service.py
@@ -1,4 +1,4 @@
-# Copyright © 2024 Province of British Columbia
+# Copyright © 2026 Province of British Columbia
 #
 # Licensed under the BSD 3 Clause License, (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ from strr_api.models import Application, ExaminerNote, Registration, User
 logger = logging.getLogger(__name__)
 
 NOTE_LIST_MAX = 500
-NOTE_MAX_TEXT_LENGTH = 4000
+NOTE_MAX_TEXT_LENGTH = 1000
 
 # Application statuses where note creation is blocked.
 APPLICATION_NOTE_BLOCKED_STATUSES = frozenset(

--- a/strr-api/tests/integration/resources/test_examiner_notes_api.py
+++ b/strr-api/tests/integration/resources/test_examiner_notes_api.py
@@ -1,0 +1,113 @@
+"""Integration tests for examiner notes APIs."""
+
+from http import HTTPStatus
+
+import pytest
+
+from strr_api.enums.enum import ErrorMessage
+from strr_api.models.application import Application as AppModel
+from tests.integration.application_seed import generate_application_number, seed_listable_application
+from tests.integration.helpers import assert_status
+from tests.utils.examiner_notes_helpers import (
+    APPLICATION,
+    REGISTRATION,
+    application_notes_url,
+    assert_application_notes_roundtrip,
+    assert_message_contains,
+    assert_notes_role_denied,
+    assert_registration_notes_roundtrip,
+    notes_url,
+    request_notes,
+)
+
+STAFF_HEADER_FIXTURES = ("headers_strr_examiner", "headers_strr_investigator")
+STAFF_ROLE_RESOURCE_CASES = [
+    pytest.param(headers_fixture, resource, id=f"{headers_fixture}-{resource}")
+    for headers_fixture in STAFF_HEADER_FIXTURES
+    for resource in (APPLICATION, REGISTRATION)
+]
+DENIED_INTEGRATION_CASES = [
+    pytest.param("headers_public_user", APPLICATION, "GET", id="public-application-get"),
+    pytest.param("headers_system", APPLICATION, "GET", id="system-application-get"),
+    pytest.param("headers_system", APPLICATION, "POST", id="system-application-post"),
+    pytest.param("headers_system", REGISTRATION, "GET", id="system-registration-get"),
+]
+
+POST_REJECTION_CASES = [
+    pytest.param(
+        "serializable_application",
+        "Should fail",
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+        (ErrorMessage.EXAMINER_NOTE_APPLICATION_REGISTERED.value,),
+        id="registered",
+    ),
+]
+
+
+@pytest.fixture
+def examination_application(session, integration_account_id, serializable_host_registration):
+    """Application in examination without registration_id (notes POST allowed)."""
+    return seed_listable_application(
+        session,
+        account_id=integration_account_id,
+        submitter_user_id=serializable_host_registration["user_id"],
+        registration_id=None,
+        application_number=generate_application_number(),
+        status=AppModel.Status.FULL_REVIEW.value,
+    )
+
+
+@pytest.mark.parametrize(
+    "headers_fixture,resource",
+    STAFF_ROLE_RESOURCE_CASES,
+)
+def test_staff_role_notes_roundtrip(
+    client,
+    examination_application,
+    serializable_host_registration,
+    headers_fixture,
+    resource,
+    request,
+):
+    headers = request.getfixturevalue(headers_fixture)()
+    body = f"Note via {headers_fixture}"
+    if resource == APPLICATION:
+        assert_application_notes_roundtrip(client, examination_application["application_number"], headers, body)
+    else:
+        assert_registration_notes_roundtrip(client, serializable_host_registration["registration_id"], headers, body)
+
+
+@pytest.mark.parametrize("headers_fixture,resource,method", DENIED_INTEGRATION_CASES)
+def test_notes_role_denied(
+    client,
+    examination_application,
+    serializable_host_registration,
+    headers_fixture,
+    resource,
+    method,
+    request,
+):
+    headers = request.getfixturevalue(headers_fixture)()
+    url = notes_url(
+        resource,
+        application=examination_application["application_number"],
+        registration_id=serializable_host_registration["registration_id"],
+    )
+    assert_notes_role_denied(request_notes(client, method, url, headers))
+
+
+@pytest.mark.parametrize("app_fixture,body,expected_status,message_parts", POST_REJECTION_CASES)
+def test_application_notes_post_rejected(
+    client, headers_strr_examiner, app_fixture, body, expected_status, message_parts, request
+):
+    app = request.getfixturevalue(app_fixture)
+    rv = request_notes(
+        client,
+        "POST",
+        application_notes_url(app["application_number"]),
+        headers_strr_examiner(),
+        body=body,
+    )
+    assert_status(rv, expected_status)
+    if message_parts:
+        assert_message_contains(rv, *message_parts)

--- a/strr-api/tests/postman/strr-api.postman_collection.json
+++ b/strr-api/tests/postman/strr-api.postman_collection.json
@@ -1830,7 +1830,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"body\": \"This is an examiner note for the application.\"\n}",
+              "raw": "{\n    \"text\": \"This is an examiner note for the application.\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1848,7 +1848,7 @@
                 "notes"
               ]
             },
-            "description": "Create an examiner note on an application. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note body must be 1-4000 characters. Blocked on certain application statuses (DRAFT, PAYMENT_DUE, PAID, AUTO_APPROVED, PROVISIONALLY_APPROVED, FULL_REVIEW_APPROVED, ADDITIONAL_INFO_REQUESTED) and if application is linked to a registration."
+            "description": "Create an examiner note on an application. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note text must be 1-4000 characters. Blocked on certain application statuses (DRAFT, PAYMENT_DUE, PAID, AUTO_APPROVED, PROVISIONALLY_APPROVED, FULL_REVIEW_APPROVED, ADDITIONAL_INFO_REQUESTED) and if application is linked to a registration."
           },
           "response": []
         }
@@ -2671,7 +2671,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"body\": \"This is an examiner note for the registration.\"\n}",
+              "raw": "{\n    \"text\": \"This is an examiner note for the registration.\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -2689,7 +2689,7 @@
                 "notes"
               ]
             },
-            "description": "Create an examiner note on a registration. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note body must be 1-4000 characters. No status restrictions."
+            "description": "Create an examiner note on a registration. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note text must be 1-4000 characters. No status restrictions."
           },
           "response": []
         }

--- a/strr-api/tests/postman/strr-api.postman_collection.json
+++ b/strr-api/tests/postman/strr-api.postman_collection.json
@@ -1,2948 +1,3098 @@
 {
-	"info": {
-		"_postman_id": "fd8c0104-07ea-4030-bfb6-a6a1c3f4cdaf",
-		"name": "strr-api",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "31792407"
-	},
-	"item": [
-		{
-			"name": "Application",
-			"item": [
-				{
-					"name": "Create host registration application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"header\": {\n        \"paymentMethod\": \"DIRECT_PAY\"\n    },\n    \"registration\": {\n        \"registrationType\": \"HOST\",\n        \"primaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"First\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mickey\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\",\n            \"socialInsuranceNumber\":\"123 222 333\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"secondaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"Other\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mouse\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-888-8888\",\n            \"extension\": \"\",\n            \"faxNumber\": \"\",\n            \"emailAddress\": \"test2@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"unitAddress\": {\n            \"nickname\": \"My Rental Property\",\n            \"country\": \"CA\",\n            \"unitNumber\": \"\",\n            \"streetNumber\": \"12166\",\n            \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n            \"addressLineTwo\": \"\",\n            \"city\": \"MAPLE RIDGE\",\n            \"province\": \"BC\",\n            \"postalCode\": \"V2X 7N1\"\n        },\n        \"strRequirements\": {\n            \"isBusinessLicenceRequired\": false,\n            \"isPrincipalResidenceRequired\": true,\n            \"isStrProhibited\": false,\n            \"isStraaExempt\": null,\n            \"organizationNm\": \"City of Maple Ridge\"\n        },\n        \"unitDetails\": {\n            \"parcelIdentifier\": \"000-460-991\",\n            \"businessLicense\": \"7777777\",\n            \"businessLicenseExpiryDate\": \"2025-01-01\",\n            \"propertyType\": \"SINGLE_FAMILY_HOME\",\n            \"ownershipType\": \"OWN\",\n            \"rentalUnitSpaceType\": \"ENTIRE_HOME\",\n            \"hostResidence\": \"SAME_UNIT\",\n            \"isUnitOnPrincipalResidenceProperty\": true,\n            \"numberOfRoomsForRent\": 1,\n            \"strataHotelCategory\": \"MULTI_UNIT_NON_PR\",\n            \"blExemptReason\": \"Business licence not required. Every booking will be longer than the minimum days required by the local government.\",\n            \"prExemptReason\": \"FRACTIONAL_OWNERSHIP\"\n        },\n        \"listingDetails\": [\n            {\n                \"url\": \"https://www.airbnb.ca/rooms/26359027\"\n            }\n        ],\n        \"documents\": [\n            {\n                \"fileName\": \"Drivers License\",\n                \"fileType\": \"pdf\",\n                \"fileKey\": \"a1234\",\n                \"documentType\": \"BC_DRIVERS_LICENSE\"\n            }\n        ]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create host renewal application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"header\": {\n        \"paymentMethod\": \"DIRECT_PAY\",\n        \"registrationId\": 123,\n        \"applicationType\": \"renewal\"\n    },\n    \"registration\": {\n        \"registrationType\": \"HOST\",\n        \"primaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"First\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mickey\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\",\n            \"socialInsuranceNumber\": \"123 222 333\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"secondaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"Other\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mouse\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-888-8888\",\n            \"extension\": \"\",\n            \"faxNumber\": \"\",\n            \"emailAddress\": \"test2@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"unitAddress\": {\n            \"nickname\": \"My Rental Property\",\n            \"country\": \"CA\",\n            \"unitNumber\": \"\",\n            \"streetNumber\": \"12166\",\n            \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n            \"addressLineTwo\": \"\",\n            \"city\": \"MAPLE RIDGE\",\n            \"province\": \"BC\",\n            \"postalCode\": \"V2X 7N1\"\n        },\n        \"strRequirements\": {\n            \"isBusinessLicenceRequired\": false,\n            \"isPrincipalResidenceRequired\": true,\n            \"isStrProhibited\": false,\n            \"isStraaExempt\": null,\n            \"organizationNm\": \"City of Maple Ridge\"\n        },\n        \"unitDetails\": {\n            \"parcelIdentifier\": \"000-460-991\",\n            \"businessLicense\": \"7777777\",\n            \"businessLicenseExpiryDate\": \"2025-01-01\",\n            \"propertyType\": \"SINGLE_FAMILY_HOME\",\n            \"ownershipType\": \"OWN\",\n            \"rentalUnitSpaceType\": \"ENTIRE_HOME\",\n            \"hostResidence\": \"SAME_UNIT\",\n            \"isUnitOnPrincipalResidenceProperty\": true,\n            \"numberOfRoomsForRent\": 1,\n            \"strataHotelCategory\": \"MULTI_UNIT_NON_PR\",\n            \"blExemptReason\": \"Business licence not required. Every booking will be longer than the minimum days required by the local government.\",\n            \"prExemptReason\": \"FRACTIONAL_OWNERSHIP\"\n        },\n        \"listingDetails\": [\n            {\n                \"url\": \"https://www.airbnb.ca/rooms/26359027\"\n            }\n        ],\n        \"documents\": [\n            {\n                \"fileName\": \"Drivers License\",\n                \"fileType\": \"pdf\",\n                \"fileKey\": \"a1234\",\n                \"documentType\": \"BC_DRIVERS_LICENSE\"\n            }\n        ]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create platform registration application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"registration\": {\n        \"registrationType\": \"PLATFORM\",\n        \"completingParty\": {\n            \"firstName\": \"Test\",\n            \"middleName\": \"\",\n            \"lastName\": \"Test\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"phoneCountryCode\": \"001\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\"\n        },\n        \"platformRepresentatives\": [\n            {\n                \"firstName\": \"Test\",\n                \"middleName\": \"\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"123-456-8970\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            },\n            {\n                \"firstName\": \"Test\",\n                \"middleName\": \"Test\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"604-999-9999\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            }\n        ],\n        \"businessDetails\": {\n            \"legalName\": \"Test Business\",\n            \"homeJurisdiction\": \"Vancouver\",\n            \"businessNumber\": \"BN12345\",\n            \"consumerProtectionBCLicenceNumber\": \"1234\",\n            \"noticeOfNonComplianceEmail\": \"test@test.test\",\n            \"noticeOfNonComplianceOptionalEmail\": \"test@test.test\",\n            \"takeDownRequestEmail\": \"test@test.test\",\n            \"takeDownRequestOptionalEmail\": \"test@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\",\n                \"locationDescription\": \"Test Location\"\n            },\n            \"registeredOfficeOrAttorneyForServiceDetails\": {\n                \"attorneyName\": \"Test\",\n                \"mailingAddress\": {\n                    \"country\": \"CA\",\n                    \"address\": \"12766 227st\",\n                    \"addressLineTwo\": \"\",\n                    \"city\": \"MAPLE RIDGE\",\n                    \"province\": \"BC\",\n                    \"postalCode\": \"V2X 6K6\",\n                    \"locationDescription\": \"Test Location\"\n                }\n            }\n        },\n        \"platformDetails\": {\n            \"brands\": [\n                {\n                    \"name\": \"Provider A\",\n                    \"website\": \"http://abc.com\"\n                },\n                {\n                    \"name\": \"Provider B\",\n                    \"website\": \"http://xyz.com\"\n                }\n            ],\n            \"listingSize\": \"THOUSAND_AND_ABOVE\"\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create platform renewal application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"header\": {\n        \"paymentMethod\": \"DIRECT_PAY\",\n        \"registrationId\": 123,\n        \"applicationType\": \"renewal\"\n    },\n    \"registration\": {\n        \"registrationType\": \"PLATFORM\",\n        \"completingParty\": {\n            \"firstName\": \"Test\",\n            \"lastName\": \"Test\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"phoneCountryCode\": \"001\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\"\n        },\n        \"platformRepresentatives\": [\n            {\n                \"firstName\": \"Test\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"123-456-8970\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            },\n            {\n                \"firstName\": \"Test\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"604-999-9999\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            }\n        ],\n        \"businessDetails\": {\n            \"legalName\": \"Test Business\",\n            \"homeJurisdiction\": \"Vancouver\",\n            \"businessNumber\": \"BN12345\",\n            \"consumerProtectionBCLicenceNumber\": \"1234\",\n            \"noticeOfNonComplianceEmail\": \"test@test.test\",\n            \"noticeOfNonComplianceOptionalEmail\": \"test@test.test\",\n            \"takeDownRequestEmail\": \"test@test.test\",\n            \"takeDownRequestOptionalEmail\": \"test@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\",\n                \"locationDescription\": \"Test Location\"\n            },\n            \"registeredOfficeOrAttorneyForServiceDetails\": {\n                \"attorneyName\": \"Test\",\n                \"mailingAddress\": {\n                    \"country\": \"CA\",\n                    \"address\": \"12766 227st\",\n                    \"addressLineTwo\": \"\",\n                    \"city\": \"MAPLE RIDGE\",\n                    \"province\": \"BC\",\n                    \"postalCode\": \"V2X 6K6\",\n                    \"locationDescription\": \"Test Location\"\n                }\n            }\n        },\n        \"platformDetails\": {\n            \"brands\": [\n                {\n                    \"name\": \"Provider A\",\n                    \"website\": \"http://abc.com\"\n                },\n                {\n                    \"name\": \"Provider B\",\n                    \"website\": \"http://xyz.com\"\n                }\n            ],\n            \"listingSize\": \"THOUSAND_AND_ABOVE\"\n        }\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create strata hotel registration application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"registration\": {\n    \"registrationType\": \"STRATA_HOTEL\",\n    \"completingParty\": {\n      \"firstName\": \"Test\",\n      \"middleName\": \"\",\n      \"lastName\": \"Test\",\n      \"phoneNumber\": \"604-999-9999\",\n      \"phoneCountryCode\": \"001\",\n      \"extension\": \"x64\",\n      \"faxNumber\": \"604-777-7777\",\n      \"emailAddress\": \"test@test.test\",\n      \"jobTitle\": \"Sales Manager\"\n    },\n    \"strataHotelRepresentatives\": [\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"123-456-8970\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      },\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"604-999-9999\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      }\n    ],\n    \"businessDetails\": {\n      \"legalName\": \"Test Business\",\n      \"homeJurisdiction\": \"Vancouver\",\n      \"businessNumber\": \"BN12345\",\n      \"mailingAddress\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"registeredOfficeOrAttorneyForServiceDetails\": {\n        \"attorneyName\": \"Test\",\n        \"mailingAddress\": {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      }\n    },\n    \"strataHotelDetails\": {\n      \"brand\": {\n        \"name\": \"Brand A\",\n        \"website\": \"http://abc.com\"\n      },\n      \"location\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"numberOfUnits\": 50,\n      \"category\": \"MULTI_UNIT_NON_PR\",\n      \"buildings\": [\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        },\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 228st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      ],\n      \"unitListings\": {\n        \"primary\": \"101\\n102\\n103\\n104\",\n        \"additional\": [\n          \"201\\n202\\n203\",\n          \"301\\n302\"\n        ]\n      }\n    }\n  }\n}\n",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create strata hotel renewal application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"header\": {\n    \"paymentMethod\": \"DIRECT_PAY\",\n    \"registrationId\": 123,\n    \"applicationType\": \"renewal\"\n  },\n  \"registration\": {\n    \"registrationType\": \"STRATA_HOTEL\",\n    \"completingParty\": {\n      \"firstName\": \"Test\",\n      \"middleName\": \"\",\n      \"lastName\": \"Test\",\n      \"phoneNumber\": \"604-999-9999\",\n      \"phoneCountryCode\": \"001\",\n      \"extension\": \"x64\",\n      \"faxNumber\": \"604-777-7777\",\n      \"emailAddress\": \"test@test.test\",\n      \"jobTitle\": \"Sales Manager\"\n    },\n    \"strataHotelRepresentatives\": [\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"123-456-8970\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      },\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"604-999-9999\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      }\n    ],\n    \"businessDetails\": {\n      \"legalName\": \"Test Business\",\n      \"homeJurisdiction\": \"Vancouver\",\n      \"businessNumber\": \"BN12345\",\n      \"mailingAddress\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"registeredOfficeOrAttorneyForServiceDetails\": {\n        \"attorneyName\": \"Test\",\n        \"mailingAddress\": {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      }\n    },\n    \"strataHotelDetails\": {\n      \"brand\": {\n        \"name\": \"Brand A\",\n        \"website\": \"http://abc.com\"\n      },\n      \"location\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"numberOfUnits\": 50,\n      \"category\": \"MULTI_UNIT_NON_PR\",\n      \"buildings\": [\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        },\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 228st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      ],\n      \"unitListings\": {\n        \"primary\": \"101\\n102\\n103\\n104\",\n        \"additional\": [\n          \"201\\n202\\n203\",\n          \"301\\n302\"\n        ]\n      }\n    }\n  }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Host Registration - Business as a host",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"registration\": {\n        \"registrationType\": \"HOST\",\n        \"primaryContact\": {\n            \"contactType\": \"BUSINESS\",\n            \"businessLegalName\": \"Test Business\",\n            \"businessNumber\": \"123456789\",\n            \"firstName\": \"The\",\n            \"middleName\": \"First\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mickey\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"secondaryContact\": {\n            \"contactType\": \"INDIVIDUAL\",\n            \"firstName\": \"The\",\n            \"middleName\": \"Other\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mouse\",\n            \"phoneNumber\": \"604-888-8888\",\n            \"extension\": \"\",\n            \"faxNumber\": \"\",\n            \"emailAddress\": \"test2@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"unitDetails\": {\n            \"parcelIdentifier\": \"000-460-991\",\n            \"businessLicense\": \"7777777\",\n            \"businessLicenseExpiryDate\": \"2025-01-01\",\n            \"propertyType\": \"SINGLE_FAMILY_HOME\",\n            \"ownershipType\": \"OWN\",\n            \"rentalUnitSpaceType\": \"ENTIRE_HOME\",\n            \"hostResidence\": \"SAME_UNIT\",\n            \"isUnitOnPrincipalResidenceProperty\": true,\n            \"numberOfRoomsForRent\": 1\n        },\n        \"unitAddress\": {\n            \"nickname\": \"My Rental Property\",\n            \"country\": \"CA\",\n            \"unitNumber\": \"\",\n            \"streetNumber\": \"12166\",\n            \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n            \"addressLineTwo\": \"\",\n            \"city\": \"MAPLE RIDGE\",\n            \"province\": \"BC\",\n            \"postalCode\": \"V2X 7N1\"\n        },\n        \"listingDetails\": [\n            {\n                \"url\": \"https://www.airbnb.ca/rooms/26359027\"\n            }\n        ]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update Application Payment Details",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/payment-details",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"payment-details"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "List applications (sort by application_date ascending)",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains applications array\", function () {",
-									"    pm.expect(jsonData).to.have.property('applications');",
-									"    pm.expect(jsonData.applications).to.be.an('array');",
-									"});",
-									"",
-									"pm.test(\"Default sort is by application_date ascending\", function () {",
-									"    if (jsonData.applications.length < 2) {",
-									"        pm.test.skip(\"Not enough applications to verify sorting\");",
-									"        return;",
-									"    }",
-									"    ",
-									"    let isSorted = true;",
-									"    for (let i = 1; i < jsonData.applications.length; i++) {",
-									"        const prevDate = new Date(jsonData.applications[i-1].header.applicationDateTime);",
-									"        const currDate = new Date(jsonData.applications[i].header.applicationDateTime);",
-									"        if (prevDate > currDate) {",
-									"            isSorted = false;",
-									"            break;",
-									"        }",
-									"    }",
-									"    pm.expect(isSorted).to.be.true;",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications?sortBy=application_date&sortOrder=asc&recordNumber=123&registrationType=HOST&registrationType=PLATFORM&registrationStatus=ACTIVE&registrationStatus=SUSPENDED&status=PAID&assignee={{username}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							],
-							"query": [
-								{
-									"key": "sortBy",
-									"value": "application_date"
-								},
-								{
-									"key": "sortOrder",
-									"value": "asc"
-								},
-								{
-									"key": "recordNumber",
-									"value": "123"
-								},
-								{
-									"key": "registrationType",
-									"value": "HOST"
-								},
-								{
-									"key": "registrationType",
-									"value": "PLATFORM"
-								},
-								{
-									"key": "registrationStatus",
-									"value": "ACTIVE"
-								},
-								{
-									"key": "registrationStatus",
-									"value": "SUSPENDED"
-								},
-								{
-									"key": "status",
-									"value": "PAID"
-								},
-								{
-									"key": "assignee",
-									"value": "{{username}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "List applications (default sort)",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"pm.test(\"Response contains applications array\", function () {",
-									"    pm.expect(jsonData).to.have.property('applications');",
-									"    pm.expect(jsonData.applications).to.be.an('array');",
-									"});",
-									"",
-									"pm.test(\"Applications are sorted by id in descending order\", function () {",
-									"    if (jsonData.applications.length < 2) {",
-									"        pm.test.skip(\"Not enough applications to verify sorting\");",
-									"        return;",
-									"    }",
-									"    ",
-									"    let isSorted = true;",
-									"    for (let i = 1; i < jsonData.applications.length; i++) {",
-									"        const prevId = jsonData.applications[i-1].header.registrationId || 0;",
-									"        const currId = jsonData.applications[i].header.registrationId || 0;",
-									"        if (prevId < currId) {",
-									"            isSorted = false;",
-									"            break;",
-									"        }",
-									"    }",
-									"    pm.expect(isSorted).to.be.true;",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications?recordNumber=123&registrationType=HOST&status=PAID&requirement=PR&requirement=BL",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications"
-							],
-							"query": [
-								{
-									"key": "recordNumber",
-									"value": "123"
-								},
-								{
-									"key": "registrationType",
-									"value": "HOST"
-								},
-								{
-									"key": "status",
-									"value": "PAID"
-								},
-								{
-									"key": "requirement",
-									"value": "PR"
-								},
-								{
-									"key": "requirement",
-									"value": "BL"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Application Details",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Draft Application",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get application events",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/events",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"events"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Search Applications",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains applications array\", function () {",
-									"    pm.expect(jsonData).to.have.property('applications');",
-									"    pm.expect(jsonData.applications).to.be.an('array');",
-									"});",
-									"",
-									"pm.test(\"Applications are sorted by id in descending order by default\", function () {",
-									"    if (jsonData.applications.length < 2) {",
-									"        pm.test.skip(\"Not enough applications to verify sorting\");",
-									"        return;",
-									"    }",
-									"    ",
-									"    let isSorted = true;",
-									"    for (let i = 1; i < jsonData.applications.length; i++) {",
-									"        const prevId = jsonData.applications[i-1].header.registrationId || 0;",
-									"        const currId = jsonData.applications[i].header.registrationId || 0;",
-									"        if (prevId < currId) {",
-									"            isSorted = false;",
-									"            break;",
-									"        }",
-									"    }",
-									"    pm.expect(isSorted).to.be.true;",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/search?text=018-851-570&limit=10&page=1&requirement=PR&requirement=BL",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"search"
-							],
-							"query": [
-								{
-									"key": "text",
-									"value": "018-851-570"
-								},
-								{
-									"key": "limit",
-									"value": "10"
-								},
-								{
-									"key": "page",
-									"value": "1"
-								},
-								{
-									"key": "requirement",
-									"value": "PR"
-								},
-								{
-									"key": "requirement",
-									"value": "BL"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Search Applications (sort by application_date ascending)",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains applications array\", function () {",
-									"    pm.expect(jsonData).to.have.property('applications');",
-									"    pm.expect(jsonData.applications).to.be.an('array');",
-									"});",
-									"",
-									"pm.test(\"Applications are sorted by application_date in ascending order\", function () {",
-									"    if (jsonData.applications.length < 2) {",
-									"        pm.test.skip(\"Not enough applications to verify sorting\");",
-									"        return;",
-									"    }",
-									"    ",
-									"    let isSorted = true;",
-									"    for (let i = 1; i < jsonData.applications.length; i++) {",
-									"        const prevDate = new Date(jsonData.applications[i-1].header.applicationDateTime);",
-									"        const currDate = new Date(jsonData.applications[i].header.applicationDateTime);",
-									"        if (prevDate > currDate) {",
-									"            isSorted = false;",
-									"            break;",
-									"        }",
-									"    }",
-									"    pm.expect(isSorted).to.be.true;",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/search?text=018-851-570&limit=10&page=1&sortBy=application_date&sortOrder=asc&recordNumber=123&registrationType=HOST&registrationType=PLATFORM&registrationStatus=ACTIVE&registrationStatus=SUSPENDED&status=PAID&assignee={{username}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"search"
-							],
-							"query": [
-								{
-									"key": "text",
-									"value": "018-851-570"
-								},
-								{
-									"key": "limit",
-									"value": "10"
-								},
-								{
-									"key": "page",
-									"value": "1"
-								},
-								{
-									"key": "sortBy",
-									"value": "application_date"
-								},
-								{
-									"key": "sortOrder",
-									"value": "asc"
-								},
-								{
-									"key": "recordNumber",
-									"value": "123"
-								},
-								{
-									"key": "registrationType",
-									"value": "HOST"
-								},
-								{
-									"key": "registrationType",
-									"value": "PLATFORM"
-								},
-								{
-									"key": "registrationStatus",
-									"value": "ACTIVE"
-								},
-								{
-									"key": "registrationStatus",
-									"value": "SUSPENDED"
-								},
-								{
-									"key": "status",
-									"value": "PAID"
-								},
-								{
-									"key": "assignee",
-									"value": "{{username}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "User Search Applications",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains applications array\", function () {",
-									"    pm.expect(jsonData).to.have.property('applications');",
-									"    pm.expect(jsonData.applications).to.be.an('array');",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/user/search?text=123&limit=10&page=1",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"user",
-								"search"
-							],
-							"query": [
-								{
-									"key": "text",
-									"value": "123"
-								},
-								{
-									"key": "limit",
-									"value": "10"
-								},
-								{
-									"key": "page",
-									"value": "1"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Staff - Get Application LTSA",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/ltsa",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"ltsa"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Staff - Get Application Auto Approval Records",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/auto-approval-records",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"auto-approval-records"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Staff - Get Existing Host Registrations",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/host/related-registrations",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"host",
-								"related-registrations"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Staff - Reject Application",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"status\": \"DECLINED\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/status",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"status"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Staff - Approve Application",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"status\": \"FULL_REVIEW_APPROVED\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/status",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"status"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Upload application document",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"file_key\",jsonData.fileKey)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "/Users/lekshmimallika/Documents/Test test"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/documents",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"documents"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Download application document",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text",
-								"disabled": true
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/documents/{{file_key}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"documents",
-								"{{file_key}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Application Document",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204\", function () {",
-									"    pm.response.to.have.status(204);",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/documents/{{file_key}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"documents",
-								"{{file_key}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Upload document",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.environment.set(\"file_key\",jsonData.fileKey)"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "/Users/shaanjotgill/Desktop/Test test"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{api_url}}/documents",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"documents"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Document",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204\", function () {",
-									"    pm.response.to.have.status(204);",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/documents/{{file_key}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"documents",
-								"{{file_key}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Payment Receipt",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/payment/receipt",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"payment",
-								"receipt"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Notice of Consideration",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"content\": \"Test NOC\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/notice-of-consideration",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"notice-of-consideration"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Set Aside Decision",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"content\": \"Test Set Aside Content\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/decision/set-aside",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"decision",
-								"set-aside"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Assign Application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains application with assigned reviewer\", function () {",
-									"    pm.expect(jsonData).to.have.property('header');",
-									"    pm.expect(jsonData.header).to.have.property('applicationNumber');",
-									"    pm.expect(jsonData.header.assignee.username).to.equal(pm.environment.get(\"username\"));",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/assign",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"assign"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Unassign Application",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains application with no reviewer\", function () {",
-									"    pm.expect(jsonData).to.have.property('header');",
-									"    pm.expect(jsonData.header).to.have.property('applicationNumber');",
-									"    pm.expect(jsonData.header.assignee).to.deep.equal({});",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/unassign",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"unassign"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update STR Address",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PATCH",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"unitAddress\": {\n        \"unitNumber\": \"\",\n        \"streetNumber\": \"66211\",\n        \"streetName\": \"COTTONWOOD DR MAPLE RIDGE\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 3L8\",\n        \"locationDescription\": \"Located at the corner of Cottonwood Dr and 119 Ave\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/applications/{{application_number}}/str-address",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"applications",
-								"{{application_number}}",
-								"str-address"
-							]
-						},
-						"description": "Update the rental unit address for a host application."
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Registration",
-			"item": [
-				{
-					"name": "Search Registrations",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains registrations array\", function () {",
-									"    pm.expect(jsonData).to.have.property('registrations');",
-									"    pm.expect(jsonData.registrations).to.be.an('array');",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/registrations/search?text=123&sortBy=id&sortOrder=desc&registrationType=HOST&status=ACTIVE",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"search"
-							],
-							"query": [
-								{
-									"key": "text",
-									"value": "123"
-								},
-								{
-									"key": "sortBy",
-									"value": "id"
-								},
-								{
-									"key": "sortOrder",
-									"value": "desc"
-								},
-								{
-									"key": "registrationType",
-									"value": "HOST"
-								},
-								{
-									"key": "status",
-									"value": "ACTIVE"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "User Search Registrations",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains registrations array\", function () {",
-									"    pm.expect(jsonData).to.have.property('registrations');",
-									"    pm.expect(jsonData.registrations).to.be.an('array');",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/user/search?text=123&limit=10&page=1",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"user",
-								"search"
-							],
-							"query": [
-								{
-									"key": "text",
-									"value": "123"
-								},
-								{
-									"key": "limit",
-									"value": "10"
-								},
-								{
-									"key": "page",
-									"value": "1"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update Registration Status",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"status\": \"CANCELLED\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/status",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"status"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Add conditions to a registration",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"status\": \"ACTIVE\",\n    \"conditionsOfApproval\": {\n        \"predefinedConditions\": [\n            \"PR\",\n            \"BL\"\n        ],\n        \"customConditions\": [\n            \"Condition 1\",\n            \"Condition 2\"\n        ],\n        \"minBookingDays\": 30\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/status",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"status"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Set Aside Registration Decision",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/decision/set-aside",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"decision",
-								"set-aside"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update Registration Expiry",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\"expiryDate\": \"2024-10-25\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_number}}/expiry",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_number}}",
-								"expiry"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Download registration document",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/documents/{{file_key}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"documents",
-								"{{file_key}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Upload registration document",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.test(\"Response has registration data\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property('id');",
-									"    pm.expect(jsonData).to.have.property('status');",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "file",
-									"type": "file",
-									"src": "/Users/lekshmimallika/Documents/Test test"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/documents",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"documents"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Registrations",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Registration By Id",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Validate Registration number",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_number}}/validate",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_number}}",
-								"validate"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Registration Events",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/events",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"events"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get ToDos",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/todos",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"todos"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update STR Address",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PATCH",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"unitAddress\": {\n        \"unitNumber\": \"\",\n        \"streetNumber\": \"66211\",\n        \"streetName\": \"COTTONWOOD DR MAPLE RIDGE\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 3L8\",\n        \"locationDescription\": \"Located at the corner of Cottonwood Dr and 119 Ave\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/str-address",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"str-address"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Send Notice of Consideration",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"content\": \"This is a test notice of consideration for your registration.\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/notice-of-consideration",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"notice-of-consideration"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Assign Registration",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains registration with assigned reviewer\", function () {",
-									"    pm.expect(jsonData).to.have.property('header');",
-									"    pm.expect(jsonData.header).to.have.property('assignee');",
-									"    pm.expect(jsonData.header.assignee.username).to.equal(pm.environment.get(\"username\"));",
-									"});",
-									"",
-									"pm.test(\"Registration ID is present\", function () {",
-									"    pm.expect(jsonData).to.have.property('id');",
-									"    pm.expect(jsonData.id).to.be.a('number');",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/assign",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"assign"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Unassign Registration",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var jsonData = pm.response.json();",
-									"",
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response contains registration with no assignee\", function () {",
-									"    pm.expect(jsonData).to.have.property('header');",
-									"    pm.expect(jsonData.header).to.have.property('assignee');",
-									"    pm.expect(jsonData.header.assignee).to.deep.equal({});",
-									"});",
-									"",
-									"pm.test(\"Registration ID is present\", function () {",
-									"    pm.expect(jsonData).to.have.property('id');",
-									"    pm.expect(jsonData.id).to.be.a('number');",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Account-Id",
-								"value": "{{account_id}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{api_url}}/registrations/{{registration_id}}/unassign",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"registrations",
-								"{{registration_id}}",
-								"unassign"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Account",
-			"item": [
-				{
-					"name": "Get User Accounts",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/accounts",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"accounts"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Search Accounts",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/accounts/search?name=Smith Autos",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"accounts",
-								"search"
-							],
-							"query": [
-								{
-									"key": "name",
-									"value": "Smith Autos"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Account",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"name\": \"Test_test_B\",\n    \"mailingAddress\": {\n        \"city\": \"Victoria\",\n        \"country\": \"CA\",\n        \"region\": \"BC\",\n        \"postalCode\": \"V8W 2C3\",\n        \"street\": \"200-1012 Douglas St\",\n        \"streetAdditional\": \"\"\n    },\n    \"email\": \"test@abc.com\",\n    \"phone\": \"(123) 456-7895\",\n    \"phoneExtension\": \"123\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/accounts",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"accounts"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "ops",
-			"item": [
-				{
-					"name": "/ops/healthz",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}}}/ops/healthz",
-							"host": [
-								"{{api_url}}}}"
-							],
-							"path": [
-								"ops",
-								"healthz"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "/ops/readyz",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/ops/readyz",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"ops",
-								"readyz"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Pay",
-			"item": [
-				{
-					"name": "/pay/fee_codes",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/pay/fee_codes",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"pay",
-								"fee_codes"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "User",
-			"item": [
-				{
-					"name": "Get User Terms of Service Copy",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{api_url}}/users/tos",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"users",
-								"tos"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update User Terms of Service Copy",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "PATCH",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"istermsaccepted\": true,\n    \"termsversion\": \"5\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/users/tos",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"users",
-								"tos"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Validation",
-			"item": [
-				{
-					"name": "Real Time Validation",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"identifier\": \"H872640770\",\n    \"address\": {\n        \"number\": 2435,\n        \"postalCode\": \"V4A 8H4\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{api_url}}/permits/validatePermit",
-							"host": [
-								"{{api_url}}"
-							],
-							"path": [
-								"permits",
-								"validatePermit"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Email",
-			"item": [
-				{
-					"name": "notify-api-example",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{staff_token}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"recipients\": \"your@email.com,your.second@email.com\",\n    \"requestBy\": \"STRR\",\n    \"content\": {\"subject\": \"Test Subject\", \"body\": \"#TBD Your application has been approved.\"}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{notify_api_url}}/api/v1/notify",
-							"host": [
-								"{{notify_api_url}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"notify"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "email-listener-example",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"message\":{\n        \"data\":\"eyJkYXRhIjogeyJhcHBsaWNhdGlvbk51bWJlciI6ICIxMDcyODI3NjA4Mjk1OCIsICJlbWFpbFR5cGUiOiAiUExBVEZPUk1fQVVUT19BUFBST1ZFRCJ9LCAiZGF0YWNvbnRlbnR0eXBlIjogImFwcGxpY2F0aW9uL2pzb24iLCAiaWQiOiAiZmFiYzY2YzQtZmIxYS00NDhiLWE5MjgtODM2ZTU4ODM5MzAyIiwgInR5cGUiOiAic3Ryci5lbWFpbCIsICJzcGVjdmVyc2lvbiI6ICIxLjAifQ==\",\n        \"messageId\":\"13650554054141430\",\n        \"message_id\":\"13650554054141430\",\n        \"publishTime\":\"2025-01-27T22:18:51.006Z\",\n        \"publish_time\":\"2025-01-27T22:18:51.006Z\"\n    },\n    \"subscription\":\"projects/bcrbk9-dev/subscriptions/strr-email-dev\"}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{email_svc_url}}",
-							"host": [
-								"{{email_svc_url}}"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "STR Requirements",
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "{{token}}",
-							"type": "string"
-						}
-					]
-				},
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"address\": {\n        \"unitNumber\": \"\",\n        \"streetNumber\": \"12166\",\n        \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\"\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{api_url}}/address/requirements",
-					"host": [
-						"{{api_url}}"
-					],
-					"path": [
-						"address",
-						"requirements"
-					]
-				}
-			},
-			"response": []
-		}
-	]
+  "info": {
+    "_postman_id": "fd8c0104-07ea-4030-bfb6-a6a1c3f4cdaf",
+    "name": "strr-api",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "31792407"
+  },
+  "item": [
+    {
+      "name": "Application",
+      "item": [
+        {
+          "name": "Create host registration application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"header\": {\n        \"paymentMethod\": \"DIRECT_PAY\"\n    },\n    \"registration\": {\n        \"registrationType\": \"HOST\",\n        \"primaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"First\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mickey\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\",\n            \"socialInsuranceNumber\":\"123 222 333\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"secondaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"Other\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mouse\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-888-8888\",\n            \"extension\": \"\",\n            \"faxNumber\": \"\",\n            \"emailAddress\": \"test2@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"unitAddress\": {\n            \"nickname\": \"My Rental Property\",\n            \"country\": \"CA\",\n            \"unitNumber\": \"\",\n            \"streetNumber\": \"12166\",\n            \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n            \"addressLineTwo\": \"\",\n            \"city\": \"MAPLE RIDGE\",\n            \"province\": \"BC\",\n            \"postalCode\": \"V2X 7N1\"\n        },\n        \"strRequirements\": {\n            \"isBusinessLicenceRequired\": false,\n            \"isPrincipalResidenceRequired\": true,\n            \"isStrProhibited\": false,\n            \"isStraaExempt\": null,\n            \"organizationNm\": \"City of Maple Ridge\"\n        },\n        \"unitDetails\": {\n            \"parcelIdentifier\": \"000-460-991\",\n            \"businessLicense\": \"7777777\",\n            \"businessLicenseExpiryDate\": \"2025-01-01\",\n            \"propertyType\": \"SINGLE_FAMILY_HOME\",\n            \"ownershipType\": \"OWN\",\n            \"rentalUnitSpaceType\": \"ENTIRE_HOME\",\n            \"hostResidence\": \"SAME_UNIT\",\n            \"isUnitOnPrincipalResidenceProperty\": true,\n            \"numberOfRoomsForRent\": 1,\n            \"strataHotelCategory\": \"MULTI_UNIT_NON_PR\",\n            \"blExemptReason\": \"Business licence not required. Every booking will be longer than the minimum days required by the local government.\",\n            \"prExemptReason\": \"FRACTIONAL_OWNERSHIP\"\n        },\n        \"listingDetails\": [\n            {\n                \"url\": \"https://www.airbnb.ca/rooms/26359027\"\n            }\n        ],\n        \"documents\": [\n            {\n                \"fileName\": \"Drivers License\",\n                \"fileType\": \"pdf\",\n                \"fileKey\": \"a1234\",\n                \"documentType\": \"BC_DRIVERS_LICENSE\"\n            }\n        ]\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create host renewal application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"header\": {\n        \"paymentMethod\": \"DIRECT_PAY\",\n        \"registrationId\": 123,\n        \"applicationType\": \"renewal\"\n    },\n    \"registration\": {\n        \"registrationType\": \"HOST\",\n        \"primaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"First\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mickey\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\",\n            \"socialInsuranceNumber\": \"123 222 333\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"secondaryContact\": {\n            \"firstName\": \"The\",\n            \"middleName\": \"Other\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mouse\",\n            \"phoneCountryCode\": \"001\",\n            \"phoneNumber\": \"604-888-8888\",\n            \"extension\": \"\",\n            \"faxNumber\": \"\",\n            \"emailAddress\": \"test2@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"unitAddress\": {\n            \"nickname\": \"My Rental Property\",\n            \"country\": \"CA\",\n            \"unitNumber\": \"\",\n            \"streetNumber\": \"12166\",\n            \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n            \"addressLineTwo\": \"\",\n            \"city\": \"MAPLE RIDGE\",\n            \"province\": \"BC\",\n            \"postalCode\": \"V2X 7N1\"\n        },\n        \"strRequirements\": {\n            \"isBusinessLicenceRequired\": false,\n            \"isPrincipalResidenceRequired\": true,\n            \"isStrProhibited\": false,\n            \"isStraaExempt\": null,\n            \"organizationNm\": \"City of Maple Ridge\"\n        },\n        \"unitDetails\": {\n            \"parcelIdentifier\": \"000-460-991\",\n            \"businessLicense\": \"7777777\",\n            \"businessLicenseExpiryDate\": \"2025-01-01\",\n            \"propertyType\": \"SINGLE_FAMILY_HOME\",\n            \"ownershipType\": \"OWN\",\n            \"rentalUnitSpaceType\": \"ENTIRE_HOME\",\n            \"hostResidence\": \"SAME_UNIT\",\n            \"isUnitOnPrincipalResidenceProperty\": true,\n            \"numberOfRoomsForRent\": 1,\n            \"strataHotelCategory\": \"MULTI_UNIT_NON_PR\",\n            \"blExemptReason\": \"Business licence not required. Every booking will be longer than the minimum days required by the local government.\",\n            \"prExemptReason\": \"FRACTIONAL_OWNERSHIP\"\n        },\n        \"listingDetails\": [\n            {\n                \"url\": \"https://www.airbnb.ca/rooms/26359027\"\n            }\n        ],\n        \"documents\": [\n            {\n                \"fileName\": \"Drivers License\",\n                \"fileType\": \"pdf\",\n                \"fileKey\": \"a1234\",\n                \"documentType\": \"BC_DRIVERS_LICENSE\"\n            }\n        ]\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create platform registration application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"registration\": {\n        \"registrationType\": \"PLATFORM\",\n        \"completingParty\": {\n            \"firstName\": \"Test\",\n            \"middleName\": \"\",\n            \"lastName\": \"Test\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"phoneCountryCode\": \"001\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\"\n        },\n        \"platformRepresentatives\": [\n            {\n                \"firstName\": \"Test\",\n                \"middleName\": \"\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"123-456-8970\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            },\n            {\n                \"firstName\": \"Test\",\n                \"middleName\": \"Test\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"604-999-9999\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            }\n        ],\n        \"businessDetails\": {\n            \"legalName\": \"Test Business\",\n            \"homeJurisdiction\": \"Vancouver\",\n            \"businessNumber\": \"BN12345\",\n            \"consumerProtectionBCLicenceNumber\": \"1234\",\n            \"noticeOfNonComplianceEmail\": \"test@test.test\",\n            \"noticeOfNonComplianceOptionalEmail\": \"test@test.test\",\n            \"takeDownRequestEmail\": \"test@test.test\",\n            \"takeDownRequestOptionalEmail\": \"test@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\",\n                \"locationDescription\": \"Test Location\"\n            },\n            \"registeredOfficeOrAttorneyForServiceDetails\": {\n                \"attorneyName\": \"Test\",\n                \"mailingAddress\": {\n                    \"country\": \"CA\",\n                    \"address\": \"12766 227st\",\n                    \"addressLineTwo\": \"\",\n                    \"city\": \"MAPLE RIDGE\",\n                    \"province\": \"BC\",\n                    \"postalCode\": \"V2X 6K6\",\n                    \"locationDescription\": \"Test Location\"\n                }\n            }\n        },\n        \"platformDetails\": {\n            \"brands\": [\n                {\n                    \"name\": \"Provider A\",\n                    \"website\": \"http://abc.com\"\n                },\n                {\n                    \"name\": \"Provider B\",\n                    \"website\": \"http://xyz.com\"\n                }\n            ],\n            \"listingSize\": \"THOUSAND_AND_ABOVE\"\n        }\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create platform renewal application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"header\": {\n        \"paymentMethod\": \"DIRECT_PAY\",\n        \"registrationId\": 123,\n        \"applicationType\": \"renewal\"\n    },\n    \"registration\": {\n        \"registrationType\": \"PLATFORM\",\n        \"completingParty\": {\n            \"firstName\": \"Test\",\n            \"lastName\": \"Test\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"phoneCountryCode\": \"001\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\"\n        },\n        \"platformRepresentatives\": [\n            {\n                \"firstName\": \"Test\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"123-456-8970\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            },\n            {\n                \"firstName\": \"Test\",\n                \"lastName\": \"Test\",\n                \"phoneNumber\": \"604-999-9999\",\n                \"phoneCountryCode\": \"001\",\n                \"extension\": \"x64\",\n                \"faxNumber\": \"604-777-7777\",\n                \"emailAddress\": \"test@test.test\",\n                \"jobTitle\": \"Sales Manager\"\n            }\n        ],\n        \"businessDetails\": {\n            \"legalName\": \"Test Business\",\n            \"homeJurisdiction\": \"Vancouver\",\n            \"businessNumber\": \"BN12345\",\n            \"consumerProtectionBCLicenceNumber\": \"1234\",\n            \"noticeOfNonComplianceEmail\": \"test@test.test\",\n            \"noticeOfNonComplianceOptionalEmail\": \"test@test.test\",\n            \"takeDownRequestEmail\": \"test@test.test\",\n            \"takeDownRequestOptionalEmail\": \"test@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\",\n                \"locationDescription\": \"Test Location\"\n            },\n            \"registeredOfficeOrAttorneyForServiceDetails\": {\n                \"attorneyName\": \"Test\",\n                \"mailingAddress\": {\n                    \"country\": \"CA\",\n                    \"address\": \"12766 227st\",\n                    \"addressLineTwo\": \"\",\n                    \"city\": \"MAPLE RIDGE\",\n                    \"province\": \"BC\",\n                    \"postalCode\": \"V2X 6K6\",\n                    \"locationDescription\": \"Test Location\"\n                }\n            }\n        },\n        \"platformDetails\": {\n            \"brands\": [\n                {\n                    \"name\": \"Provider A\",\n                    \"website\": \"http://abc.com\"\n                },\n                {\n                    \"name\": \"Provider B\",\n                    \"website\": \"http://xyz.com\"\n                }\n            ],\n            \"listingSize\": \"THOUSAND_AND_ABOVE\"\n        }\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create strata hotel registration application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"registration\": {\n    \"registrationType\": \"STRATA_HOTEL\",\n    \"completingParty\": {\n      \"firstName\": \"Test\",\n      \"middleName\": \"\",\n      \"lastName\": \"Test\",\n      \"phoneNumber\": \"604-999-9999\",\n      \"phoneCountryCode\": \"001\",\n      \"extension\": \"x64\",\n      \"faxNumber\": \"604-777-7777\",\n      \"emailAddress\": \"test@test.test\",\n      \"jobTitle\": \"Sales Manager\"\n    },\n    \"strataHotelRepresentatives\": [\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"123-456-8970\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      },\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"604-999-9999\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      }\n    ],\n    \"businessDetails\": {\n      \"legalName\": \"Test Business\",\n      \"homeJurisdiction\": \"Vancouver\",\n      \"businessNumber\": \"BN12345\",\n      \"mailingAddress\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"registeredOfficeOrAttorneyForServiceDetails\": {\n        \"attorneyName\": \"Test\",\n        \"mailingAddress\": {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      }\n    },\n    \"strataHotelDetails\": {\n      \"brand\": {\n        \"name\": \"Brand A\",\n        \"website\": \"http://abc.com\"\n      },\n      \"location\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"numberOfUnits\": 50,\n      \"category\": \"MULTI_UNIT_NON_PR\",\n      \"buildings\": [\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        },\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 228st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      ],\n      \"unitListings\": {\n        \"primary\": \"101\\n102\\n103\\n104\",\n        \"additional\": [\n          \"201\\n202\\n203\",\n          \"301\\n302\"\n        ]\n      }\n    }\n  }\n}\n",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create strata hotel renewal application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"header\": {\n    \"paymentMethod\": \"DIRECT_PAY\",\n    \"registrationId\": 123,\n    \"applicationType\": \"renewal\"\n  },\n  \"registration\": {\n    \"registrationType\": \"STRATA_HOTEL\",\n    \"completingParty\": {\n      \"firstName\": \"Test\",\n      \"middleName\": \"\",\n      \"lastName\": \"Test\",\n      \"phoneNumber\": \"604-999-9999\",\n      \"phoneCountryCode\": \"001\",\n      \"extension\": \"x64\",\n      \"faxNumber\": \"604-777-7777\",\n      \"emailAddress\": \"test@test.test\",\n      \"jobTitle\": \"Sales Manager\"\n    },\n    \"strataHotelRepresentatives\": [\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"123-456-8970\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      },\n      {\n        \"firstName\": \"Test\",\n        \"lastName\": \"Test\",\n        \"phoneNumber\": \"604-999-9999\",\n        \"phoneCountryCode\": \"001\",\n        \"extension\": \"x64\",\n        \"faxNumber\": \"604-777-7777\",\n        \"emailAddress\": \"test@test.test\",\n        \"jobTitle\": \"Sales Manager\"\n      }\n    ],\n    \"businessDetails\": {\n      \"legalName\": \"Test Business\",\n      \"homeJurisdiction\": \"Vancouver\",\n      \"businessNumber\": \"BN12345\",\n      \"mailingAddress\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"registeredOfficeOrAttorneyForServiceDetails\": {\n        \"attorneyName\": \"Test\",\n        \"mailingAddress\": {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      }\n    },\n    \"strataHotelDetails\": {\n      \"brand\": {\n        \"name\": \"Brand A\",\n        \"website\": \"http://abc.com\"\n      },\n      \"location\": {\n        \"country\": \"CA\",\n        \"address\": \"12766 227st\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 6K6\",\n        \"locationDescription\": \"Test Location\"\n      },\n      \"numberOfUnits\": 50,\n      \"category\": \"MULTI_UNIT_NON_PR\",\n      \"buildings\": [\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 227st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        },\n        {\n          \"country\": \"CA\",\n          \"address\": \"12766 228st\",\n          \"addressLineTwo\": \"\",\n          \"city\": \"MAPLE RIDGE\",\n          \"province\": \"BC\",\n          \"postalCode\": \"V2X 6K6\",\n          \"locationDescription\": \"Test Location\"\n        }\n      ],\n      \"unitListings\": {\n        \"primary\": \"101\\n102\\n103\\n104\",\n        \"additional\": [\n          \"201\\n202\\n203\",\n          \"301\\n302\"\n        ]\n      }\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Host Registration - Business as a host",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"application_number\",jsonData.header.applicationNumber)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"registration\": {\n        \"registrationType\": \"HOST\",\n        \"primaryContact\": {\n            \"contactType\": \"BUSINESS\",\n            \"businessLegalName\": \"Test Business\",\n            \"businessNumber\": \"123456789\",\n            \"firstName\": \"The\",\n            \"middleName\": \"First\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mickey\",\n            \"phoneNumber\": \"604-999-9999\",\n            \"extension\": \"x64\",\n            \"faxNumber\": \"604-777-7777\",\n            \"emailAddress\": \"test@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"secondaryContact\": {\n            \"contactType\": \"INDIVIDUAL\",\n            \"firstName\": \"The\",\n            \"middleName\": \"Other\",\n            \"lastName\": \"Guy\",\n            \"dateOfBirth\": \"1986-10-23\",\n            \"preferredName\": \"Mouse\",\n            \"phoneNumber\": \"604-888-8888\",\n            \"extension\": \"\",\n            \"faxNumber\": \"\",\n            \"emailAddress\": \"test2@test.test\",\n            \"mailingAddress\": {\n                \"country\": \"CA\",\n                \"address\": \"12766 227st\",\n                \"addressLineTwo\": \"\",\n                \"city\": \"MAPLE RIDGE\",\n                \"province\": \"BC\",\n                \"postalCode\": \"V2X 6K6\"\n            }\n        },\n        \"unitDetails\": {\n            \"parcelIdentifier\": \"000-460-991\",\n            \"businessLicense\": \"7777777\",\n            \"businessLicenseExpiryDate\": \"2025-01-01\",\n            \"propertyType\": \"SINGLE_FAMILY_HOME\",\n            \"ownershipType\": \"OWN\",\n            \"rentalUnitSpaceType\": \"ENTIRE_HOME\",\n            \"hostResidence\": \"SAME_UNIT\",\n            \"isUnitOnPrincipalResidenceProperty\": true,\n            \"numberOfRoomsForRent\": 1\n        },\n        \"unitAddress\": {\n            \"nickname\": \"My Rental Property\",\n            \"country\": \"CA\",\n            \"unitNumber\": \"\",\n            \"streetNumber\": \"12166\",\n            \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n            \"addressLineTwo\": \"\",\n            \"city\": \"MAPLE RIDGE\",\n            \"province\": \"BC\",\n            \"postalCode\": \"V2X 7N1\"\n        },\n        \"listingDetails\": [\n            {\n                \"url\": \"https://www.airbnb.ca/rooms/26359027\"\n            }\n        ]\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Application Payment Details",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/payment-details",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "payment-details"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List applications (sort by application_date ascending)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains applications array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('applications');",
+                  "    pm.expect(jsonData.applications).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test(\"Default sort is by application_date ascending\", function () {",
+                  "    if (jsonData.applications.length < 2) {",
+                  "        pm.test.skip(\"Not enough applications to verify sorting\");",
+                  "        return;",
+                  "    }",
+                  "    ",
+                  "    let isSorted = true;",
+                  "    for (let i = 1; i < jsonData.applications.length; i++) {",
+                  "        const prevDate = new Date(jsonData.applications[i-1].header.applicationDateTime);",
+                  "        const currDate = new Date(jsonData.applications[i].header.applicationDateTime);",
+                  "        if (prevDate > currDate) {",
+                  "            isSorted = false;",
+                  "            break;",
+                  "        }",
+                  "    }",
+                  "    pm.expect(isSorted).to.be.true;",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications?sortBy=application_date&sortOrder=asc&recordNumber=123&registrationType=HOST&registrationType=PLATFORM&registrationStatus=ACTIVE&registrationStatus=SUSPENDED&status=PAID&assignee={{username}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ],
+              "query": [
+                {
+                  "key": "sortBy",
+                  "value": "application_date"
+                },
+                {
+                  "key": "sortOrder",
+                  "value": "asc"
+                },
+                {
+                  "key": "recordNumber",
+                  "value": "123"
+                },
+                {
+                  "key": "registrationType",
+                  "value": "HOST"
+                },
+                {
+                  "key": "registrationType",
+                  "value": "PLATFORM"
+                },
+                {
+                  "key": "registrationStatus",
+                  "value": "ACTIVE"
+                },
+                {
+                  "key": "registrationStatus",
+                  "value": "SUSPENDED"
+                },
+                {
+                  "key": "status",
+                  "value": "PAID"
+                },
+                {
+                  "key": "assignee",
+                  "value": "{{username}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List applications (default sort)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "pm.test(\"Response contains applications array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('applications');",
+                  "    pm.expect(jsonData.applications).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test(\"Applications are sorted by id in descending order\", function () {",
+                  "    if (jsonData.applications.length < 2) {",
+                  "        pm.test.skip(\"Not enough applications to verify sorting\");",
+                  "        return;",
+                  "    }",
+                  "    ",
+                  "    let isSorted = true;",
+                  "    for (let i = 1; i < jsonData.applications.length; i++) {",
+                  "        const prevId = jsonData.applications[i-1].header.registrationId || 0;",
+                  "        const currId = jsonData.applications[i].header.registrationId || 0;",
+                  "        if (prevId < currId) {",
+                  "            isSorted = false;",
+                  "            break;",
+                  "        }",
+                  "    }",
+                  "    pm.expect(isSorted).to.be.true;",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications?recordNumber=123&registrationType=HOST&status=PAID&requirement=PR&requirement=BL",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications"
+              ],
+              "query": [
+                {
+                  "key": "recordNumber",
+                  "value": "123"
+                },
+                {
+                  "key": "registrationType",
+                  "value": "HOST"
+                },
+                {
+                  "key": "status",
+                  "value": "PAID"
+                },
+                {
+                  "key": "requirement",
+                  "value": "PR"
+                },
+                {
+                  "key": "requirement",
+                  "value": "BL"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Application Details",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Draft Application",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get application events",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/events",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "events"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Search Applications",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains applications array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('applications');",
+                  "    pm.expect(jsonData.applications).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test(\"Applications are sorted by id in descending order by default\", function () {",
+                  "    if (jsonData.applications.length < 2) {",
+                  "        pm.test.skip(\"Not enough applications to verify sorting\");",
+                  "        return;",
+                  "    }",
+                  "    ",
+                  "    let isSorted = true;",
+                  "    for (let i = 1; i < jsonData.applications.length; i++) {",
+                  "        const prevId = jsonData.applications[i-1].header.registrationId || 0;",
+                  "        const currId = jsonData.applications[i].header.registrationId || 0;",
+                  "        if (prevId < currId) {",
+                  "            isSorted = false;",
+                  "            break;",
+                  "        }",
+                  "    }",
+                  "    pm.expect(isSorted).to.be.true;",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/search?text=018-851-570&limit=10&page=1&requirement=PR&requirement=BL",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "text",
+                  "value": "018-851-570"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "requirement",
+                  "value": "PR"
+                },
+                {
+                  "key": "requirement",
+                  "value": "BL"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Search Applications (sort by application_date ascending)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains applications array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('applications');",
+                  "    pm.expect(jsonData.applications).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test(\"Applications are sorted by application_date in ascending order\", function () {",
+                  "    if (jsonData.applications.length < 2) {",
+                  "        pm.test.skip(\"Not enough applications to verify sorting\");",
+                  "        return;",
+                  "    }",
+                  "    ",
+                  "    let isSorted = true;",
+                  "    for (let i = 1; i < jsonData.applications.length; i++) {",
+                  "        const prevDate = new Date(jsonData.applications[i-1].header.applicationDateTime);",
+                  "        const currDate = new Date(jsonData.applications[i].header.applicationDateTime);",
+                  "        if (prevDate > currDate) {",
+                  "            isSorted = false;",
+                  "            break;",
+                  "        }",
+                  "    }",
+                  "    pm.expect(isSorted).to.be.true;",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/search?text=018-851-570&limit=10&page=1&sortBy=application_date&sortOrder=asc&recordNumber=123&registrationType=HOST&registrationType=PLATFORM&registrationStatus=ACTIVE&registrationStatus=SUSPENDED&status=PAID&assignee={{username}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "text",
+                  "value": "018-851-570"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "sortBy",
+                  "value": "application_date"
+                },
+                {
+                  "key": "sortOrder",
+                  "value": "asc"
+                },
+                {
+                  "key": "recordNumber",
+                  "value": "123"
+                },
+                {
+                  "key": "registrationType",
+                  "value": "HOST"
+                },
+                {
+                  "key": "registrationType",
+                  "value": "PLATFORM"
+                },
+                {
+                  "key": "registrationStatus",
+                  "value": "ACTIVE"
+                },
+                {
+                  "key": "registrationStatus",
+                  "value": "SUSPENDED"
+                },
+                {
+                  "key": "status",
+                  "value": "PAID"
+                },
+                {
+                  "key": "assignee",
+                  "value": "{{username}}"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "User Search Applications",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains applications array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('applications');",
+                  "    pm.expect(jsonData.applications).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/user/search?text=123&limit=10&page=1",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "user",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "text",
+                  "value": "123"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "page",
+                  "value": "1"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Staff - Get Application LTSA",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/ltsa",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "ltsa"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Staff - Get Application Auto Approval Records",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/auto-approval-records",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "auto-approval-records"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Staff - Get Existing Host Registrations",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/host/related-registrations",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "host",
+                "related-registrations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Staff - Reject Application",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"status\": \"DECLINED\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/status",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "status"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Staff - Approve Application",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"status\": \"FULL_REVIEW_APPROVED\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/status",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "status"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Upload application document",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"file_key\",jsonData.fileKey)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "/Users/lekshmimallika/Documents/Test test"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/documents",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "documents"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Download application document",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text",
+                "disabled": true
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/documents/{{file_key}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "documents",
+                "{{file_key}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Application Document",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204\", function () {",
+                  "    pm.response.to.have.status(204);",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/documents/{{file_key}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "documents",
+                "{{file_key}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Upload document",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.environment.set(\"file_key\",jsonData.fileKey)"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "/Users/shaanjotgill/Desktop/Test test"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{api_url}}/documents",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "documents"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Document",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204\", function () {",
+                  "    pm.response.to.have.status(204);",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/documents/{{file_key}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "documents",
+                "{{file_key}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Payment Receipt",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/payment/receipt",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "payment",
+                "receipt"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Notice of Consideration",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"content\": \"Test NOC\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/notice-of-consideration",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "notice-of-consideration"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Set Aside Decision",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"content\": \"Test Set Aside Content\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/decision/set-aside",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "decision",
+                "set-aside"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Assign Application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains application with assigned reviewer\", function () {",
+                  "    pm.expect(jsonData).to.have.property('header');",
+                  "    pm.expect(jsonData.header).to.have.property('applicationNumber');",
+                  "    pm.expect(jsonData.header.assignee.username).to.equal(pm.environment.get(\"username\"));",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/assign",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "assign"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Unassign Application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains application with no reviewer\", function () {",
+                  "    pm.expect(jsonData).to.have.property('header');",
+                  "    pm.expect(jsonData.header).to.have.property('applicationNumber');",
+                  "    pm.expect(jsonData.header.assignee).to.deep.equal({});",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/unassign",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "unassign"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update STR Address",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"unitAddress\": {\n        \"unitNumber\": \"\",\n        \"streetNumber\": \"66211\",\n        \"streetName\": \"COTTONWOOD DR MAPLE RIDGE\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 3L8\",\n        \"locationDescription\": \"Located at the corner of Cottonwood Dr and 119 Ave\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/str-address",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "str-address"
+              ]
+            },
+            "description": "Update the rental unit address for a host application."
+          },
+          "response": []
+        },
+        {
+          "name": "List Application Notes",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{examiner_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/notes",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "notes"
+              ]
+            },
+            "description": "List examiner notes for an application. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Returns notes newest first, maximum 500."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Application Note",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{examiner_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"body\": \"This is an examiner note for the application.\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/applications/{{application_number}}/notes",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "applications",
+                "{{application_number}}",
+                "notes"
+              ]
+            },
+            "description": "Create an examiner note on an application. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note body must be 1-4000 characters. Blocked on certain application statuses (DRAFT, PAYMENT_DUE, PAID, AUTO_APPROVED, PROVISIONALLY_APPROVED, FULL_REVIEW_APPROVED, ADDITIONAL_INFO_REQUESTED) and if application is linked to a registration."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Registration",
+      "item": [
+        {
+          "name": "Search Registrations",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains registrations array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('registrations');",
+                  "    pm.expect(jsonData.registrations).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/registrations/search?text=123&sortBy=id&sortOrder=desc&registrationType=HOST&status=ACTIVE",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "text",
+                  "value": "123"
+                },
+                {
+                  "key": "sortBy",
+                  "value": "id"
+                },
+                {
+                  "key": "sortOrder",
+                  "value": "desc"
+                },
+                {
+                  "key": "registrationType",
+                  "value": "HOST"
+                },
+                {
+                  "key": "status",
+                  "value": "ACTIVE"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "User Search Registrations",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains registrations array\", function () {",
+                  "    pm.expect(jsonData).to.have.property('registrations');",
+                  "    pm.expect(jsonData.registrations).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/user/search?text=123&limit=10&page=1",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "user",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "text",
+                  "value": "123"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "page",
+                  "value": "1"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Registration Status",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"status\": \"CANCELLED\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/status",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "status"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Add conditions to a registration",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"status\": \"ACTIVE\",\n    \"conditionsOfApproval\": {\n        \"predefinedConditions\": [\n            \"PR\",\n            \"BL\"\n        ],\n        \"customConditions\": [\n            \"Condition 1\",\n            \"Condition 2\"\n        ],\n        \"minBookingDays\": 30\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/status",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "status"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Set Aside Registration Decision",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/decision/set-aside",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "decision",
+                "set-aside"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Registration Expiry",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"expiryDate\": \"2024-10-25\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_number}}/expiry",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_number}}",
+                "expiry"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Download registration document",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/documents/{{file_key}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "documents",
+                "{{file_key}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Upload registration document",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has registration data\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('id');",
+                  "    pm.expect(jsonData).to.have.property('status');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "/Users/lekshmimallika/Documents/Test test"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/documents",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "documents"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Registrations",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                ""
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Registration By Id",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Validate Registration number",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_number}}/validate",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_number}}",
+                "validate"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Registration Events",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/events",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "events"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get ToDos",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/todos",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "todos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update STR Address",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"unitAddress\": {\n        \"unitNumber\": \"\",\n        \"streetNumber\": \"66211\",\n        \"streetName\": \"COTTONWOOD DR MAPLE RIDGE\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\",\n        \"postalCode\": \"V2X 3L8\",\n        \"locationDescription\": \"Located at the corner of Cottonwood Dr and 119 Ave\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/str-address",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "str-address"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Send Notice of Consideration",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"content\": \"This is a test notice of consideration for your registration.\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/notice-of-consideration",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "notice-of-consideration"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Assign Registration",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains registration with assigned reviewer\", function () {",
+                  "    pm.expect(jsonData).to.have.property('header');",
+                  "    pm.expect(jsonData.header).to.have.property('assignee');",
+                  "    pm.expect(jsonData.header.assignee.username).to.equal(pm.environment.get(\"username\"));",
+                  "});",
+                  "",
+                  "pm.test(\"Registration ID is present\", function () {",
+                  "    pm.expect(jsonData).to.have.property('id');",
+                  "    pm.expect(jsonData.id).to.be.a('number');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/assign",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "assign"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Unassign Registration",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains registration with no assignee\", function () {",
+                  "    pm.expect(jsonData).to.have.property('header');",
+                  "    pm.expect(jsonData.header).to.have.property('assignee');",
+                  "    pm.expect(jsonData.header.assignee).to.deep.equal({});",
+                  "});",
+                  "",
+                  "pm.test(\"Registration ID is present\", function () {",
+                  "    pm.expect(jsonData).to.have.property('id');",
+                  "    pm.expect(jsonData.id).to.be.a('number');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Account-Id",
+                "value": "{{account_id}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/unassign",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "unassign"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Registration Notes",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{examiner_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/notes",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "notes"
+              ]
+            },
+            "description": "List examiner notes for a registration. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Returns notes newest first, maximum 500."
+          },
+          "response": []
+        },
+        {
+          "name": "Create Registration Note",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{examiner_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"body\": \"This is an examiner note for the registration.\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/registrations/{{registration_id}}/notes",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "registrations",
+                "{{registration_id}}",
+                "notes"
+              ]
+            },
+            "description": "Create an examiner note on a registration. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note body must be 1-4000 characters. No status restrictions."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Account",
+      "item": [
+        {
+          "name": "Get User Accounts",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/accounts",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "accounts"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Search Accounts",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/accounts/search?name=Smith Autos",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "accounts",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "name",
+                  "value": "Smith Autos"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Account",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Test_test_B\",\n    \"mailingAddress\": {\n        \"city\": \"Victoria\",\n        \"country\": \"CA\",\n        \"region\": \"BC\",\n        \"postalCode\": \"V8W 2C3\",\n        \"street\": \"200-1012 Douglas St\",\n        \"streetAdditional\": \"\"\n    },\n    \"email\": \"test@abc.com\",\n    \"phone\": \"(123) 456-7895\",\n    \"phoneExtension\": \"123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/accounts",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "accounts"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "ops",
+      "item": [
+        {
+          "name": "/ops/healthz",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}}}/ops/healthz",
+              "host": [
+                "{{api_url}}}}"
+              ],
+              "path": [
+                "ops",
+                "healthz"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "/ops/readyz",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/ops/readyz",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "ops",
+                "readyz"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Pay",
+      "item": [
+        {
+          "name": "/pay/fee_codes",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/pay/fee_codes",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "pay",
+                "fee_codes"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "User",
+      "item": [
+        {
+          "name": "Get User Terms of Service Copy",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_url}}/users/tos",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "users",
+                "tos"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update User Terms of Service Copy",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"istermsaccepted\": true,\n    \"termsversion\": \"5\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/users/tos",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "users",
+                "tos"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Validation",
+      "item": [
+        {
+          "name": "Real Time Validation",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"identifier\": \"H872640770\",\n    \"address\": {\n        \"number\": 2435,\n        \"postalCode\": \"V4A 8H4\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{api_url}}/permits/validatePermit",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "permits",
+                "validatePermit"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Email",
+      "item": [
+        {
+          "name": "notify-api-example",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{staff_token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"recipients\": \"your@email.com,your.second@email.com\",\n    \"requestBy\": \"STRR\",\n    \"content\": {\"subject\": \"Test Subject\", \"body\": \"#TBD Your application has been approved.\"}\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{notify_api_url}}/api/v1/notify",
+              "host": [
+                "{{notify_api_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "notify"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "email-listener-example",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"message\":{\n        \"data\":\"eyJkYXRhIjogeyJhcHBsaWNhdGlvbk51bWJlciI6ICIxMDcyODI3NjA4Mjk1OCIsICJlbWFpbFR5cGUiOiAiUExBVEZPUk1fQVVUT19BUFBST1ZFRCJ9LCAiZGF0YWNvbnRlbnR0eXBlIjogImFwcGxpY2F0aW9uL2pzb24iLCAiaWQiOiAiZmFiYzY2YzQtZmIxYS00NDhiLWE5MjgtODM2ZTU4ODM5MzAyIiwgInR5cGUiOiAic3Ryci5lbWFpbCIsICJzcGVjdmVyc2lvbiI6ICIxLjAifQ==\",\n        \"messageId\":\"13650554054141430\",\n        \"message_id\":\"13650554054141430\",\n        \"publishTime\":\"2025-01-27T22:18:51.006Z\",\n        \"publish_time\":\"2025-01-27T22:18:51.006Z\"\n    },\n    \"subscription\":\"projects/bcrbk9-dev/subscriptions/strr-email-dev\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{email_svc_url}}",
+              "host": [
+                "{{email_svc_url}}"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "STR Requirements",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"address\": {\n        \"unitNumber\": \"\",\n        \"streetNumber\": \"12166\",\n        \"streetName\": \"GREENWELL ST MAPLE RIDGE\",\n        \"addressLineTwo\": \"\",\n        \"city\": \"MAPLE RIDGE\",\n        \"province\": \"BC\"\n    }\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{api_url}}/address/requirements",
+          "host": [
+            "{{api_url}}"
+          ],
+          "path": [
+            "address",
+            "requirements"
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
 }

--- a/strr-api/tests/postman/strr-api.postman_collection.json
+++ b/strr-api/tests/postman/strr-api.postman_collection.json
@@ -1848,7 +1848,7 @@
                 "notes"
               ]
             },
-            "description": "Create an examiner note on an application. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note text must be 1-4000 characters. Blocked on certain application statuses (DRAFT, PAYMENT_DUE, PAID, AUTO_APPROVED, PROVISIONALLY_APPROVED, FULL_REVIEW_APPROVED, ADDITIONAL_INFO_REQUESTED) and if application is linked to a registration."
+            "description": "Create an examiner note on an application. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note text must be 1-1000 characters. Blocked on certain application statuses (DRAFT, PAYMENT_DUE, PAID, AUTO_APPROVED, PROVISIONALLY_APPROVED, FULL_REVIEW_APPROVED, ADDITIONAL_INFO_REQUESTED) and if application is linked to a registration."
           },
           "response": []
         }
@@ -2689,7 +2689,7 @@
                 "notes"
               ]
             },
-            "description": "Create an examiner note on a registration. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note text must be 1-4000 characters. No status restrictions."
+            "description": "Create an examiner note on a registration. Staff only (STRR_EXAMINER or STRR_INVESTIGATOR role required). Note text must be 1-1000 characters. No status restrictions."
           },
           "response": []
         }

--- a/strr-api/tests/unit/resources/test_examiner_notes.py
+++ b/strr-api/tests/unit/resources/test_examiner_notes.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Province of British Columbia
 """Resource tests for examiner notes endpoints."""
+
 from datetime import datetime, timedelta
 from http import HTTPStatus
 
@@ -172,19 +173,19 @@ def test_application_notes_not_found(session, client, jwt):
 def test_registration_list_excludes_application_notes(session, client, jwt, app_and_registration):
     app, reg, user = app_and_registration
     headers = _headers(jwt, (STRR_EXAMINER,))
-    ExaminerNote(body="on app", application_id=app.id, author_user_id=user.id).save()
+    ExaminerNote(text="on app", application_id=app.id, author_user_id=user.id).save()
     request_notes(client, "POST", registration_notes_url(reg.id), headers, body="on reg")
     rv = request_notes(client, "GET", registration_notes_url(reg.id), headers)
     assert rv.status_code == HTTPStatus.OK
     assert len(rv.json["notes"]) == 1
-    assert rv.json["notes"][0]["body"] == "on reg"
+    assert rv.json["notes"][0]["text"] == "on reg"
 
 
 def test_application_notes_truncated_flag(session, client, jwt, monkeypatch, app_and_registration):
     monkeypatch.setattr("strr_api.services.examiner_note_service.NOTE_LIST_MAX", 2)
     app, _reg, user = app_and_registration
     for i in range(3):
-        ExaminerNote(body=f"n{i}", application_id=app.id, author_user_id=user.id).save()
+        ExaminerNote(text=f"n{i}", application_id=app.id, author_user_id=user.id).save()
     rv = request_notes(client, "GET", application_notes_url(app), _headers(jwt, (STRR_EXAMINER,)))
     assert rv.status_code == HTTPStatus.OK
     assert rv.json["truncated"] is True

--- a/strr-api/tests/unit/resources/test_examiner_notes.py
+++ b/strr-api/tests/unit/resources/test_examiner_notes.py
@@ -1,0 +1,191 @@
+# Copyright © 2024 Province of British Columbia
+"""Resource tests for examiner notes endpoints."""
+from datetime import datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+
+from strr_api.enums.enum import ErrorMessage, RegistrationStatus, RegistrationType
+from strr_api.models import Application, ExaminerNote, Registration, User
+from tests.shared_test_constants import ACCOUNT_ID
+from tests.unit.utils.auth_helpers import PUBLIC_USER, STRR_EXAMINER, STRR_INVESTIGATOR, SYSTEM_ROLE, create_header
+from tests.utils.examiner_notes_helpers import (
+    APPLICATION,
+    REGISTRATION,
+    application_notes_url,
+    assert_application_notes_roundtrip,
+    assert_message_contains,
+    assert_notes_role_denied,
+    assert_registration_notes_roundtrip,
+    notes_url,
+    registration_notes_url,
+    request_notes,
+)
+
+STAFF_ROLES = (STRR_EXAMINER, STRR_INVESTIGATOR)
+STAFF_ROLE_RESOURCE_CASES = [
+    pytest.param(role, resource, id=f"{role}-{resource}")
+    for role in STAFF_ROLES
+    for resource in (APPLICATION, REGISTRATION)
+]
+UNIT_DENIED_ROLE_CASES = [
+    pytest.param((PUBLIC_USER,), APPLICATION, "GET", id="public-application-get"),
+    pytest.param((SYSTEM_ROLE,), APPLICATION, "GET", id="system-application-get"),
+    pytest.param((SYSTEM_ROLE,), APPLICATION, "POST", id="system-application-post"),
+    pytest.param((SYSTEM_ROLE,), REGISTRATION, "GET", id="system-registration-get"),
+]
+
+POST_REJECTION_CASES = [
+    pytest.param(
+        "app_with_registration",
+        "blocked",
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+        (ErrorMessage.EXAMINER_NOTE_APPLICATION_REGISTERED.value,),
+        id="registered",
+    ),
+    pytest.param(
+        "draft_app",
+        "blocked",
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+        (Application.Status.DRAFT.value, "active examination"),
+        id="draft-status",
+    ),
+    pytest.param("note_app", "   ", HTTPStatus.BAD_REQUEST, (), id="empty-body"),
+]
+
+
+def _seed_application(session, *, registration_id=None, status=Application.Status.FULL_REVIEW.value):
+    user = User(username="note-resource-user")
+    session.add(user)
+    session.flush()
+    app = Application(
+        application_number=Application.generate_unique_application_number(),
+        application_json={"header": {"applicationType": "registration"}},
+        type="registration",
+        status=status,
+        registration_id=registration_id,
+        submitter_id=user.id,
+        payment_account=str(ACCOUNT_ID),
+    )
+    session.add(app)
+    session.commit()
+    return app, user
+
+
+def _seed_registration(session, user: User):
+    reg = Registration(
+        user_id=user.id,
+        registration_number="REG9876543210",
+        sbc_account_id=ACCOUNT_ID,
+        status=RegistrationStatus.ACTIVE,
+        registration_type=RegistrationType.HOST.value,
+        start_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=365),
+    )
+    session.add(reg)
+    session.commit()
+    return reg
+
+
+def _headers(jwt, roles):
+    if roles == (PUBLIC_USER,):
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = str(ACCOUNT_ID)
+        return headers
+    return create_header(jwt, list(roles))
+
+
+@pytest.fixture
+def note_app(session):
+    app, _user = _seed_application(session, registration_id=None)
+    return app
+
+
+@pytest.fixture
+def draft_app(session):
+    app, _user = _seed_application(session, status=Application.Status.DRAFT.value)
+    return app
+
+
+@pytest.fixture
+def app_with_registration(session):
+    app, user = _seed_application(session)
+    reg = _seed_registration(session, user)
+    app.registration_id = reg.id
+    app.save()
+    return app
+
+
+@pytest.fixture
+def app_and_registration(session):
+    app, user = _seed_application(session)
+    reg = _seed_registration(session, user)
+    return app, reg, user
+
+
+@pytest.mark.parametrize("role,resource", STAFF_ROLE_RESOURCE_CASES)
+def test_staff_role_notes_roundtrip(
+    mock_create_invoice, session, client, jwt, note_app, app_and_registration, role, resource
+):
+    headers = _headers(jwt, (role,))
+    if resource == APPLICATION:
+        assert_application_notes_roundtrip(client, note_app.application_number, headers, note_body="First note")
+    else:
+        _app, reg, _user = app_and_registration
+        assert_registration_notes_roundtrip(client, reg.id, headers, body=f"Note from {role}")
+
+
+@pytest.mark.parametrize("roles,resource,method", UNIT_DENIED_ROLE_CASES)
+def test_notes_role_denied(session, client, jwt, app_and_registration, roles, resource, method):
+    app, reg, _user = app_and_registration
+    url = notes_url(resource, application=app, registration_id=reg.id)
+    assert_notes_role_denied(request_notes(client, method, url, _headers(jwt, roles)))
+
+
+@pytest.mark.parametrize("app_fixture,body,expected_status,message_parts", POST_REJECTION_CASES)
+def test_application_notes_post_rejected(
+    session, client, jwt, app_fixture, body, expected_status, message_parts, request
+):
+    app = request.getfixturevalue(app_fixture)
+    rv = request_notes(
+        client,
+        "POST",
+        application_notes_url(app),
+        _headers(jwt, (STRR_EXAMINER,)),
+        body=body,
+    )
+    assert rv.status_code == expected_status
+    if message_parts:
+        assert_message_contains(rv, *message_parts)
+
+
+def test_application_notes_not_found(session, client, jwt):
+    rv = request_notes(
+        client,
+        "GET",
+        "/applications/00000000000000/notes",
+        _headers(jwt, (STRR_EXAMINER,)),
+    )
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_registration_list_excludes_application_notes(session, client, jwt, app_and_registration):
+    app, reg, user = app_and_registration
+    headers = _headers(jwt, (STRR_EXAMINER,))
+    ExaminerNote(body="on app", application_id=app.id, author_user_id=user.id).save()
+    request_notes(client, "POST", registration_notes_url(reg.id), headers, body="on reg")
+    rv = request_notes(client, "GET", registration_notes_url(reg.id), headers)
+    assert rv.status_code == HTTPStatus.OK
+    assert len(rv.json["notes"]) == 1
+    assert rv.json["notes"][0]["body"] == "on reg"
+
+
+def test_application_notes_truncated_flag(session, client, jwt, monkeypatch, app_and_registration):
+    monkeypatch.setattr("strr_api.services.examiner_note_service.NOTE_LIST_MAX", 2)
+    app, _reg, user = app_and_registration
+    for i in range(3):
+        ExaminerNote(body=f"n{i}", application_id=app.id, author_user_id=user.id).save()
+    rv = request_notes(client, "GET", application_notes_url(app), _headers(jwt, (STRR_EXAMINER,)))
+    assert rv.status_code == HTTPStatus.OK
+    assert rv.json["truncated"] is True
+    assert len(rv.json["notes"]) == 2

--- a/strr-api/tests/unit/services/test_examiner_note_service.py
+++ b/strr-api/tests/unit/services/test_examiner_note_service.py
@@ -1,0 +1,162 @@
+# Copyright © 2024 Province of British Columbia
+"""Unit tests for ExaminerNoteService."""
+
+from datetime import datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+
+from strr_api.enums.enum import ErrorMessage, RegistrationStatus, RegistrationType
+from strr_api.exceptions import ValidationException
+from strr_api.models import Application, ExaminerNote, Registration, User
+from strr_api.services.examiner_note_service import ExaminerNoteNotAllowedException, ExaminerNoteService
+
+VALIDATE_BODY_CASES = [
+    pytest.param("  hello  ", "hello", None, id="trims"),
+    pytest.param("   ", None, ErrorMessage.EXAMINER_NOTE_BODY_REQUIRED.value, id="empty"),
+    pytest.param("x" * 4001, None, ErrorMessage.EXAMINER_NOTE_BODY_TOO_LONG.value, id="too-long"),
+]
+
+CAN_POST_CASES = [
+    pytest.param(None, Application.Status.FULL_REVIEW.value, True, None, id="examination"),
+    pytest.param(
+        True,
+        Application.Status.FULL_REVIEW.value,
+        False,
+        ErrorMessage.EXAMINER_NOTE_APPLICATION_REGISTERED.value,
+        id="registered",
+    ),
+    pytest.param(
+        True,
+        Application.Status.PROVISIONAL_REVIEW.value,
+        False,
+        ErrorMessage.EXAMINER_NOTE_APPLICATION_REGISTERED.value,
+        id="provisional-with-registration",
+    ),
+    pytest.param(
+        None,
+        Application.Status.DRAFT.value,
+        False,
+        Application.Status.DRAFT.value,
+        id="draft-status",
+    ),
+]
+
+
+def _staff_user(session) -> User:
+    user = User(username="examiner-note-tester")
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _registration(session, user: User) -> Registration:
+    reg = Registration(
+        user_id=user.id,
+        registration_number="REG1234567890",
+        sbc_account_id=12345,
+        status=RegistrationStatus.ACTIVE,
+        registration_type=RegistrationType.HOST.value,
+        start_date=datetime.now(),
+        expiry_date=datetime.now() + timedelta(days=365),
+    )
+    session.add(reg)
+    session.flush()
+    return reg
+
+
+def _application(session, *, registration_id=None, status=Application.Status.FULL_REVIEW.value) -> Application:
+    user = _staff_user(session)
+    if registration_id is True:
+        registration_id = _registration(session, user).id
+    app = Application(
+        application_number=Application.generate_unique_application_number(),
+        application_json={"header": {"applicationType": "registration"}},
+        type="registration",
+        status=status,
+        registration_id=registration_id,
+        submitter_id=user.id,
+        payment_account="12345",
+    )
+    session.add(app)
+    session.commit()
+    return app
+
+
+@pytest.mark.parametrize("body,expected,error_fragment", VALIDATE_BODY_CASES)
+def test_validate_body(session, body, expected, error_fragment):
+    if error_fragment:
+        with pytest.raises(ValidationException) as exc:
+            ExaminerNoteService.validate_body(body)
+        assert error_fragment in exc.value.message
+    else:
+        assert ExaminerNoteService.validate_body(body) == expected
+
+
+@pytest.mark.parametrize("registration_id,status,can_post,block_fragment", CAN_POST_CASES)
+def test_can_post_application_note(session, registration_id, status, can_post, block_fragment):
+    app = _application(session, registration_id=registration_id, status=status)
+    reason = ExaminerNoteService.application_note_post_block_reason(app)
+    if can_post:
+        assert reason is None
+    else:
+        assert reason is not None
+        assert block_fragment in reason
+
+
+def test_create_application_note_raises_when_not_allowed(session):
+    user = _staff_user(session)
+    app = _application(session, registration_id=True)
+    with pytest.raises(ExaminerNoteNotAllowedException) as exc:
+        ExaminerNoteService.create_application_note(app, user, "note")
+    assert exc.value.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert exc.value.message == ErrorMessage.EXAMINER_NOTE_APPLICATION_REGISTERED.value
+
+
+def test_list_truncated_when_over_cap(session, monkeypatch):
+    monkeypatch.setattr("strr_api.services.examiner_note_service.NOTE_LIST_MAX", 2)
+    user = _staff_user(session)
+    app = _application(session)
+    for i in range(3):
+        ExaminerNote(body=f"note-{i}", application_id=app.id, author_user_id=user.id).save()
+    notes, truncated = ExaminerNoteService.list_by_application_id(app.id)
+    assert len(notes) == 2
+    assert truncated is True
+    assert notes[0].body == "note-2"
+
+
+def test_serialize_shape(session):
+    user = _staff_user(session)
+    app = _application(session)
+    note = ExaminerNoteService.create_application_note(app, user, "hello")
+    payload = ExaminerNoteService.serialize(note)
+    assert set(payload.keys()) == {"id", "body", "authorUserId", "authorUsername", "createdAt"}
+    assert payload["authorUserId"] == user.id
+    assert payload["authorUsername"] == user.username
+    assert "application_id" not in payload
+    assert "registration_id" not in payload
+
+
+def test_list_returns_username_from_users_table(session):
+    user = _staff_user(session)
+    user.username = "idir/original"
+    session.commit()
+    app = _application(session)
+    ExaminerNoteService.create_application_note(app, user, "hello")
+    user.username = "idir/renamed"
+    session.commit()
+    notes, _ = ExaminerNoteService.list_by_application_id(app.id)
+    payload = ExaminerNoteService.serialize(notes[0])
+    assert payload["authorUsername"] == "idir/renamed"
+
+
+def test_registration_notes_isolated_from_application(session):
+    user = _staff_user(session)
+    app = _application(session)
+    reg = _registration(session, user)
+    session.commit()
+    ExaminerNoteService.create_application_note(app, user, "app note")
+    ExaminerNoteService.create_registration_note(reg, user, "reg note")
+    reg_notes, _ = ExaminerNoteService.list_by_registration_id(reg.id)
+    assert len(reg_notes) == 1
+    assert reg_notes[0].body == "reg note"

--- a/strr-api/tests/unit/services/test_examiner_note_service.py
+++ b/strr-api/tests/unit/services/test_examiner_note_service.py
@@ -11,10 +11,10 @@ from strr_api.exceptions import ValidationException
 from strr_api.models import Application, ExaminerNote, Registration, User
 from strr_api.services.examiner_note_service import ExaminerNoteNotAllowedException, ExaminerNoteService
 
-VALIDATE_BODY_CASES = [
+VALIDATE_TEXT_CASES = [
     pytest.param("  hello  ", "hello", None, id="trims"),
-    pytest.param("   ", None, ErrorMessage.EXAMINER_NOTE_BODY_REQUIRED.value, id="empty"),
-    pytest.param("x" * 4001, None, ErrorMessage.EXAMINER_NOTE_BODY_TOO_LONG.value, id="too-long"),
+    pytest.param("   ", None, ErrorMessage.EXAMINER_NOTE_TEXT_REQUIRED.value, id="empty"),
+    pytest.param("x" * 4001, None, ErrorMessage.EXAMINER_NOTE_TEXT_TOO_LONG.value, id="too-long"),
 ]
 
 CAN_POST_CASES = [
@@ -83,14 +83,14 @@ def _application(session, *, registration_id=None, status=Application.Status.FUL
     return app
 
 
-@pytest.mark.parametrize("body,expected,error_fragment", VALIDATE_BODY_CASES)
-def test_validate_body(session, body, expected, error_fragment):
+@pytest.mark.parametrize("text,expected,error_fragment", VALIDATE_TEXT_CASES)
+def test_validate_text(session, text, expected, error_fragment):
     if error_fragment:
         with pytest.raises(ValidationException) as exc:
-            ExaminerNoteService.validate_body(body)
+            ExaminerNoteService.validate_text(text)
         assert error_fragment in exc.value.message
     else:
-        assert ExaminerNoteService.validate_body(body) == expected
+        assert ExaminerNoteService.validate_text(text) == expected
 
 
 @pytest.mark.parametrize("registration_id,status,can_post,block_fragment", CAN_POST_CASES)
@@ -118,11 +118,11 @@ def test_list_truncated_when_over_cap(session, monkeypatch):
     user = _staff_user(session)
     app = _application(session)
     for i in range(3):
-        ExaminerNote(body=f"note-{i}", application_id=app.id, author_user_id=user.id).save()
+        ExaminerNote(text=f"note-{i}", application_id=app.id, author_user_id=user.id).save()
     notes, truncated = ExaminerNoteService.list_by_application_id(app.id)
     assert len(notes) == 2
     assert truncated is True
-    assert notes[0].body == "note-2"
+    assert notes[0].text == "note-2"
 
 
 def test_serialize_shape(session):
@@ -130,7 +130,7 @@ def test_serialize_shape(session):
     app = _application(session)
     note = ExaminerNoteService.create_application_note(app, user, "hello")
     payload = ExaminerNoteService.serialize(note)
-    assert set(payload.keys()) == {"id", "body", "authorUserId", "authorUsername", "createdAt"}
+    assert set(payload.keys()) == {"id", "text", "authorUserId", "authorUsername", "createdAt"}
     assert payload["authorUserId"] == user.id
     assert payload["authorUsername"] == user.username
     assert "application_id" not in payload
@@ -159,4 +159,4 @@ def test_registration_notes_isolated_from_application(session):
     ExaminerNoteService.create_registration_note(reg, user, "reg note")
     reg_notes, _ = ExaminerNoteService.list_by_registration_id(reg.id)
     assert len(reg_notes) == 1
-    assert reg_notes[0].body == "reg note"
+    assert reg_notes[0].text == "reg note"

--- a/strr-api/tests/unit/services/test_examiner_note_service.py
+++ b/strr-api/tests/unit/services/test_examiner_note_service.py
@@ -14,7 +14,7 @@ from strr_api.services.examiner_note_service import ExaminerNoteNotAllowedExcept
 VALIDATE_TEXT_CASES = [
     pytest.param("  hello  ", "hello", None, id="trims"),
     pytest.param("   ", None, ErrorMessage.EXAMINER_NOTE_TEXT_REQUIRED.value, id="empty"),
-    pytest.param("x" * 4001, None, ErrorMessage.EXAMINER_NOTE_TEXT_TOO_LONG.value, id="too-long"),
+    pytest.param("x" * 1001, None, ErrorMessage.EXAMINER_NOTE_TEXT_TOO_LONG.value, id="too-long"),
 ]
 
 CAN_POST_CASES = [

--- a/strr-api/tests/utils/__init__.py
+++ b/strr-api/tests/utils/__init__.py
@@ -1,0 +1,2 @@
+# Copyright © 2024 Province of British Columbia
+"""Shared test utilities used by unit and integration suites."""

--- a/strr-api/tests/utils/examiner_notes_helpers.py
+++ b/strr-api/tests/utils/examiner_notes_helpers.py
@@ -1,0 +1,89 @@
+# Copyright © 2024 Province of British Columbia
+"""Shared helpers for examiner notes API tests (unit and integration)."""
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+from werkzeug.test import TestResponse
+
+APPLICATION = "application"
+REGISTRATION = "registration"
+
+
+def response_json(rv: TestResponse) -> dict[str, Any] | list[Any] | Any:
+    """Normalize Flask test client vs integration response JSON access."""
+    if hasattr(rv, "get_json"):
+        return rv.get_json()
+    return rv.json
+
+
+def assert_notes_role_denied(rv: TestResponse) -> None:
+    """JWT role decorator rejects non-examiner/non-investigator callers."""
+    assert rv.status_code == HTTPStatus.UNAUTHORIZED
+    assert response_json(rv)["code"] == "missing_a_valid_role"
+
+
+def request_notes(client, method: str, url: str, headers, *, body: str | None = None) -> TestResponse:
+    if method == "GET":
+        return client.get(url, headers=headers)
+    return client.post(url, json={"body": body if body is not None else "note"}, headers=headers)
+
+
+def application_notes_url(application) -> str:
+    """``application`` may be an application number string or an ``Application`` model."""
+    number = application.application_number if hasattr(application, "application_number") else application
+    return f"/applications/{number}/notes"
+
+
+def registration_notes_url(registration_id: int) -> str:
+    return f"/registrations/{registration_id}/notes"
+
+
+def notes_url(resource: str, *, application=None, registration_id: int | None = None) -> str:
+    """Build resource-specific notes URL."""
+    if resource == APPLICATION:
+        return application_notes_url(application)
+    return registration_notes_url(registration_id)
+
+
+def assert_message_contains(response: TestResponse, *parts: str) -> None:
+    message = response_json(response)["message"]
+    for part in parts:
+        assert part in message
+
+
+def assert_registration_notes_roundtrip(client, registration_id: int, headers, body: str) -> None:
+    url = registration_notes_url(registration_id)
+    rv = request_notes(client, "POST", url, headers, body=body)
+    assert rv.status_code == HTTPStatus.CREATED
+
+    rv = request_notes(client, "GET", url, headers)
+    assert rv.status_code == HTTPStatus.OK
+    data = response_json(rv)
+    assert data["registrationId"] == registration_id
+    assert any(n["body"] == body for n in data["notes"])
+
+
+def assert_application_notes_roundtrip(client, application_number: str, headers, note_body: str) -> None:
+    url = application_notes_url(application_number)
+    rv = request_notes(client, "GET", url, headers)
+    assert rv.status_code == HTTPStatus.OK
+    data = response_json(rv)
+    assert data["applicationNumber"] == application_number
+    assert data["truncated"] is False
+    assert data["notes"] == []
+
+    rv = request_notes(client, "POST", url, headers, body=note_body)
+    assert rv.status_code == HTTPStatus.CREATED
+    note = response_json(rv)
+    assert note["body"] == note_body
+    assert "authorUserId" in note
+    assert "authorUsername" in note
+    note_id = note["id"]
+
+    rv = request_notes(client, "GET", url, headers)
+    assert rv.status_code == HTTPStatus.OK
+    listed = response_json(rv)
+    assert len(listed["notes"]) == 1
+    assert listed["notes"][0]["id"] == note_id

--- a/strr-api/tests/utils/examiner_notes_helpers.py
+++ b/strr-api/tests/utils/examiner_notes_helpers.py
@@ -1,5 +1,6 @@
 # Copyright © 2024 Province of British Columbia
 """Shared helpers for examiner notes API tests (unit and integration)."""
+
 from __future__ import annotations
 
 from http import HTTPStatus
@@ -27,7 +28,7 @@ def assert_notes_role_denied(rv: TestResponse) -> None:
 def request_notes(client, method: str, url: str, headers, *, body: str | None = None) -> TestResponse:
     if method == "GET":
         return client.get(url, headers=headers)
-    return client.post(url, json={"body": body if body is not None else "note"}, headers=headers)
+    return client.post(url, json={"text": body if body is not None else "note"}, headers=headers)
 
 
 def application_notes_url(application) -> str:
@@ -62,7 +63,7 @@ def assert_registration_notes_roundtrip(client, registration_id: int, headers, b
     assert rv.status_code == HTTPStatus.OK
     data = response_json(rv)
     assert data["registrationId"] == registration_id
-    assert any(n["body"] == body for n in data["notes"])
+    assert any(n["text"] == body for n in data["notes"])
 
 
 def assert_application_notes_roundtrip(client, application_number: str, headers, note_body: str) -> None:
@@ -77,7 +78,7 @@ def assert_application_notes_roundtrip(client, application_number: str, headers,
     rv = request_notes(client, "POST", url, headers, body=note_body)
     assert rv.status_code == HTTPStatus.CREATED
     note = response_json(rv)
-    assert note["body"] == note_body
+    assert note["text"] == note_body
     assert "authorUserId" in note
     assert "authorUsername" in note
     note_id = note["id"]


### PR DESCRIPTION
### Issue

- bcgov/strr/issues/1687

### Description of changes

Implements a new examiner notes API feature that allows STRR staff (examiners and investigators) to create and retrieve internal notes on applications and registrations for audit trail and collaboration purposes.

### New Endpoints

- `GET /applications/{application_number}/notes` - List notes for an application
- `POST /applications/{application_number}/notes` - Create note on application
- `GET /registrations/{registration_id}/notes` - List notes for a registration
- `POST /registrations/{registration_id}/notes` - Create note on registration

All endpoints require either `STRR_EXAMINER` or `STRR_INVESTIGATOR` role. 
 >  *Confirmed with @pasherwo that both should have the abiltiy to create an list notes.*

### Business Rules

- Application notes blocked on certain statuses (DRAFT, PAYMENT_DUE, PAID, AUTO_APPROVED, PROVISIONALLY_APPROVED, FULL_REVIEW_APPROVED, ADDITIONAL_INFO_REQUESTED)
- Application notes blocked if application is linked to a registration (initial application is already approved and has a registration)
- Registration notes have no status restrictions
- Note body required (1-4000 characters after trimming)
- Notes listed newest first, maximum 500 per list (with truncation indicator)

## Database Changes

- **Migration**: `20260529_1200_c9e8f7a6b5d4_examiner_notes.py`
- **New Table**: `examiner_notes` with:
    - Foreign keys to applications/registrations (one required via CHECK constraint)
    - Author tracking via users table
    - Optimized partial indexes for application_id and registration_id queries