### PR TITLE
fix(ui): host cta buttons layout

### DIFF
--- a/strr-host-pm-web/app/pages/application.vue
+++ b/strr-host-pm-web/app/pages/application.vue
@@ -443,12 +443,8 @@ setOnBeforeSessionExpired(() => {
 
 <style>
 @media (min-width: 1024px) {
-  .button-control .app-inner-container > div::after {
-    content: '';
-    display: block;
-    width: 340px;
-    padding: 0 1.25rem;
-    flex-shrink: 0;
+  .button-control .app-inner-container > div {
+    padding-right: 340px;
   }
 }
 </style>

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
*Issue:*

- CTA layout was broken in the Host app

*Description of changes:*
- Fix CTA layout in Host app only (add padding to align Back/Next buttons with top form)

<img width="3164" height="1022" alt="Screenshot 2026-07-02 at 11 52 27" src="https://github.com/user-attachments/assets/d7237d70-fe67-4f6d-b686-1da10c9e5fd1" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
