### PR TITLE
feat(api)!: remove validUntil from permit validation responses

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "STRR API: Flask debug",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "flask",
+      "args": [
+        "run",
+        "--port",
+        "8000",
+        "--no-reload",
+        "--debugger"
+      ],
+      "env": {
+        "FLASK_DEBUG": "1"
+      },
+      "cwd": "${workspaceFolder}/strr-api",
+      "jinja": true,
+      "justMyCode": true
+    }
+  ]
+}

--- a/docs/oas/platform.yaml
+++ b/docs/oas/platform.yaml
@@ -2,21 +2,21 @@ openapi: 3.0.0
 x-stoplight:
   id: 1d3quzhv06iyi
 info:
-  title: BC Short-Term Rental Registry Validation API
-  version: '0.1'
+  title: BC Short Term Rental Registry Validation API
+  version: '0.8'
   termsOfService: 'https://developer.connect.gov.bc.ca/shared/api-terms-of-use.pdf'
   contact:
     url: 'https://www2.gov.bc.ca/gov/content/housing-tenancy/short-term-rentals'
     name: Developer Engagement
     email: thor@daxiom.com
-  description: This service is used to validate the registration and key elements of listing details against Short-Term Rental Registrations and annual Permits.
+  description: This service is used to validate the registration and key elements of listing details against Short Term Rental Registrations and annual Permits.
   license:
     name: bsd-3-clause
     url: 'https://opensource.org/license/bsd-3-clause'
 servers:
-  - url: 'https://bcregistry-sandbox.apigee.net/v1'
+  - url: 'https://sandbox.api.connect.gov.bc.ca/strr/v1'
     description: Test
-  - url: 'https://bcregistry-prod.apigee.net/v1'
+  - url: 'https://api.connect.gov.bc.ca/strr/v1'
     description: Production
 paths:
   '/permits/:validatePermit':
@@ -28,7 +28,6 @@ paths:
           description: |-
             {
               "identifier": "H1234567",
-              "validUntil": "2025-08-24",
               "status": "ACTIVE",
               "address": {
                 "unitNumber": "101a",
@@ -47,7 +46,6 @@ paths:
                 x-examples:
                   Example 1:
                     identifier: string
-                    validUntil: '2019-08-24'
                     status: ACTIVE
                     address:
                       unitNumber: 101a
@@ -66,8 +64,6 @@ paths:
                   - address
                 properties:
                   identifier:
-                    type: string
-                  validUntil:
                     type: string
                   status:
                     type: string
@@ -106,7 +102,6 @@ paths:
                 Valid Permit:
                   value:
                     identifier: H1234567
-                    validUntil: '2025-08-24'
                     status: ACTIVE
                     address:
                       unitNumber: 101a
@@ -180,6 +175,7 @@ paths:
                   properties:
                     unitNumber:
                       type: string
+                      description: Unit number must be included if it was included in the Registration.
                     streetNumber:
                       type: string
                     streetName:
@@ -208,6 +204,8 @@ paths:
       description: Validate a property has a valid permit.
       x-stoplight:
         id: 97n85oxv4riix
+      parameters:
+        - $ref: '#/components/parameters/Account-Id'
     parameters: []
   '/address/:requirements':
     post:
@@ -256,6 +254,9 @@ paths:
                   required:
                     - streetNumber
                     - streetName
+                    - country
+                    - postalCode
+                    - province
                     - city
                   properties:
                     unitNumber:
@@ -283,10 +284,12 @@ paths:
                     postalCode: H0H0H0
                     province: BC
                     city: Test city
-        description: Post the address to get the short-term rental requirements.
-      description: Post the address to get the short-term rental requirements for that address.
+        description: Post the address to get the short term rental requirements.
+      description: Post the address to get the short term rental requirements for that address.
       x-stoplight:
         id: 4sqp07r1juk5x
+      parameters:
+        - $ref: '#/components/parameters/Account-Id'
     parameters: []
   '/permits/:batchValidate':
     post:
@@ -332,10 +335,10 @@ paths:
               properties:
                 control:
                   type: object
+                  description: Directives for the submission.
                   required:
                     - count
                     - callBackUrl
-                  description: Directives for the submission.
                   properties:
                     count:
                       type: integer
@@ -360,11 +363,10 @@ paths:
                         required:
                           - streetNumber
                           - postalCode
-                          - streetName
-                          - city
                         properties:
                           unitNumber:
                             type: string
+                            description: Unit number must be included if it was included in the Registration.
                           streetNumber:
                             type: string
                           postalCode:
@@ -421,6 +423,8 @@ paths:
                       examples:
                         ok:
                           value: ok
+      parameters:
+        - $ref: '#/components/parameters/Account-Id'
     parameters: []
 components:
   schemas:
@@ -515,7 +519,6 @@ components:
       x-examples:
         Validation successful:
           identifier: H1234567
-          validUntil: '2019-08-24'
           status: ACTIVE
           address:
             unitNumber: 101a
@@ -556,10 +559,6 @@ components:
         identifier:
           type: string
           description: The registration number of the Permit
-        validUntil:
-          type: string
-          format: date
-          description: The date when the permit is no longer valid.
         status:
           enum:
             - ACTIVE
@@ -607,7 +606,7 @@ components:
       title: addressRequirements
       x-stoplight:
         id: n0699fszvtnml
-      description: Short-term rental requirements for an address.
+      description: Short term rental requirements for an address.
       type: object
       x-examples:
         Example:
@@ -641,12 +640,20 @@ components:
     jwt:
       type: openIdConnect
       openIdConnectUrl: 'https://AUTH_PROVIDER/.well-known/openid-configuration'
+  parameters:
+    Account-Id:
+      name: Account-Id
+      in: header
+      required: true
+      schema:
+        type: string
+      description: The account that the user is operating on behalf of.
 tags:
   - name: Draft
     description: The release state
-  - name: Short-Term Rental
-    description: 'Short-term rentals are defined under the Act as accommodations provided to members of the public in a host''s property, in exchange for money, for a period of less than 90 consecutive days.'
+  - name: Short Term Rental
+    description: "Short-term rentals are defined under the Act as accommodations provided to members of the public in a host's property, in exchange for money, for a period of less than 90 consecutive days."
   - name: Verification
-    description: The process of establishing the validity of a host's property as a qualified Short-Term Rental
+    description: The process of establishing the validity of a host's property as a qualified Short Term Rental
 security:
   - api_key: []

--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.28"
+version = "0.3.29"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/services/validation_service.py
+++ b/strr-api/src/strr_api/services/validation_service.py
@@ -46,7 +46,6 @@ from strr_api.models import BulkValidation, RealTimeValidation, Registration
 from strr_api.schemas.utils import validate
 from strr_api.services.gcp_storage_service import GCPStorageService
 from strr_api.services.registration_service import RegistrationService
-from strr_api.utils.date_util import DateUtil
 
 
 class ValidationService:
@@ -182,7 +181,6 @@ class ValidationService:
             status_code = HTTPStatus.BAD_REQUEST
         else:
             response["status"] = registration.status.name
-            response["validUntil"] = DateUtil.as_legislation_timezone(registration.expiry_date).strftime("%Y-%m-%d")
         return response, status_code
 
     @classmethod

--- a/strr-api/tests/integration/resources/test_validation_api.py
+++ b/strr-api/tests/integration/resources/test_validation_api.py
@@ -44,7 +44,6 @@ def test_validate_permit_legacy_real_service_ok(client, headers_public_user, ser
     assert_status(rv, HTTPStatus.OK)
     data = rv.get_json()
     assert data.get("status") == "ACTIVE"
-    assert "validUntil" in data
 
 
 def test_validate_permit_v1_real_service_ok(client, headers_public_user, serializable_host_registration):

--- a/strr-api/tests/unit/resources/test_validation.py
+++ b/strr-api/tests/unit/resources/test_validation.py
@@ -72,7 +72,6 @@ def test_permit_exists(app, session, client, jwt):
             response_json = rv.json
 
             assert response_json.get("status")
-            assert response_json.get("validUntil")
 
 
 @patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)

--- a/strr-host-pm-web/tests/stress/validate-permits.js
+++ b/strr-host-pm-web/tests/stress/validate-permits.js
@@ -118,9 +118,7 @@ export default function (data) {
         'streetNumber is correct': b => b?.address?.streetNumber === streetNumber,
         'postalCode is correct': b => b?.address?.postalCode === postalCode,
         // only check if unitNumber exits in the registration
-        ...(unitNumber && { 'unitNumber is correct': b => b?.address?.unitNumber === unitNumber }),
-        // validUntil exists only for ACTIVE registrations
-        ...(REGISTRATIONS_STATUS === 'ACTIVE' && { 'validUntil exists': b => !!b?.validUntil })
+        ...(unitNumber && { 'unitNumber is correct': b => b?.address?.unitNumber === unitNumber })
       })
     })
 


### PR DESCRIPTION


*Issue:*

- JIRA: [REGBACKLOG-126](https://hous-hpb.atlassian.net/browse/REGBACKLOG-126)

*Description of changes:*
Remove validUntil from permit validation API response payloads and OpenAPI docs.

Update API tests and host stress checks to match the new response contract.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
