### PR TITLE
build(pnpm): approve build scripts for native deps

### DIFF
--- a/strr-examiner-web/pnpm-workspace.yaml
+++ b/strr-examiner-web/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/strr-platform-web/pnpm-workspace.yaml
+++ b/strr-platform-web/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true

--- a/strr-strata-web/pnpm-workspace.yaml
+++ b/strr-strata-web/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION


*Issue:* N/A

*Description of changes:*
I noticed some CI builds were failing (see link). therefore the below changes were required

Allow post-install build scripts for @parcel/watcher, esbuild, sharp, and unrs-resolver in the examiner app to resolve ERR_PNPM_IGNORED_BUILDS failure in Cloud Build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
