### PR TITLE
feat(ui): 1682 show discard model for unsaved notes on events

### DIFF
--- a/strr-examiner-web/app/components/ActionButtons.vue
+++ b/strr-examiner-web/app/components/ActionButtons.vue
@@ -19,6 +19,7 @@ const {
   sendNoticeOfConsiderationForRegistration
 } = useExaminerStore()
 const { openConfirmActionModal, close: closeConfirmActionModal } = useStrrModals()
+const { withNoteCheck } = useExaminerNotes()
 
 const hasSetAsideAction = computed((): boolean =>
   activeHeader.value?.examinerActions.includes(ApplicationActionsE.SET_ASIDE))
@@ -189,6 +190,9 @@ const setAside = async () => {
   await setAsideRegistration(activeReg.value.id)
   refreshNuxtData()
 }
+
+const handleSetAside = () => withNoteCheck(() => setAside())
+const handleMainAction = () => withNoteCheck(() => selectedAction.value?.action())
 </script>
 
 <template>
@@ -206,7 +210,7 @@ const setAside = async () => {
               color="primary"
               :disabled="!isAssignedToUser"
               data-testid="action-button-set-aside"
-              @click="setAside"
+              @click="handleSetAside"
             />
           </div>
         </div>
@@ -239,7 +243,7 @@ const setAside = async () => {
               variant="outline"
               class="max-w-fit px-7 py-3"
               data-testid="main-action-button"
-              @click="selectedAction?.action"
+              @click="handleMainAction"
             />
           </div>
         </div>

--- a/strr-examiner-web/app/components/ExaminerNotes.vue
+++ b/strr-examiner-web/app/components/ExaminerNotes.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import { useTimeoutFn } from '@vueuse/core'
-const { openConfirmActionModal, close } = useStrrModals()
 const { t } = useNuxtApp().$i18n
 const { kcUser } = useKeycloak()
+const { noteContent, withNoteCheck } = useExaminerNotes()
 
 defineProps<{
   isReadonly?: boolean
@@ -14,7 +14,6 @@ const showHighlight = ref(false)
 
 const NOTE_ANIMATION_DURATION = 3000 // new note background highlight in ms
 const NOTE_MAX_LENGTH = 1000
-const noteContent = ref('')
 const showSaveError = ref(false)
 
 watch(noteContent, () => {
@@ -48,17 +47,7 @@ const handleSaveNote = () => {
 }
 
 const handleDiscardNote = () => {
-  openConfirmActionModal(
-    t('modal.discardNote.title'),
-    t('modal.discardNote.message'),
-    t('modal.discardNote.confirmBtn'),
-    () => {
-      noteContent.value = ''
-      close()
-      return Promise.resolve()
-    },
-    t('modal.discardNote.keepEditing')
-  )
+  withNoteCheck(() => {})
 }
 
 </script>

--- a/strr-examiner-web/app/composables/useExaminerNotes.ts
+++ b/strr-examiner-web/app/composables/useExaminerNotes.ts
@@ -1,0 +1,75 @@
+// Module-level singleton so noteContent is shared between ExaminerNotes.vue and any
+// component/page that needs to guard against navigating away with unsaved content.
+const noteContent = ref('')
+
+export const useExaminerNotes = () => {
+  const { openConfirmActionModal, close } = useStrrModals()
+  const { t } = useNuxtApp().$i18n
+
+  const hasUnsavedNote = computed(() => noteContent.value.trim().length > 0)
+
+  /**
+   * Wraps a major action (approve, reject, cancel, navigate, etc.) with an
+   * unsaved-note check. If the examiner has typed but not yet saved a note,
+   * the Discard Note modal appears before the action runs.
+   * If there is no unsaved content the action executes immediately.
+   */
+  const withNoteCheck = (action: () => void) => {
+    if (!hasUnsavedNote.value) {
+      action()
+      return
+    }
+    openConfirmActionModal(
+      t('modal.discardNote.title'),
+      t('modal.discardNote.message'),
+      t('modal.discardNote.confirmBtn'),
+      () => {
+        noteContent.value = ''
+        close()
+        action()
+        return Promise.resolve()
+      },
+      t('modal.discardNote.keepEditing')
+    )
+  }
+
+  /**
+   * Registers a Vue Router leave guard on the calling page component.
+   * When the examiner tries to navigate away with unsaved note content the
+   * Discard Note modal is shown. Confirming clears the note and completes
+   * the original navigation; cancelling keeps them on the current page.
+   *
+   * Must be called at the top level of a component's setup() (same rules as
+   * all Vue lifecycle hooks).
+   */
+  const useNoteLeaveGuard = () => {
+    onBeforeRouteLeave((to, _from, next) => {
+      if (!hasUnsavedNote.value) {
+        next()
+        return
+      }
+
+      // Cancel navigation first; we will trigger it manually after confirmation.
+      next(false)
+
+      openConfirmActionModal(
+        t('modal.discardNote.title'),
+        t('modal.discardNote.message'),
+        t('modal.discardNote.confirmBtn'),
+        async () => {
+          noteContent.value = ''
+          close()
+          await navigateTo(to.fullPath)
+        },
+        t('modal.discardNote.keepEditing')
+      )
+    })
+  }
+
+  return {
+    noteContent,
+    hasUnsavedNote,
+    withNoteCheck,
+    useNoteLeaveGuard
+  }
+}

--- a/strr-examiner-web/app/pages/examine/[applicationId].vue
+++ b/strr-examiner-web/app/pages/examine/[applicationId].vue
@@ -22,6 +22,8 @@ const {
   isHostApplication
 } = storeToRefs(useExaminerStore())
 const { isExaminerNotesEnabled } = useExaminerFeatureFlags()
+const { withNoteCheck, useNoteLeaveGuard } = useExaminerNotes()
+useNoteLeaveGuard()
 
 // Statuses when Examiner Notes could be added, otherwise readonly
 const ADD_NOTES_STATUSES = new Set([
@@ -121,7 +123,7 @@ const handleAssigneeAction = (
   buttonIndex: number
 ) => {
   if (isAssignedToUser.value) {
-    return handleApplicationAction(id, action, buttonPosition, buttonIndex)
+    withNoteCheck(() => handleApplicationAction(id, action, buttonPosition, buttonIndex))
   } else {
     openConfirmActionModal(
       t('modal.assignError.title'),

--- a/strr-examiner-web/app/pages/registration/[registrationId]/index.vue
+++ b/strr-examiner-web/app/pages/registration/[registrationId]/index.vue
@@ -24,6 +24,8 @@ const {
   isSnapshotVersionsTableEnabled,
   isExaminerNotesEnabled
 } = useExaminerFeatureFlags()
+const { withNoteCheck, useNoteLeaveGuard } = useExaminerNotes()
+useNoteLeaveGuard()
 
 useHead({
   title: t('page.dashboardList.title')
@@ -100,7 +102,7 @@ const handleAssigneeAction = (
   buttonIndex: number
 ) => {
   if (isAssignedToUser.value) {
-    return handleRegistrationAction(id, action, buttonPosition, buttonIndex)
+    withNoteCheck(() => handleRegistrationAction(id, action, buttonPosition, buttonIndex))
   } else {
     openConfirmActionModal(
       t('modal.assignError.title'),

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "engines": {
     "node": ">=24"
   },

--- a/strr-examiner-web/tests/unit/action-buttons.spec.ts
+++ b/strr-examiner-web/tests/unit/action-buttons.spec.ts
@@ -56,6 +56,16 @@ vi.mock('nuxt/app', () => ({
   refreshNuxtData: vi.fn()
 }))
 
+// withNoteCheck passes the action straight through — note-guard logic is tested in use-examiner-notes.spec.ts
+vi.mock('@/composables/useExaminerNotes', () => ({
+  useExaminerNotes: () => ({
+    noteContent: ref(''),
+    hasUnsavedNote: ref(false),
+    withNoteCheck: vi.fn((action: () => void) => action()),
+    useNoteLeaveGuard: vi.fn()
+  })
+}))
+
 const mount = () => mountSuspended(ActionButtons, { global: { plugins: [enI18n] } })
 
 const clickMainButton = (wrapper: any) =>

--- a/strr-examiner-web/tests/unit/examiner-notes.spec.ts
+++ b/strr-examiner-web/tests/unit/examiner-notes.spec.ts
@@ -1,18 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { enI18n } from '../mocks/i18n'
 import { MOCK_EXAMINER_USER } from '../mocks/mockedData'
 import ExaminerNotes from '~/components/ExaminerNotes.vue'
 
-const mockOpenConfirmActionModal = vi.fn()
-const mockKcUser = ref<any>(MOCK_EXAMINER_USER)
+const mockWithNoteCheck = vi.fn()
+const mockNoteContent = ref('')
 
-mockNuxtImport('useStrrModals', () => () => ({
-  openConfirmActionModal: mockOpenConfirmActionModal,
-  close: vi.fn()
+mockNuxtImport('useExaminerNotes', () => () => ({
+  noteContent: mockNoteContent,
+  withNoteCheck: mockWithNoteCheck,
+  hasUnsavedNote: computed(() => mockNoteContent.value.trim().length > 0),
+  useNoteLeaveGuard: vi.fn()
 }))
+
+const mockKcUser = ref<any>(MOCK_EXAMINER_USER)
 
 mockNuxtImport('useKeycloak', () => () => ({
   isAuthenticated: ref(true),
@@ -24,11 +28,11 @@ describe('Examiner Notes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockKcUser.value = MOCK_EXAMINER_USER
+    mockNoteContent.value = ''
   })
 
   it('should render the notes header', async () => {
     const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
-    await flushPromises()
     expect(wrapper.find('h3').exists()).toBe(true)
   })
 
@@ -48,16 +52,37 @@ describe('Examiner Notes', () => {
     expect(wrapper.find('[data-testid="discard-note-btn"]').exists()).toBe(true)
   })
 
-  it('should call openConfirmActionModal with correct args when discarding', async () => {
+  it('should call withNoteCheck when the Discard button is clicked', async () => {
     const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
     await wrapper.find('textarea').setValue('Draft note')
     await wrapper.find('[data-testid="discard-note-btn"]').trigger('click')
-    expect(mockOpenConfirmActionModal).toHaveBeenCalledOnce()
-    const args = mockOpenConfirmActionModal.mock.calls[0]
-    expect(args![0]).toBe('Discard note?')
-    expect(args![1]).toBe('Your note has not been saved.')
-    expect(args![2]).toBe('Discard Note')
-    expect(args![4]).toBe('Keep Editing')
+    expect(mockWithNoteCheck).toHaveBeenCalledOnce()
+  })
+
+  it('should clear noteContent after saving a note', async () => {
+    const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
+    await wrapper.find('textarea').setValue('A saved note')
+    await wrapper.find('[data-testid="save-note-btn"]').trigger('click')
+    await flushPromises()
+    expect(mockNoteContent.value).toBe('')
+  })
+
+  it('should add the note to the list and display it after saving', async () => {
+    const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
+    expect(wrapper.find('[data-testid="no-notes-available"]').exists()).toBe(true)
+    await wrapper.find('textarea').setValue('A new note')
+    await wrapper.find('[data-testid="save-note-btn"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="no-notes-available"]').exists()).toBe(false)
+  })
+
+  it('should display the character counter', async () => {
+    const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('0/1000')
+    await wrapper.find('textarea').setValue('hello')
+    await flushPromises()
+    expect(wrapper.text()).toContain('5/1000')
   })
 
   it('should show empty state when notes array is empty', async () => {
@@ -79,11 +104,23 @@ describe('Examiner Notes', () => {
   })
 
   it('should show error alert when saving the note fails', async () => {
-    mockKcUser.value = null // will cause the save error
+    mockKcUser.value = null // forces an error inside handleSaveNote
     const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
     await wrapper.find('textarea').setValue('Some note text')
     expect(wrapper.find('[data-testid="save-note-error"]').exists()).toBe(false)
     await wrapper.find('[data-testid="save-note-btn"]').trigger('click')
     expect(wrapper.find('[data-testid="save-note-error"]').exists()).toBe(true)
+  })
+
+  it('should clear the save error alert when note content is updated', async () => {
+    mockKcUser.value = null // force an initial save error
+    const wrapper = await mountSuspended(ExaminerNotes, { global: { plugins: [enI18n] } })
+    await wrapper.find('textarea').setValue('Note text')
+    await wrapper.find('[data-testid="save-note-btn"]').trigger('click')
+    expect(wrapper.find('[data-testid="save-note-error"]').exists()).toBe(true)
+
+    await wrapper.find('textarea').setValue('Updated note text')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="save-note-error"]').exists()).toBe(false)
   })
 })

--- a/strr-examiner-web/tests/unit/use-examiner-notes.spec.ts
+++ b/strr-examiner-web/tests/unit/use-examiner-notes.spec.ts
@@ -101,8 +101,10 @@ describe('useExaminerNotes', () => {
 
       withNoteCheck(action)
       expect(capturedConfirmHandler).not.toBeNull()
-
-      await capturedConfirmHandler!()
+      if (capturedConfirmHandler === null) {
+        throw new Error('confirm handler was not captured')
+      }
+      await capturedConfirmHandler()
 
       expect(noteContent.value).toBe('')
       expect(mockClose).toHaveBeenCalledOnce()

--- a/strr-examiner-web/tests/unit/use-examiner-notes.spec.ts
+++ b/strr-examiner-web/tests/unit/use-examiner-notes.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+// Capture the confirmHandler the modal receives so tests can invoke it directly.
+let capturedConfirmHandler: (() => Promise<void>) | null = null
+
+const mockOpenConfirmActionModal = vi.fn(
+  (_title: string, _content: string, _confirmBtn: string, confirmHandler: () => Promise<void>) => {
+    capturedConfirmHandler = confirmHandler
+  }
+)
+const mockClose = vi.fn()
+const mockTranslation = vi.fn((key: string) => key)
+
+mockNuxtImport('useStrrModals', () => () => ({
+  openConfirmActionModal: mockOpenConfirmActionModal,
+  close: mockClose
+}))
+
+mockNuxtImport('useNuxtApp', () => () => ({
+  $i18n: { t: mockTranslation }
+}))
+
+describe('useExaminerNotes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedConfirmHandler = null
+    // Reset the module-level singleton between tests.
+    const { noteContent } = useExaminerNotes()
+    noteContent.value = ''
+  })
+
+  describe('hasUnsavedNote', () => {
+    it('is false when noteContent is empty', () => {
+      const { hasUnsavedNote } = useExaminerNotes()
+      expect(hasUnsavedNote.value).toBe(false)
+    })
+
+    it('is false when noteContent is only whitespace', () => {
+      const { noteContent, hasUnsavedNote } = useExaminerNotes()
+      noteContent.value = '   '
+      expect(hasUnsavedNote.value).toBe(false)
+    })
+
+    it('is true when noteContent has non-whitespace characters', () => {
+      const { noteContent, hasUnsavedNote } = useExaminerNotes()
+      noteContent.value = 'some draft'
+      expect(hasUnsavedNote.value).toBe(true)
+    })
+  })
+
+  describe('noteContent singleton', () => {
+    it('is shared across multiple calls to useExaminerNotes()', () => {
+      const a = useExaminerNotes()
+      const b = useExaminerNotes()
+
+      a.noteContent.value = 'written by a'
+      expect(b.noteContent.value).toBe('written by a')
+    })
+  })
+
+  describe('withNoteCheck', () => {
+    it('calls the action immediately when there is no unsaved note', () => {
+      const { withNoteCheck } = useExaminerNotes()
+      const action = vi.fn()
+
+      withNoteCheck(action)
+
+      expect(action).toHaveBeenCalledOnce()
+      expect(mockOpenConfirmActionModal).not.toHaveBeenCalled()
+    })
+
+    it('opens the Discard Note modal instead of calling the action when a note has content', () => {
+      const { noteContent, withNoteCheck } = useExaminerNotes()
+      noteContent.value = 'unfinished thought'
+      const action = vi.fn()
+
+      withNoteCheck(action)
+
+      expect(mockOpenConfirmActionModal).toHaveBeenCalledOnce()
+      expect(action).not.toHaveBeenCalled()
+    })
+
+    it('passes the correct i18n keys to the modal', () => {
+      const { noteContent, withNoteCheck } = useExaminerNotes()
+      noteContent.value = 'draft'
+
+      withNoteCheck(vi.fn())
+
+      const [title, content, confirmBtn, , cancelBtn] = mockOpenConfirmActionModal.mock.calls[0]!
+      expect(title).toBe('modal.discardNote.title')
+      expect(content).toBe('modal.discardNote.message')
+      expect(confirmBtn).toBe('modal.discardNote.confirmBtn')
+      expect(cancelBtn).toBe('modal.discardNote.keepEditing')
+    })
+
+    it('clears noteContent, closes the modal, and calls the action when confirm is invoked', async () => {
+      const { noteContent, withNoteCheck } = useExaminerNotes()
+      noteContent.value = 'draft'
+      const action = vi.fn()
+
+      withNoteCheck(action)
+      expect(capturedConfirmHandler).not.toBeNull()
+
+      await capturedConfirmHandler!()
+
+      expect(noteContent.value).toBe('')
+      expect(mockClose).toHaveBeenCalledOnce()
+      expect(action).toHaveBeenCalledOnce()
+    })
+
+    it('does not call the action before the user confirms the modal', () => {
+      const { noteContent, withNoteCheck } = useExaminerNotes()
+      noteContent.value = 'draft'
+      const action = vi.fn()
+
+      withNoteCheck(action)
+
+      // confirmHandler has been captured but not yet invoked
+      expect(action).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1682

*Description of changes:*
Discard Note Modal will show on these events now if unsaved:
- Approve / Update approval
- Decline / Reject
- Send notice
- Cancel registration
- Set aside
- Logo Click 
- Browser back
- Open another record like an app snapshot

It will not show on:
- Scrolling
- Opening expansion panels like filing history for example
- Viewing details
Assign / Unassign
- Saving a note (ofc it clears it but no modal)

Here's a video of multiple examples stated above:


https://github.com/user-attachments/assets/e17837d7-f41b-4ebe-ba5a-1de99670ccd4






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
