### PR TITLE
fix(api): 1582 update approval button updates history & sends email

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.26"
+version = "0.3.27"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -767,14 +767,16 @@ class RegistrationService:
             "CANCELLED": Events.EventName.REGISTRATION_CANCELLED,
         }
         event_name = None
-        if status != previous_status.value or registration.is_set_aside:
-            if status == RegistrationStatus.ACTIVE.value:
-                if previous_status == RegistrationStatus.SUSPENDED:
-                    event_name = Events.EventName.REGISTRATION_REINSTATED
-                else:
-                    event_name = Events.EventName.REGISTRATION_APPROVED
+        if status == RegistrationStatus.ACTIVE.value:
+            # Always fire an approval event when setting ACTIVE, regardless of previous status.
+            # This ensures Update Approval on an already ACTIVE renewal registration always
+            # writes a history entry and triggers the approval email.
+            if previous_status == RegistrationStatus.SUSPENDED:
+                event_name = Events.EventName.REGISTRATION_REINSTATED
             else:
-                event_name = event_status_map.get(status)
+                event_name = Events.EventName.REGISTRATION_APPROVED
+        elif status != previous_status.value or registration.is_set_aside:
+            event_name = event_status_map.get(status)
 
         registration.status = status
         registration.is_set_aside = False


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1582

*Description of changes:*
When clicking on update approval with no conditions now:
<img width="1680" height="71" alt="image" src="https://github.com/user-attachments/assets/99f9e907-3ed0-495a-8ab7-0f4fabdd51ad" />
<img width="1022" height="1132" alt="image" src="https://github.com/user-attachments/assets/c6e4601d-6004-4327-956b-711287af74ae" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
