### PR TITLE
fix(UIs): 1649 update form layouts and CTA buttons

### DIFF
--- a/strr-base-web/app/components/connect/ButtonControl.vue
+++ b/strr-base-web/app/components/connect/ButtonControl.vue
@@ -8,45 +8,50 @@ const rightButtons = computed(() => buttonControl.value?.rightButtons || [])
 <template>
   <div class="bg-white py-10" data-testid="button-control">
     <div class="app-inner-container">
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div>
-          <div class="flex justify-center gap-4 md:justify-start">
-            <UButton
-              v-for="(button, i) in leftButtons"
-              :key="'left-button-' + i"
-              class="max-w-fit px-7 py-3"
-              :color="button.color || 'primary'"
-              :icon="button.icon || ''"
-              :label="button.label"
-              :trailing="button.trailing || false"
-              :variant="button.variant || 'solid'"
-              :disabled="button.disabled || false"
-              :loading="button.loading || false"
-              data-testid="button-control-left-button"
-              @click="button.action()"
-            />
+      <div class="flex flex-col lg:flex-row">
+        <div class="grow">
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <div class="flex justify-center gap-4 md:justify-start">
+                <UButton
+                  v-for="(button, i) in leftButtons"
+                  :key="'left-button-' + i"
+                  class="max-w-fit px-7 py-3"
+                  :color="button.color || 'primary'"
+                  :icon="button.icon || ''"
+                  :label="button.label"
+                  :trailing="button.trailing || false"
+                  :variant="button.variant || 'solid'"
+                  :disabled="button.disabled || false"
+                  :loading="button.loading || false"
+                  data-testid="button-control-left-button"
+                  @click="button.action()"
+                />
+              </div>
+            </div>
+            <div>
+              <div class="flex justify-center gap-4 md:justify-end">
+                <UButton
+                  v-for="(button, i) in rightButtons"
+                  :key="'right-button-' + i"
+                  class="max-w-fit px-7 py-3"
+                  :class="button.class"
+                  block
+                  :color="button.color || 'primary'"
+                  :disabled="button.disabled || false"
+                  :icon="button.icon || ''"
+                  :label="button.label"
+                  :loading="button.loading || false"
+                  :trailing="button.trailing || false"
+                  :variant="button.variant || 'solid'"
+                  data-testid="button-control-right-button"
+                  @click="button.action()"
+                />
+              </div>
+            </div>
           </div>
         </div>
-        <div>
-          <div class="flex justify-center gap-4 md:justify-end">
-            <UButton
-              v-for="(button, i) in rightButtons"
-              :key="'right-button-' + i"
-              class="max-w-fit px-7 py-3"
-              :class="button.class"
-              block
-              :color="button.color || 'primary'"
-              :disabled="button.disabled || false"
-              :icon="button.icon || ''"
-              :label="button.label"
-              :loading="button.loading || false"
-              :trailing="button.trailing || false"
-              :variant="button.variant || 'solid'"
-              data-testid="button-control-right-button"
-              @click="button.action()"
-            />
-          </div>
-        </div>
+        <div class="hidden lg:block lg:w-[340px] lg:px-5" />
       </div>
     </div>
   </div>

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "engines": {
     "node": ">=24"
   },

--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -289,7 +289,7 @@ function updateButtonControl () {
   buttons.push({
     action: isLastStep ? handleSubmit : () => stepperRef.value?.setNextStep(),
     icon: 'i-mdi-chevron-right',
-    label: isLastStep ? t('btn.proceedToPay') : t(`strr.step.description.${activeStepIndex.value + 1}`),
+    label: isLastStep ? t('btn.proceedToPay') : t('btn.next'),
     trailing: true
   })
 

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "engines": {
     "node": ">=24"
   },

--- a/strr-platform-web/app/pages/platform/application.vue
+++ b/strr-platform-web/app/pages/platform/application.vue
@@ -246,7 +246,7 @@ watch(activeStepIndex, (val) => {
   buttons.push({
     action: isLastStep ? handlePlatformSubmit : () => stepperRef.value?.setNextStep(),
     icon: 'i-mdi-chevron-right',
-    label: isLastStep ? t('btn.submitAndPay') : t(`strr.step.description.${val + 1}`),
+    label: isLastStep ? t('btn.submitAndPay') : t('btn.next'),
     trailing: true
   })
 

--- a/strr-platform-web/package.json
+++ b/strr-platform-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-platform-web",
   "private": true,
   "type": "module",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "engines": {
     "node": ">=24"
   },

--- a/strr-strata-web/app/pages/strata-hotel/application.vue
+++ b/strr-strata-web/app/pages/strata-hotel/application.vue
@@ -209,7 +209,7 @@ watch(activeStepIndex, (val) => {
   buttons.push({
     action: isLastStep ? handleStrataSubmit : () => stepperRef.value?.setNextStep(),
     icon: 'i-mdi-chevron-right',
-    label: isLastStep ? t('btn.submitAndPay') : t(`strr.step.description.${val + 1}`),
+    label: isLastStep ? t('btn.submitAndPay') : t('btn.next'),
     trailing: true
   })
 

--- a/strr-strata-web/package.json
+++ b/strr-strata-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-strata-web",
   "private": true,
   "type": "module",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- bcgov/strr/issues/1649

*Description of changes:*
Previously on step 1:
<img width="1847" height="1221" alt="prev step 1" src="https://github.com/user-attachments/assets/edcc83cc-fa39-4141-b494-2f7f02663c0b" />

Now, step 1 looks like this:
<img width="1787" height="1230" alt="after step 1" src="https://github.com/user-attachments/assets/a0f5180c-1ad2-4ccf-9a59-8c5818edd016" />

Previously on step 2:
<img width="1757" height="1231" alt="prev step 2" src="https://github.com/user-attachments/assets/7e6d4a7d-1afa-45ee-8ee5-d0298da30df8" />

Now on step 2:
<img width="1745" height="1222" alt="after step 2" src="https://github.com/user-attachments/assets/15eb66af-d194-45f3-829f-a3000fd059c5" />

So, changed buttons to Next + aligned with contained above instead with the fee widget. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
