### PR TITLE
feat(strr-api): show initial status for email interaction events prior to notify_delivery metadata

### DIFF
--- a/strr-api/src/strr_api/services/interaction.py
+++ b/strr-api/src/strr_api/services/interaction.py
@@ -156,20 +156,17 @@ class InteractionService:
     @classmethod
     def _build_delivery_row(cls, interaction: CustomerInteraction, event_type: str) -> dict | None:
         """Convert a single interaction row into filing-history event shape."""
-        if not isinstance(interaction.meta_data, dict):
-            return None
-
-        notify_delivery = interaction.meta_data.get("notify_delivery")
-        if not isinstance(notify_delivery, dict):
-            return None
-
-        recipient_statuses = notify_delivery.get("recipient_statuses")
-        if not isinstance(recipient_statuses, dict) or not recipient_statuses:
-            return None
-
         channel = interaction.channel.value if interaction.channel else ""
         if channel != ChannelType.EMAIL.value:
             return None
+
+        meta_data = interaction.meta_data if isinstance(interaction.meta_data, dict) else {}
+        notify_delivery = meta_data.get("notify_delivery") if isinstance(meta_data.get("notify_delivery"), dict) else {}
+        recipient_statuses = (
+            notify_delivery.get("recipient_statuses")
+            if isinstance(notify_delivery.get("recipient_statuses"), dict)
+            else {}
+        )
         status = interaction.status.value if interaction.status else ""
 
         return {
@@ -180,7 +177,7 @@ class InteractionService:
             "details": None,
             "structuredDetails": {
                 "channel": channel,
-                "emailType": interaction.meta_data.get("email_type"),
+                "emailType": meta_data.get("email_type"),
                 "interactionStatus": status,
                 "recipientStatusUpdatedAt": notify_delivery.get("updated_at"),
                 "recipientStatuses": cls._normalize_recipient_statuses(recipient_statuses),

--- a/strr-api/tests/unit/services/test_interaction_service.py
+++ b/strr-api/tests/unit/services/test_interaction_service.py
@@ -482,7 +482,7 @@ def test_filing_history_rows_application_maps_status_to_event_name(
             {
                 "email_type": "HOST_FULL_REVIEW_APPROVED",
             },
-            0,
+            1,
         ),
         (
             ChannelType.EMAIL,
@@ -511,8 +511,8 @@ def test_filing_history_rows_application_edge_cases(session, setup_parents, chan
     rows = InteractionService.filing_history_rows_for_application(setup_parents["application_id"])
     assert len(rows) == expected_count
     if expected_count:
-        recipient = rows[0]["structuredDetails"]["recipientStatuses"][0]
-        assert recipient["notify_reference"] == "610066"
+        assert rows[0]["eventName"] == "EMAIL_SENT"
+        assert rows[0]["structuredDetails"]["interactionStatus"] == "SENT"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes:

Relaxes the strict check for `notify_delivery` metadata in `InteractionService._build_delivery_row` so that email interaction events display their initial status (`EMAIL_SENT`, `EMAIL_QUEUED`, `EMAIL_FAILED`) immediately in the events API (`GET /applications/{id}/events` and `GET /registrations/{id}/events`) when `include_interaction_delivery=true` is requested, prior to background polling updating recipient-level delivery metadata.

### Highlights:
- **`strr-api/src/strr_api/services/interaction.py`**:
  - Removed strict guard dropping interaction delivery events when `notify_delivery` or `recipient_statuses` is missing or empty.
  - Formats initial filing-history delivery row using available interaction attributes (`status`, `created_at`, `channel`, `email_type`).
- **`strr-api/tests/unit/services/test_interaction_service.py`**:
  - Updated unit test expectations to verify that `EMAIL` interactions return 1 event row with initial status prior to `notify_delivery` metadata availability.

### Tests:
- Executed unit and integration test suites: `pytest --no-cov tests/unit/services/test_interaction_service.py tests/integration/resources/test_registrations_api.py tests/integration/resources/test_applications_api.py` (96 tests passed).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
