### PR TITLE
fix(ui): 1692 fix exemption label in examiner details pages

### DIFF
--- a/strr-examiner-web/app/components/Host/SupportingInfo.vue
+++ b/strr-examiner-web/app/components/Host/SupportingInfo.vue
@@ -44,12 +44,12 @@ const getPrExemptReason = (label: string): string =>
   t(`prExemptReason.${label}`)
 
 const getPrExempt = (): string =>
-  prExemptReason
+  prExemptReason.value
     ? t('pr.exempt')
     : t('pr.notExempt')
 
 const getBlExempt = (): string =>
-  businessLicenseExemptReason
+  businessLicenseExemptReason.value
     ? t('pr.exempt')
     : t('pr.notExempt')
 
@@ -218,7 +218,7 @@ const businessLicenseRegistrationConfig: SupportingDocumentsConfig = {
                   </span>
                 </div>
                 <div
-                  v-if="activeReg.documents && !isEmpty(activeReg.documents)"
+                  v-if="activeReg?.documents && !isEmpty(activeReg?.documents)"
                   data-testid="pr-req-documents"
                 >
                   <SupportingDocuments

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/host-application-details.spec.ts
+++ b/strr-examiner-web/tests/unit/host-application-details.spec.ts
@@ -187,6 +187,11 @@ describe('Examiner - Host Application Details Page', () => {
     expect(mockOpen).toHaveBeenCalledWith('blob:url', '_blank')
   })
 
+  it('should show Not Exempt label in the PR section when no prExemptReason is set', () => {
+    const prSection = wrapper.findComponent(HostSupportingInfo).findTestId('pr-req-section')
+    expect(prSection.text()).toContain('Not Exempt')
+  })
+
   it('displays PR exemption reason and Strata category', async () => {
     currentMockData = mockWithPrExemptAndStrataHotel
 


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1692

*Description of changes:*
- Fix to correctly show Not Exempt label in the PR section when no prExemptReason is set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
