### PR TITLE
fix(strr-api): safeguard nested object lookups against AttributeError

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.27"
+version = "0.3.28"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/rental.py
+++ b/strr-api/src/strr_api/models/rental.py
@@ -138,7 +138,7 @@ class Registration(Versioned, BaseModel):
         if filter_criteria.requirements:
             query = cls._filter_by_registration_requirement(filter_criteria.requirements, query)
         if filter_criteria.local_gov:
-            query = query.join(RentalProperty).filter(
+            query = query.join(RentalProperty, Registration.id == RentalProperty.registration_id).filter(
                 RentalProperty.jurisdiction.ilike(f"%{filter_criteria.local_gov}%")
             )
         sub_status_conditions = cls._collect_sub_status_conditions(filter_criteria)

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -1090,7 +1090,7 @@ def get_document(application_number, file_key):
             raise AuthException()
         application_documents = [
             doc
-            for doc in application.application_json.get("registration").get("documents", [])
+            for doc in application.application_json.get("registration", {}).get("documents", [])
             if doc.get("fileKey") == file_key
         ]
         if not application_documents:

--- a/strr-api/src/strr_api/responses/RegistrationSerializer.py
+++ b/strr-api/src/strr_api/responses/RegistrationSerializer.py
@@ -164,14 +164,17 @@ class RegistrationSerializer:
         registration_data["header"]["applications"] = []
 
         for application in sorted_applications:
+            organization_name = None
+            if registration_json := application.application_json.get("registration"):
+                if str_requirements := registration_json.get("strRequirements"):
+                    organization_name = str_requirements.get("organizationNm")
+
             application_data = {
                 "applicationNumber": application.application_number,
                 "applicationDateTime": application.application_date.isoformat(),
                 "applicationType": application.type,
                 "applicationStatus": application.status,
-                "organizationName": application.application_json.get("registration")
-                .get("strRequirements", {})
-                .get("organizationNm"),
+                "organizationName": organization_name,
             }
             application_data["assignee"] = cls._get_user_info(application.reviewer_id, application.reviewer)
             application_data["decider"] = cls._get_user_info(application.decider_id, application.decider)
@@ -521,4 +524,6 @@ class RegistrationSerializer:
             return None
 
         latest_application = sorted(applications, key=lambda app: app.application_date, reverse=True)[0]
+        if not latest_application.application_json:
+            return None
         return latest_application.application_json.get("registration", {}).get("strRequirements", {})

--- a/strr-api/src/strr_api/services/application_service.py
+++ b/strr-api/src/strr_api/services/application_service.py
@@ -127,7 +127,7 @@ class ApplicationService:
         application_type = request_json.get("header", {}).get("applicationType")
         if not application:
             application = Application()
-            application.registration_type = request_json.get("registration").get("registrationType")
+            application.registration_type = request_json.get("registration", {}).get("registrationType")
             application.application_number = Application.generate_unique_application_number()
         application.payment_account = account_id
         application.submitter_id = user.id
@@ -185,7 +185,7 @@ class ApplicationService:
             return application
 
         application.invoice_id = invoice_details["id"]
-        application.payment_account = invoice_details.get("paymentAccount").get("accountId")
+        application.payment_account = invoice_details.get("paymentAccount", {}).get("accountId")
         application.payment_status_code = invoice_details.get("statusCode")
 
         if (
@@ -411,7 +411,11 @@ class ApplicationService:
     def update_document_list(application: Application, document: str) -> Application:
         """Updates the document list of an application."""
         application_json = copy.deepcopy(application.application_json)
-        application_json.get("registration").get("documents", []).append(document)
+        registration = application_json.get("registration", {})
+        if "documents" not in registration:
+            registration["documents"] = []
+        registration["documents"].append(document)
+        application_json["registration"] = registration
         application.application_json = application_json
         application.save()
         return application

--- a/strr-api/src/strr_api/services/payment_service.py
+++ b/strr-api/src/strr_api/services/payment_service.py
@@ -159,11 +159,11 @@ class PayService:
         return payload
 
     def _get_platform_filing_type(self, registration_json, application_type):
-        cpbc_number = registration_json.get("businessDetails").get("consumerProtectionBCLicenceNumber")
+        cpbc_number = registration_json.get("businessDetails", {}).get("consumerProtectionBCLicenceNumber")
         if cpbc_number and (not cpbc_number.isspace()):
             filing_type = PLATFORM_FEE_WAIVED if application_type == "registration" else PLATFORM_RENEWAL_WAIVED
             self.app.logger.info("Filing type for Platform application - CPBC::" + filing_type)
-        elif registration_json.get("platformDetails").get("listingSize") == "THOUSAND_AND_ABOVE":
+        elif registration_json.get("platformDetails", {}).get("listingSize") == "THOUSAND_AND_ABOVE":
             filing_type = PLATFORM_LARGE_USER_BASE if application_type == "registration" else PLATFORM_RENEWAL_LARGE
             self.app.logger.info("Filing type for Platform application - Thousand and above::" + filing_type)
         else:
@@ -174,8 +174,9 @@ class PayService:
     def _get_host_filing_type(self, registration_json, application_type="registration"):
         quantity = 1
         filing_type = None
-        rental_unit_setup_option = registration_json.get("unitDetails").get("rentalUnitSetupOption")
-        property_type = registration_json.get("unitDetails").get("propertyType")
+        unit_details = registration_json.get("unitDetails", {})
+        rental_unit_setup_option = unit_details.get("rentalUnitSetupOption")
+        property_type = unit_details.get("propertyType")
         if application_type == "registration":
             if rental_unit_setup_option:
                 if property_type == PropertyType.BED_AND_BREAKFAST.name:
@@ -195,13 +196,12 @@ class PayService:
         return filing_type, quantity
 
     def _get_host_registration_fee_using_legacy_option(self, filing_type, quantity, registration_json):
-        rental_unit_space_type = registration_json.get("unitDetails").get("rentalUnitSpaceType")
-        is_rental_unit_on_principal_residence = registration_json.get("unitDetails").get(
-            "isUnitOnPrincipalResidenceProperty"
-        )
+        unit_details = registration_json.get("unitDetails", {})
+        rental_unit_space_type = unit_details.get("rentalUnitSpaceType")
+        is_rental_unit_on_principal_residence = unit_details.get("isUnitOnPrincipalResidenceProperty")
         if rental_unit_space_type == RentalProperty.RentalUnitSpaceType.ENTIRE_HOME:
             if is_rental_unit_on_principal_residence:
-                host_residence = registration_json.get("unitDetails").get("hostResidence")
+                host_residence = unit_details.get("hostResidence")
                 if host_residence == RentalProperty.HostResidence.SAME_UNIT:
                     filing_type = HOST_REGISTRATION_FEE_1
                 elif host_residence == RentalProperty.HostResidence.ANOTHER_UNIT:
@@ -210,11 +210,11 @@ class PayService:
                 filing_type = HOST_REGISTRATION_FEE_2
         elif rental_unit_space_type == RentalProperty.RentalUnitSpaceType.SHARED_ACCOMMODATION:
             filing_type = HOST_REGISTRATION_FEE_1
-            property_type = registration_json.get("unitDetails").get("propertyType")
+            property_type = unit_details.get("propertyType")
             if property_type in {PropertyType.BED_AND_BREAKFAST.name, PropertyType.RECREATIONAL.name}:
                 filing_type = HOST_REGISTRATION_FEE_3
-            elif registration_json.get("unitDetails").get("numberOfRoomsForRent"):
-                quantity = registration_json.get("unitDetails").get("numberOfRoomsForRent")
+            elif unit_details.get("numberOfRoomsForRent"):
+                quantity = unit_details.get("numberOfRoomsForRent")
         return filing_type, quantity
 
     def _get_renewal_filing_type_for_host(self, rental_unit_setup_option, property_type):

--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -322,8 +322,8 @@ class RegistrationService:
                 postal_code=mailing_address.get("postalCode"),
                 location_description=mailing_address.get("locationDescription"),
             ),
-            brand_name=strata_hotel_details_dict.get("brand").get("name"),
-            website=strata_hotel_details_dict.get("brand").get("website"),
+            brand_name=strata_hotel_details_dict.get("brand", {}).get("name"),
+            website=strata_hotel_details_dict.get("brand", {}).get("website"),
             number_of_units=strata_hotel_details_dict.get("numberOfUnits"),
             category=strata_hotel_details_dict.get("category"),
             unit_listings=strata_hotel_details_dict.get("unitListings"),
@@ -850,9 +850,9 @@ class RegistrationService:
     def find_all_by_host_sin(sin: str, count_only=False) -> list[Registration] | int:
         """Return all registrations with the given host SIN."""
         query = (
-            Registration.query.join(RentalProperty)
-            .join(PropertyContact)
-            .join(Contact)
+            Registration.query.join(RentalProperty, Registration.id == RentalProperty.registration_id)
+            .join(PropertyContact, RentalProperty.id == PropertyContact.property_id)
+            .join(Contact, PropertyContact.contact_id == Contact.id)
             .filter(Registration.status.in_([RegistrationStatus.ACTIVE, RegistrationStatus.SUSPENDED]))
             .filter(PropertyContact.is_primary)
             .filter(PropertyContact.contact_type == PropertyContact.ContactType.INDIVIDUAL)

--- a/strr-api/src/strr_api/utils/user_context.py
+++ b/strr-api/src/strr_api/utils/user_context.py
@@ -37,9 +37,7 @@ class UserContext:  # pylint: disable=too-many-instance-attributes
         self._first_name: str = token_info.get("firstname", None)
         self._last_name: str = token_info.get("lastname", None)
         self._bearer_token: str = _get_token()
-        self._roles: list = (
-            token_info.get("realm_access", None).get("roles", []) if "realm_access" in token_info else []
-        )
+        self._roles: list = token_info.get("realm_access", {}).get("roles", [])
         self._sub: str = token_info.get("sub", None)
         self._login_source: str = token_info.get("loginSource", None)
         self._name: str = f"{token_info.get('firstname', None)} {token_info.get('lastname', None)}"


### PR DESCRIPTION


*Issue:* 

- bcgov/strr/issues/1718

*Description of changes:*
- Replace chained `.get().get()` calls with safe fallbacks to prevent AttributeError exceptions when parent keys are missing from dict payloads.
- Resolve AmbiguousForeignKeysError by specifying join conditions

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
