### PR TITLE
fix(ui): footer cta buttons layout

### DIFF
--- a/strr-base-web/.eslintrc
+++ b/strr-base-web/.eslintrc
@@ -24,7 +24,8 @@
         "connect-date-picker",
         "connect-date-picker__err",
         "prose-bcGov",
-        "max-w-bcGovInput"
+        "max-w-bcGovInput",
+        "button-control"
       ]
     }],
     "no-use-before-define": "off"

--- a/strr-base-web/app/components/connect/ButtonControl.vue
+++ b/strr-base-web/app/components/connect/ButtonControl.vue
@@ -6,52 +6,43 @@ const rightButtons = computed(() => buttonControl.value?.rightButtons || [])
 
 </script>
 <template>
-  <div class="bg-white py-10" data-testid="button-control">
+  <div class="button-control bg-white py-10" data-testid="button-control">
     <div class="app-inner-container">
-      <div class="flex flex-col lg:flex-row">
-        <div class="grow">
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div>
-              <div class="flex justify-center gap-4 md:justify-start">
-                <UButton
-                  v-for="(button, i) in leftButtons"
-                  :key="'left-button-' + i"
-                  class="max-w-fit px-7 py-3"
-                  :color="button.color || 'primary'"
-                  :icon="button.icon || ''"
-                  :label="button.label"
-                  :trailing="button.trailing || false"
-                  :variant="button.variant || 'solid'"
-                  :disabled="button.disabled || false"
-                  :loading="button.loading || false"
-                  data-testid="button-control-left-button"
-                  @click="button.action()"
-                />
-              </div>
-            </div>
-            <div>
-              <div class="flex justify-center gap-4 md:justify-end">
-                <UButton
-                  v-for="(button, i) in rightButtons"
-                  :key="'right-button-' + i"
-                  class="max-w-fit px-7 py-3"
-                  :class="button.class"
-                  block
-                  :color="button.color || 'primary'"
-                  :disabled="button.disabled || false"
-                  :icon="button.icon || ''"
-                  :label="button.label"
-                  :loading="button.loading || false"
-                  :trailing="button.trailing || false"
-                  :variant="button.variant || 'solid'"
-                  data-testid="button-control-right-button"
-                  @click="button.action()"
-                />
-              </div>
-            </div>
-          </div>
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div class="flex justify-center gap-4 md:justify-start">
+          <UButton
+            v-for="(button, i) in leftButtons"
+            :key="'left-button-' + i"
+            class="max-w-fit px-7 py-3"
+            :color="button.color || 'primary'"
+            :icon="button.icon || ''"
+            :label="button.label"
+            :trailing="button.trailing || false"
+            :variant="button.variant || 'solid'"
+            :disabled="button.disabled || false"
+            :loading="button.loading || false"
+            data-testid="button-control-left-button"
+            @click="button.action()"
+          />
         </div>
-        <div class="hidden lg:block lg:w-[340px] lg:px-5" />
+        <div class="flex justify-center gap-4 md:justify-end">
+          <UButton
+            v-for="(button, i) in rightButtons"
+            :key="'right-button-' + i"
+            class="max-w-fit px-7 py-3"
+            :class="button.class"
+            block
+            :color="button.color || 'primary'"
+            :disabled="button.disabled || false"
+            :icon="button.icon || ''"
+            :label="button.label"
+            :loading="button.loading || false"
+            :trailing="button.trailing || false"
+            :variant="button.variant || 'solid'"
+            data-testid="button-control-right-button"
+            @click="button.action()"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/strr-base-web/package.json
+++ b/strr-base-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-base-web",
   "private": true,
   "type": "module",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "engines": {
     "node": ">=24"
   },

--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -440,3 +440,15 @@ setOnBeforeSessionExpired(() => {
     </div>
   </div>
 </template>
+
+<style>
+@media (min-width: 1024px) {
+  .button-control .app-inner-container > div::after {
+    content: '';
+    display: block;
+    width: 340px;
+    padding: 0 1.25rem;
+    flex-shrink: 0;
+  }
+}
+</style>

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- Recent changes to the button control layout broke the Examiner Details page, where the buttons would have empty space on the right
- 
<img width="2830" height="1454" alt="Screenshot 2026-06-30 at 10 52 56" src="https://github.com/user-attachments/assets/c31b423f-0f9c-4aea-9ff8-82d61b0429ef" />


*Description of changes:*
- fix layout using css only, and revert previous change to remove the empty div block

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
