### PR TITLE
fix(ui): 1695 clear action buttons state between route changes

### DIFF
--- a/strr-examiner-web/app/layouts/examine.vue
+++ b/strr-examiner-web/app/layouts/examine.vue
@@ -5,6 +5,7 @@ const localePath = useLocalePath()
 const { isApplication, hasRegistrationNumber, activeReg, activeHeader } = storeToRefs(useExaminerStore())
 const { isExaminerDecisionsEnabled } = useExaminerFeatureFlags()
 const { isSnapshotRoute } = useExaminerRoute()
+const { setButtonControl } = useButtonControl()
 
 /* show the bottom action buttons for strata hotel renewal applications */
 const isStrataHotelRenewalApplication = computed(() => {
@@ -19,6 +20,12 @@ const isStrataHotelRenewalApplication = computed(() => {
 const shouldHideBottomActions = computed(() => {
   return isApplication.value && hasRegistrationNumber.value && !isStrataHotelRenewalApplication.value
 })
+
+// clear buttons when switching between routes
+watch(
+  () => useRoute().name,
+  () => setButtonControl({ leftButtons: [], rightButtons: [] })
+)
 
 </script>
 <template>

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1695

*Description of changes:*
- Fix multiple action buttons showing up on Application Details page
- Clear stale buttons when switching between application and registration routes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
