### PR TITLE
chore(api): bump strr-api version to 0.3.25

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.24"
+version = "0.3.25"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
## Summary
Bumps strr-api from 0.3.24 to 0.3.25 so we have a fresh API version to verify on the next deployment.

The Alembic IAM ownership change from #1671 has already been deployed to TEST from current main at commit 3fb6263. This version bump is just to make the next deployed build easier to identify through /meta/info and the API response header.

## Testing
- git diff --check
- parsed strr-api/pyproject.toml with Python tomllib and confirmed strr-api 0.3.25