### PR TITLE
fix(ui): 1682 show leave site dialog on tab close with unsaved note

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
+# Global code owner for the entire repository
+
+* @jimmypalelil
+
 # Specify a code owner for the strr-api directory
 
 /strr-api @Jacky-Pham @JazzarKarim @thorwolpert @dimak1 @jimmypalelil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,3 @@
-# Global code owner for the entire repository
-
-* @jimmypalelil @JazzarKarim @dimak1
-
 # Specify a code owner for the strr-api directory
 
 /strr-api @Jacky-Pham @JazzarKarim @thorwolpert @dimak1 @jimmypalelil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Global code owner for the entire repository
 
-* @jimmypalelil
+* @jimmypalelil @JazzarKarim @dimak1
 
 # Specify a code owner for the strr-api directory
 

--- a/strr-examiner-web/app/composables/useExaminerNotes.ts
+++ b/strr-examiner-web/app/composables/useExaminerNotes.ts
@@ -43,6 +43,7 @@ export const useExaminerNotes = () => {
    * all Vue lifecycle hooks).
    */
   const useNoteLeaveGuard = () => {
+    // In-app navigation guard - shows the custom Discard Note modal.
     onBeforeRouteLeave((to, _from, next) => {
       if (!hasUnsavedNote.value) {
         next()
@@ -64,6 +65,17 @@ export const useExaminerNotes = () => {
         t('modal.discardNote.keepEditing')
       )
     })
+
+    // Browser tab close / refresh / external navigation guard.
+    // Browsers only allow their native "Leave site?" dialog here
+    // custom modals are not permitted in this case.
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasUnsavedNote.value) { return }
+      event.preventDefault()
+    }
+
+    window.addEventListener('beforeunload', onBeforeUnload)
+    onUnmounted(() => window.removeEventListener('beforeunload', onBeforeUnload))
   }
 
   return {

--- a/strr-examiner-web/app/composables/useExaminerNotes.ts
+++ b/strr-examiner-web/app/composables/useExaminerNotes.ts
@@ -69,7 +69,7 @@ export const useExaminerNotes = () => {
     // Browser tab close / refresh / external navigation guard.
     // Browsers only allow their native "Leave site?" dialog here
     // custom modals are not permitted in this case.
-    useEventListener(window, 'beforeunload', (event: BeforeUnloadEvent) => {
+    useEventListener(globalThis, 'beforeunload', (event: BeforeUnloadEvent) => {
       if (!hasUnsavedNote.value) { return }
       event.preventDefault()
     })

--- a/strr-examiner-web/app/composables/useExaminerNotes.ts
+++ b/strr-examiner-web/app/composables/useExaminerNotes.ts
@@ -69,13 +69,10 @@ export const useExaminerNotes = () => {
     // Browser tab close / refresh / external navigation guard.
     // Browsers only allow their native "Leave site?" dialog here
     // custom modals are not permitted in this case.
-    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+    useEventListener(window, 'beforeunload', (event: BeforeUnloadEvent) => {
       if (!hasUnsavedNote.value) { return }
       event.preventDefault()
-    }
-
-    window.addEventListener('beforeunload', onBeforeUnload)
-    onUnmounted(() => window.removeEventListener('beforeunload', onBeforeUnload))
+    })
   }
 
   return {

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1682

*Description of changes:*

**I spoke and confirmed with Elham about this.**

Due to some restrictions, browsers don't allow custom modals to be shown for tab close scenario. Because of that, I'll be showing the generic "Leave Site?" modal that are within browsers, like such:

<img width="1687" height="696" alt="image" src="https://github.com/user-attachments/assets/02acd189-f715-4963-998f-c44931c54064" />

Elham is OK with this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
