### PR TITLE
feat(strr-api): include email interactions in events payload

### DIFF
--- a/strr-api/pyproject.toml
+++ b/strr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strr-api"
-version = "0.3.29"
+version = "0.3.30"
 description = ""
 authors = ["thorwolpert <thor@wolpert.ca>"]
 license = "BSD 3-Clause"

--- a/strr-api/src/strr_api/models/interactions.py
+++ b/strr-api/src/strr_api/models/interactions.py
@@ -127,3 +127,13 @@ class CustomerInteraction(Versioned, SimpleBaseModel):
     ):
         """Return an Interation if it exists."""
         return cls.query.filter(cls.interaction_uuid == interaction_uuid).one_or_none()
+
+    @classmethod
+    def fetch_application_interactions(cls, application_id: int) -> list[CustomerInteraction]:
+        """Return interactions for an application sorted by create time."""
+        return cls.query.filter(cls.application_id == application_id).order_by(cls.created_at).all()
+
+    @classmethod
+    def fetch_registration_interactions(cls, registration_id: int) -> list[CustomerInteraction]:
+        """Return interactions for a registration sorted by create time."""
+        return cls.query.filter(cls.registration_id == registration_id).order_by(cls.created_at).all()

--- a/strr-api/src/strr_api/resources/application.py
+++ b/strr-api/src/strr_api/resources/application.py
@@ -68,6 +68,7 @@ from strr_api.services import (
     ApprovalService,
     DocumentService,
     EventsService,
+    InteractionService,
     LtsaService,
     RegistrationService,
     UserService,
@@ -622,23 +623,31 @@ def get_application_events(application_number):
     try:
         account_id = request.headers.get("Account-Id", None)
         applicant_visible_events_only = True
+        include_interaction_delivery = request.args.get("include_interaction_delivery", "false").lower() == "true"
         UserService.get_or_create_user_by_jwt(g.jwt_oidc_token_info)
         if UserService.is_strr_staff_or_system():
             account_id = None
             applicant_visible_events_only = False
         application = ApplicationService.get_application(application_number=application_number, account_id=account_id)
-        application_id = application.id
         if not application:
             return error_response(HTTPStatus.NOT_FOUND, ErrorMessage.APPLICATION_NOT_FOUND.value)
+        application_id = application.id
 
         records = EventsService.fetch_application_events(application_id, applicant_visible_events_only)
+        response_events = [Events.from_db(record).model_dump(mode="json") for record in records]
+        if include_interaction_delivery:
+            response_events.extend(InteractionService.filing_history_rows_for_application(application_id))
+            response_events.sort(key=lambda event: event.get("createdDate") or "")
         return (
-            jsonify([Events.from_db(record).model_dump(mode="json") for record in records]),
+            jsonify(response_events),
             HTTPStatus.OK,
         )
     except Exception as exception:
-        logger.error(exception)
-        return error_response("ErrorMessage.PROCESSING_ERROR.value", HTTPStatus.INTERNAL_SERVER_ERROR)
+        logger.exception(exception)
+        return error_response(
+            message=ErrorMessage.PROCESSING_ERROR.value,
+            http_status=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
 
 
 @bp.route("/<application_number>/notes", methods=("GET",))

--- a/strr-api/src/strr_api/resources/registrations.py
+++ b/strr-api/src/strr_api/resources/registrations.py
@@ -70,7 +70,14 @@ from strr_api.models import Application, Document, User
 from strr_api.models.dataclass import RegistrationSearch
 from strr_api.responses import Events
 from strr_api.schemas.utils import validate
-from strr_api.services import DocumentService, EventsService, RegistrationService, SnapshotService, UserService
+from strr_api.services import (
+    DocumentService,
+    EventsService,
+    InteractionService,
+    RegistrationService,
+    SnapshotService,
+    UserService,
+)
 from strr_api.services.examiner_note_service import ExaminerNoteNotAllowedException, ExaminerNoteService
 from strr_api.services.registration_service import (
     REGISTRATION_STATES_STAFF_ACTION,
@@ -456,6 +463,7 @@ def get_registration_events(registration_id):
     try:
         account_id = request.headers.get("Account-Id")
         user = User.get_or_create_user_by_jwt(g.jwt_oidc_token_info)
+        include_interaction_delivery = request.args.get("include_interaction_delivery", "false").lower() == "true"
         if not user:
             raise AuthException()
 
@@ -465,8 +473,12 @@ def get_registration_events(registration_id):
             raise AuthException()
 
         records = EventsService.fetch_registration_events(registration_id, only_show_visible_to_user)
+        response_events = [Events.from_db(record).model_dump(mode="json") for record in records]
+        if include_interaction_delivery:
+            response_events.extend(InteractionService.filing_history_rows_for_registration(registration_id))
+            response_events.sort(key=lambda event: event.get("createdDate") or "")
         return (
-            jsonify([Events.from_db(record).model_dump(mode="json") for record in records]),
+            jsonify(response_events),
             HTTPStatus.OK,
         )
     except AuthException as auth_exception:

--- a/strr-api/src/strr_api/services/interaction.py
+++ b/strr-api/src/strr_api/services/interaction.py
@@ -64,11 +64,129 @@ class EmailInfo:
 class InteractionService:
     """Service to handle interaction logic."""
 
+    DELIVERY_EVENT_NAME_BY_STATUS = {
+        InteractionStatus.QUEUED.value: "EMAIL_QUEUED",
+        InteractionStatus.SENT.value: "EMAIL_SENT",
+        InteractionStatus.DELIVERED.value: "EMAIL_DELIVERED",
+        InteractionStatus.FAILED.value: "EMAIL_FAILED",
+        InteractionStatus.OPENED.value: "EMAIL_OPENED",
+    }
+
+    RECIPIENT_DELIVERY_STATUS_MAP = {
+        "CREATED": "CREATED",
+        "SENDING": "IN_TRANSIT",
+        "SENT": "SENT",
+        "PENDING": "PENDING",
+        "DELIVERED": "DELIVERED",
+        "PENDING_VIRUS_CHECK": "PENDING",
+        "PERMANENT_FAILURE": "FAILED",
+        "TEMPORARY_FAILURE": "FAILED",
+        "TECHNICAL_FAILURE": "FAILED",
+        "VIRUS_SCAN_FAILED": "FAILED",
+        "FAILED": "FAILED",
+        "FAILURE": "FAILED",
+    }
+
     email_event_mapper = {
         "HOST_RENEWAL_REMINDER": Events.EventName.RENEWAL_REMINDER_SENT,
         "STRATA_HOTEL_RENEWAL_REMINDER": Events.EventName.RENEWAL_REMINDER_SENT,
         "PLATFORM_RENEWAL_REMINDER": Events.EventName.RENEWAL_REMINDER_SENT,
     }
+
+    @classmethod
+    def filing_history_rows_for_application(cls, application_id: int) -> list[dict]:
+        """Build filing-history rows from interaction delivery metadata for an application."""
+        interactions = CustomerInteraction.fetch_application_interactions(application_id)
+        return cls._build_delivery_rows(interactions, Events.EventType.APPLICATION.value)
+
+    @classmethod
+    def filing_history_rows_for_registration(cls, registration_id: int) -> list[dict]:
+        """Build filing-history rows from interaction delivery metadata for a registration."""
+        interactions = CustomerInteraction.fetch_registration_interactions(registration_id)
+        return cls._build_delivery_rows(interactions, Events.EventType.REGISTRATION.value)
+
+    @classmethod
+    def _build_delivery_rows(cls, interactions: list[CustomerInteraction], event_type: str) -> list[dict]:
+        rows: list[dict] = []
+        for interaction in interactions:
+            if row := cls._build_delivery_row(interaction, event_type):
+                rows.append(row)
+        return rows
+
+    @staticmethod
+    def _message_for_delivery_status(channel: str, status: str) -> str:
+        """Create a readable filing-history message for interaction delivery rows."""
+        channel_label = channel.capitalize()
+        status_label = status.capitalize()
+        return f"{channel_label} delivery status updated ({status_label})."
+
+    @classmethod
+    def _event_name_for_status(cls, status: str) -> str:
+        """Map persisted interaction status to filing-history event name."""
+        return cls.DELIVERY_EVENT_NAME_BY_STATUS.get(status, "EMAIL_SENT")
+
+    @classmethod
+    def _map_recipient_delivery_status(cls, status: str | None) -> str:
+        """Map provider delivery outcomes to internal recipient statuses."""
+        normalized = str(status).strip().upper().replace("-", "_") if status else ""
+        return cls.RECIPIENT_DELIVERY_STATUS_MAP.get(normalized, "UNKNOWN")
+
+    @staticmethod
+    def _normalize_recipient_statuses(recipient_statuses: dict) -> list[dict]:
+        """Normalize stored recipient statuses to API response array shape."""
+        normalized = []
+        for notify_reference, payload in recipient_statuses.items():
+            row = payload if isinstance(payload, dict) else {}
+            provider_status = row.get("status")
+            normalized.append(
+                {
+                    "email_address": row.get("email_address"),
+                    "failure_reason": row.get("failure_reason"),
+                    "failure_type": row.get("failure_type"),
+                    "notify_reference": row.get("notify_reference") or str(notify_reference),
+                    "provider_reference": row.get("provider_reference"),
+                    "request_date": row.get("request_date"),
+                    "sent_date": row.get("sent_date"),
+                    "status": InteractionService._map_recipient_delivery_status(provider_status),
+                    "provider_status": provider_status,
+                }
+            )
+        return normalized
+
+    @classmethod
+    def _build_delivery_row(cls, interaction: CustomerInteraction, event_type: str) -> dict | None:
+        """Convert a single interaction row into filing-history event shape."""
+        if not isinstance(interaction.meta_data, dict):
+            return None
+
+        notify_delivery = interaction.meta_data.get("notify_delivery")
+        if not isinstance(notify_delivery, dict):
+            return None
+
+        recipient_statuses = notify_delivery.get("recipient_statuses")
+        if not isinstance(recipient_statuses, dict) or not recipient_statuses:
+            return None
+
+        channel = interaction.channel.value if interaction.channel else ""
+        if channel != ChannelType.EMAIL.value:
+            return None
+        status = interaction.status.value if interaction.status else ""
+
+        return {
+            "eventType": event_type,
+            "eventName": cls._event_name_for_status(status),
+            "message": cls._message_for_delivery_status(channel, status),
+            "createdDate": interaction.created_at.isoformat() if interaction.created_at else None,
+            "details": None,
+            "structuredDetails": {
+                "channel": channel,
+                "emailType": interaction.meta_data.get("email_type"),
+                "interactionStatus": status,
+                "recipientStatusUpdatedAt": notify_delivery.get("updated_at"),
+                "recipientStatuses": cls._normalize_recipient_statuses(recipient_statuses),
+            },
+            "idir": None,
+        }
 
     @overload
     def dispatch(*, application_id: int) -> None:

--- a/strr-api/tests/integration/resources/test_applications_api.py
+++ b/strr-api/tests/integration/resources/test_applications_api.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from strr_api.enums.enum import ErrorMessage
+from strr_api.enums.enum import ChannelType, ErrorMessage, InteractionStatus
+from strr_api.models import CustomerInteraction
 from tests.integration.application_seed import (
     count_renewal_applications_for_account_registration,
     generate_application_number,
@@ -100,6 +101,63 @@ def test_get_application_events_item_keys(client, session, headers_public_user, 
         assert k in first, first
     assert first["details"] == "Integration seed"
     assert first["structuredDetails"] is None
+
+
+@pytest.mark.parametrize(
+    "include_interaction_delivery, expected_present",
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+def test_get_application_events_include_interaction_delivery_toggle(
+    client,
+    session,
+    headers_public_user,
+    serializable_application,
+    include_interaction_delivery,
+    expected_present,
+):
+    aid = serializable_application["application_id"]
+    num = serializable_application["application_number"]
+
+    interaction = CustomerInteraction(
+        channel=ChannelType.EMAIL,
+        status=InteractionStatus.DELIVERED,
+        application_id=aid,
+        meta_data={
+            "email_type": "HOST_FULL_REVIEW_APPROVED",
+            "notify_delivery": {
+                "updated_at": "2026-07-08T20:53:21.399598+00:00",
+                "recipient_statuses": {
+                    "610066": {
+                        "email_address": "karim.jazzar@gov.bc.ca",
+                        "failure_reason": None,
+                        "failure_type": None,
+                        "notify_reference": "610066",
+                        "provider_reference": "610522",
+                        "request_date": "2026-06-09T22:23:11.634878",
+                        "sent_date": "2026-06-09T22:23:11.714837",
+                        "status": "SENT",
+                    }
+                },
+            },
+        },
+    )
+    session.add(interaction)
+    session.flush()
+
+    query = "?include_interaction_delivery=true" if include_interaction_delivery else ""
+    rv = client.get(f"/applications/{num}/events{query}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    events = rv.get_json()
+    email_event = next((e for e in events if e.get("eventName") == "EMAIL_DELIVERED"), None)
+    assert (email_event is not None) is expected_present
+    if expected_present:
+        assert email_event["details"] is None
+        assert email_event["idir"] is None
+        assert email_event["structuredDetails"]["interactionStatus"] == "DELIVERED"
+        assert isinstance(email_event["structuredDetails"]["recipientStatuses"], list)
 
 
 def test_get_application_not_found_wrong_account(client, session, headers_public_user, serializable_host_registration):

--- a/strr-api/tests/integration/resources/test_registrations_api.py
+++ b/strr-api/tests/integration/resources/test_registrations_api.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-from strr_api.enums.enum import ErrorMessage, RegistrationNocStatus
-from strr_api.models import Events
+from strr_api.enums.enum import ChannelType, ErrorMessage, InteractionStatus, RegistrationNocStatus
+from strr_api.models import CustomerInteraction, Events
 from strr_api.models.rental import Document
 from tests.integration.helpers import (
     assert_json_keys,
@@ -208,6 +208,62 @@ def test_get_registration_events_item_shape(client, session, headers_public_user
     }
     assert seeded_event["details"] == "Integration seed event"
     assert seeded_event["structuredDetails"] is None
+
+
+@pytest.mark.parametrize(
+    "include_interaction_delivery, expected_present",
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+def test_get_registration_events_include_interaction_delivery_toggle(
+    client,
+    session,
+    headers_public_user,
+    serializable_host_registration,
+    include_interaction_delivery,
+    expected_present,
+):
+    rid = serializable_host_registration["registration_id"]
+
+    interaction = CustomerInteraction(
+        channel=ChannelType.EMAIL,
+        status=InteractionStatus.FAILED,
+        registration_id=rid,
+        meta_data={
+            "email_type": "HOST_FULL_REVIEW_APPROVED",
+            "notify_delivery": {
+                "updated_at": "2026-07-08T20:53:21.399598+00:00",
+                "recipient_statuses": {
+                    "610067": {
+                        "email_address": "karim.jazzar@gov.bc.ca",
+                        "failure_reason": "Mailbox unavailable",
+                        "failure_type": "permanent",
+                        "notify_reference": "610067",
+                        "provider_reference": "610523",
+                        "request_date": "2026-06-09T22:23:11.634878",
+                        "sent_date": "2026-06-09T22:23:11.714837",
+                        "status": "FAILED",
+                    }
+                },
+            },
+        },
+    )
+    session.add(interaction)
+    session.flush()
+
+    query = "?include_interaction_delivery=true" if include_interaction_delivery else ""
+    rv = client.get(f"/registrations/{rid}/events{query}", headers=headers_public_user())
+    assert_status(rv, HTTPStatus.OK)
+    events = rv.get_json()
+    email_event = next((e for e in events if e.get("eventName") == "EMAIL_FAILED"), None)
+    assert (email_event is not None) is expected_present
+    if expected_present:
+        assert email_event["details"] is None
+        assert email_event["idir"] is None
+        assert email_event["structuredDetails"]["interactionStatus"] == "FAILED"
+        assert isinstance(email_event["structuredDetails"]["recipientStatuses"], list)
 
 
 def test_post_registration_document_rejected_without_noc(client, headers_public_user, serializable_host_registration):

--- a/strr-api/tests/unit/resources/test_registration_applications.py
+++ b/strr-api/tests/unit/resources/test_registration_applications.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from strr_api.enums.enum import PaymentStatus, RegistrationStatus
-from strr_api.models import Application, Events
+from strr_api.enums.enum import ChannelType, InteractionStatus, PaymentStatus, RegistrationStatus
+from strr_api.models import Application, CustomerInteraction, Events
 from strr_api.models.application import ApplicationSerializer
 from strr_api.services import ApplicationService
 from tests.shared_test_constants import ACCOUNT_ID, MOCK_INVOICE_RESPONSE, MOCK_PAYMENT_COMPLETED_RESPONSE
@@ -301,6 +301,12 @@ def test_get_application_auto_approval_invalid_application(session, client, jwt)
     assert HTTPStatus.NOT_FOUND == rv.status_code
 
 
+def test_get_application_events_invalid_application(session, client, jwt):
+    headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+    rv = client.get("/applications/100/events", headers=headers)
+    assert HTTPStatus.NOT_FOUND == rv.status_code
+
+
 def test_get_application_auto_approval(session, client, jwt):
     with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
         json_data = json.load(f)
@@ -332,6 +338,67 @@ def test_get_application_events_user(session, client, jwt):
         events_response = rv.json
         assert events_response[0].get("eventName") == Events.EventName.APPLICATION_SUBMITTED
         assert events_response[0].get("eventType") == Events.EventType.APPLICATION
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_get_application_events_with_interaction_delivery(session, client, jwt):
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        json_data = json.load(f)
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        rv = client.post("/applications", json=json_data, headers=headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        application_number = response_json.get("header").get("applicationNumber")
+        application = Application.find_by_application_number(application_number)
+
+        interaction = CustomerInteraction(
+            channel=ChannelType.EMAIL,
+            status=InteractionStatus.DELIVERED,
+            application_id=application.id,
+            body_content="Renewal reminder",
+            notify_reference="notify-ref-001",
+            provider_reference="provider-ref-001",
+            meta_data={
+                "email_type": "HOST_RENEWAL_REMINDER",
+                "notify_delivery": {
+                    "updated_at": "2026-07-10T12:00:00+00:00",
+                    "recipient_statuses": {
+                        "notify-ref-001": {
+                            "email_address": "karim.jazzar@gov.bc.ca",
+                            "failure_reason": None,
+                            "failure_type": None,
+                            "notify_reference": "notify-ref-001",
+                            "provider_reference": "provider-ref-001",
+                            "request_date": "2026-06-09T22:23:11.634878",
+                            "sent_date": "2026-06-09T22:23:11.714837",
+                            "status": "SENT",
+                        }
+                    },
+                },
+            },
+        )
+        interaction.save()
+
+        rv = client.get(
+            f"/applications/{application_number}/events?include_interaction_delivery=true",
+            headers=headers,
+        )
+        assert HTTPStatus.OK == rv.status_code
+        events_response = rv.json
+        delivery_event = next(
+            (event for event in events_response if event.get("eventName") == "EMAIL_DELIVERED"),
+            None,
+        )
+        assert delivery_event is not None
+        assert delivery_event.get("eventType") == "APPLICATION"
+        assert delivery_event.get("details") is None
+        assert delivery_event.get("idir") is None
+        assert delivery_event.get("structuredDetails", {}).get("interactionStatus") == "DELIVERED"
+        assert delivery_event.get("structuredDetails", {}).get("recipientStatusUpdatedAt")
+        recipient_statuses = delivery_event.get("structuredDetails", {}).get("recipientStatuses", [])
+        assert isinstance(recipient_statuses, list)
+        assert recipient_statuses[0].get("notify_reference") == "notify-ref-001"
 
 
 def test_update_application_payment(session, client, jwt):

--- a/strr-api/tests/unit/resources/test_registrations.py
+++ b/strr-api/tests/unit/resources/test_registrations.py
@@ -10,13 +10,15 @@ from dateutil.relativedelta import relativedelta
 
 from strr_api.enums.enum import (
     ApplicationType,
+    ChannelType,
+    InteractionStatus,
     PaymentStatus,
     RegistrationNocStatus,
     RegistrationStatus,
     RegistrationType,
 )
 from strr_api.exceptions import ExternalServiceException
-from strr_api.models import Application, Document, Events, Registration, User
+from strr_api.models import Application, CustomerInteraction, Document, Events, Registration, User
 from strr_api.responses import RegistrationSerializer
 from tests.shared_test_constants import ACCOUNT_ID, MOCK_INVOICE_RESPONSE
 from tests.unit.utils.auth_helpers import PUBLIC_USER, STRR_EXAMINER, create_header
@@ -161,6 +163,78 @@ def test_get_registration_events(app, session, client, jwt):
         first_application = applications[0]
         assert first_application.get("applicationType") == ApplicationType.REGISTRATION.value
         assert first_application.get("applicationStatus") == Application.Status.FULL_REVIEW_APPROVED
+
+
+@patch("strr_api.services.strr_pay.create_invoice", return_value=MOCK_INVOICE_RESPONSE)
+def test_get_registration_events_with_interaction_delivery(app, session, client, jwt):
+    with open(CREATE_HOST_REGISTRATION_REQUEST) as f:
+        headers = create_header(jwt, [PUBLIC_USER], "Account-Id")
+        headers["Account-Id"] = ACCOUNT_ID
+        json_data = json.load(f)
+        rv = client.post("/applications", json=json_data, headers=headers)
+        response_json = rv.json
+        application_number = response_json.get("header").get("applicationNumber")
+
+        application = Application.find_by_application_number(application_number=application_number)
+        application.payment_status = PaymentStatus.COMPLETED.value
+        application.status = Application.Status.FULL_REVIEW
+        application.save()
+
+        staff_headers = create_header(jwt, [STRR_EXAMINER], "Account-Id")
+        rv = client.put(f"/applications/{application_number}/assign", headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        status_update_request = {"status": Application.Status.FULL_REVIEW_APPROVED}
+        rv = client.put(f"/applications/{application_number}/status", json=status_update_request, headers=staff_headers)
+        assert HTTPStatus.OK == rv.status_code
+        response_json = rv.json
+        registration_id = response_json.get("header").get("registrationId")
+
+        interaction = CustomerInteraction(
+            channel=ChannelType.EMAIL,
+            status=InteractionStatus.FAILED,
+            registration_id=registration_id,
+            body_content="Renewal reminder",
+            notify_reference="notify-ref-002",
+            provider_reference="provider-ref-002",
+            meta_data={
+                "email_type": "HOST_RENEWAL_REMINDER",
+                "notify_delivery": {
+                    "updated_at": "2026-07-10T12:30:00+00:00",
+                    "recipient_statuses": {
+                        "notify-ref-002": {
+                            "email_address": "karim.jazzar@gov.bc.ca",
+                            "failure_reason": "Mailbox unavailable",
+                            "failure_type": "permanent",
+                            "notify_reference": "notify-ref-002",
+                            "provider_reference": "provider-ref-002",
+                            "request_date": "2026-06-09T22:23:11.634878",
+                            "sent_date": "2026-06-09T22:23:11.714837",
+                            "status": "FAILED",
+                        }
+                    },
+                },
+            },
+        )
+        interaction.save()
+
+        rv = client.get(
+            f"/registrations/{registration_id}/events?include_interaction_delivery=true",
+            headers=headers,
+        )
+        assert rv.status_code == HTTPStatus.OK
+        events = rv.json
+        delivery_event = next(
+            (event for event in events if event.get("eventName") == "EMAIL_FAILED"),
+            None,
+        )
+        assert delivery_event is not None
+        assert delivery_event.get("eventType") == "REGISTRATION"
+        assert delivery_event.get("details") is None
+        assert delivery_event.get("idir") is None
+        assert delivery_event.get("structuredDetails", {}).get("interactionStatus") == "FAILED"
+        recipient_statuses = delivery_event.get("structuredDetails", {}).get("recipientStatuses", [])
+        assert isinstance(recipient_statuses, list)
+        assert recipient_statuses[0].get("notify_reference") == "notify-ref-002"
 
 
 @pytest.mark.skip(reason="Skipping the test until certificate generation is supported")

--- a/strr-api/tests/unit/services/test_interaction_service.py
+++ b/strr-api/tests/unit/services/test_interaction_service.py
@@ -405,3 +405,157 @@ def test_dispatch_email_all_recipients_fail(mock_requests_post, mock_get_token, 
     assert mock_requests_post.call_count == 2
     assert excinfo.value.status_code == HTTPStatus.BAD_REQUEST
     assert excinfo.value.error == "'Email not sent', 400"
+
+
+@pytest.mark.parametrize(
+    "interaction_status, expected_event_name",
+    [
+        (InteractionStatus.QUEUED, "EMAIL_QUEUED"),
+        (InteractionStatus.SENT, "EMAIL_SENT"),
+        (InteractionStatus.DELIVERED, "EMAIL_DELIVERED"),
+        (InteractionStatus.FAILED, "EMAIL_FAILED"),
+        (InteractionStatus.OPENED, "EMAIL_OPENED"),
+    ],
+)
+def test_filing_history_rows_application_maps_status_to_event_name(
+    session, setup_parents, interaction_status, expected_event_name
+):
+    interaction = CustomerInteraction(
+        channel=ChannelType.EMAIL,
+        status=interaction_status,
+        application_id=setup_parents["application_id"],
+        user_id=setup_parents["user_id"],
+        notify_reference="notify-ref-status",
+        provider_reference="provider-ref-status",
+        meta_data={
+            "email_type": "HOST_FULL_REVIEW_APPROVED",
+            "notify_delivery": {
+                "updated_at": "2026-07-08T20:53:21.399598+00:00",
+                "recipient_statuses": {
+                    "610066": {
+                        "email_address": "karim.jazzar@gov.bc.ca",
+                        "failure_reason": None,
+                        "failure_type": None,
+                        "notify_reference": "610066",
+                        "provider_reference": "610522",
+                        "request_date": "2026-06-09T22:23:11.634878",
+                        "sent_date": "2026-06-09T22:23:11.714837",
+                        "status": "SENT",
+                    }
+                },
+            },
+        },
+    )
+    interaction.save()
+
+    rows = InteractionService.filing_history_rows_for_application(setup_parents["application_id"])
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["eventName"] == expected_event_name
+    assert row["details"] is None
+    assert row["structuredDetails"]["recipientStatusUpdatedAt"] == "2026-07-08T20:53:21.399598+00:00"
+    assert isinstance(row["structuredDetails"]["recipientStatuses"], list)
+    assert row["structuredDetails"]["recipientStatuses"][0]["notify_reference"] == "610066"
+    assert row["structuredDetails"]["recipientStatuses"][0]["status"] == "SENT"
+
+
+@pytest.mark.parametrize(
+    "channel, meta_data, expected_count",
+    [
+        (
+            ChannelType.SMS,
+            {
+                "email_type": "HOST_FULL_REVIEW_APPROVED",
+                "notify_delivery": {
+                    "updated_at": "2026-07-08T20:53:21.399598+00:00",
+                    "recipient_statuses": {
+                        "610066": {
+                            "status": "SENT",
+                        }
+                    },
+                },
+            },
+            0,
+        ),
+        (
+            ChannelType.EMAIL,
+            {
+                "email_type": "HOST_FULL_REVIEW_APPROVED",
+            },
+            0,
+        ),
+        (
+            ChannelType.EMAIL,
+            {
+                "email_type": "HOST_FULL_REVIEW_APPROVED",
+                "notify_delivery": {
+                    "updated_at": "2026-07-08T20:53:21.399598+00:00",
+                    "recipient_statuses": {
+                        "610066": "malformed",
+                    },
+                },
+            },
+            1,
+        ),
+    ],
+)
+def test_filing_history_rows_application_edge_cases(session, setup_parents, channel, meta_data, expected_count):
+    interaction = CustomerInteraction(
+        channel=channel,
+        status=InteractionStatus.SENT,
+        application_id=setup_parents["application_id"],
+        meta_data=meta_data,
+    )
+    interaction.save()
+
+    rows = InteractionService.filing_history_rows_for_application(setup_parents["application_id"])
+    assert len(rows) == expected_count
+    if expected_count:
+        recipient = rows[0]["structuredDetails"]["recipientStatuses"][0]
+        assert recipient["notify_reference"] == "610066"
+
+
+@pytest.mark.parametrize(
+    "provider_status, expected_status",
+    [
+        ("created", "CREATED"),
+        ("sending", "IN_TRANSIT"),
+        ("pending", "PENDING"),
+        ("delivered", "DELIVERED"),
+        ("sent", "SENT"),
+        ("permanent-failure", "FAILED"),
+        ("temporary-failure", "FAILED"),
+        ("technical-failure", "FAILED"),
+        ("pending-virus-check", "PENDING"),
+        ("virus-scan-failed", "FAILED"),
+    ],
+)
+def test_filing_history_rows_application_maps_provider_status_to_internal_status(
+    session, setup_parents, provider_status, expected_status
+):
+    interaction = CustomerInteraction(
+        channel=ChannelType.EMAIL,
+        status=InteractionStatus.SENT,
+        application_id=setup_parents["application_id"],
+        meta_data={
+            "email_type": "HOST_RENEWAL_REMINDER",
+            "notify_delivery": {
+                "updated_at": "2026-07-08T20:53:21.399598+00:00",
+                "recipient_statuses": {
+                    "610066": {
+                        "email_address": "karim.jazzar@gov.bc.ca",
+                        "notify_reference": "610066",
+                        "provider_reference": "610522",
+                        "status": provider_status,
+                    }
+                },
+            },
+        },
+    )
+    interaction.save()
+
+    rows = InteractionService.filing_history_rows_for_application(setup_parents["application_id"])
+    assert len(rows) == 1
+    recipient = rows[0]["structuredDetails"]["recipientStatuses"][0]
+    assert recipient["status"] == expected_status
+    assert recipient["provider_status"] == provider_status


### PR DESCRIPTION
*Issue:*

JIRA: https://hous-hpb.atlassian.net/browse/REGBACKLOG-74

*Description of changes:*
In the existing events endpoint, email interaction events are added so that the filing history time line view can support these event rows on the UI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
