### PR TITLE
feat(interaction-update-job): add github action for cd job

### DIFF
--- a/.github/workflows/strr-interaction-updates-job-cd.yaml
+++ b/.github/workflows/strr-interaction-updates-job-cd.yaml
@@ -1,0 +1,42 @@
+name: STRR INTERACTION UPDATES JOB CD
+
+on:
+  push:
+    branches:
+      - main
+      - feature*
+      - hotfix*
+      - release*
+    paths:
+      - 'jobs/interactions-update/**'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deploy To'
+        required: true
+        type: choice
+        options:
+          - 'dev'
+          - 'test'
+          - 'uat'
+          - 'sandbox'
+          - 'prod'
+      redeploy:
+        description: 'Redeploy Application'
+        required: true
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+jobs:
+  strr-interaction-updates-job-cd:
+    uses: bcgov/bcregistry-sre/.github/workflows/backend-job-cd.yaml@main
+    with:
+      target: ${{ inputs.target }}
+      app_name: 'strr-interactions-update'
+      working_directory: './jobs/interactions-update'
+      redeploy: ${{ inputs.redeploy }}
+    secrets:
+      WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
*Issue:*
- JIRA: https://hous-hpb.atlassian.net/browse/REGBACKLOG-75

*Description of changes:*
new Github action workflow to deploy the interactions update job


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
