### PR TITLE
fix(examiner-ui): format filing history timestamps in PST using Luxon

### DIFF
--- a/strr-examiner-web/app/components/Host/Expansion/FilingHistory.vue
+++ b/strr-examiner-web/app/components/Host/Expansion/FilingHistory.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 
+import { DateTime } from 'luxon'
 import { useFilingHistory } from '~/composables/useFilingHistory'
 
 defineEmits<{ close: [void] }>()
@@ -18,50 +19,12 @@ const {
   isEmptyFilingHistoryAccordion
 } = await useFilingHistory()
 
-const formatSentDateTime = (value: string): string => {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
+const toPacificDate = (val: string, fmt: string): string =>
+  val ? DateTime.fromISO(val, { zone: 'utc' }).setZone('America/Vancouver').toFormat(fmt).toLowerCase() : ''
 
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'America/Vancouver',
-    month: 'short',
-    day: '2-digit',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }).format(date)
-}
-
-const formatHistoryDate = (value: string): string => {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'America/Vancouver',
-    month: 'short',
-    day: '2-digit',
-    year: 'numeric'
-  }).format(date)
-}
-
-const formatHistoryTime = (value: string): string => {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'America/Vancouver',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }).format(date)
-}
+const formatSentDateTime = (val: string): string => toPacificDate(val, 'MMM dd, yyyy, h:mm a')
+const formatHistoryDate = (val: string): string => toPacificDate(val, 'MMM dd, yyyy')
+const formatHistoryTime = (val: string): string => toPacificDate(val, 'h:mm a')
 
 const recipientStatusClass = (status: string): string => {
   if (status === 'DELIVERED') {

--- a/strr-examiner-web/package.json
+++ b/strr-examiner-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-examiner-web",
   "private": true,
   "type": "module",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
## Description of changes:

Formats all filing history event dates, times, and email sent dates in **Pacific Time (PST/PDT)** using Luxon's `DateTime.fromISO(value, { zone: 'utc' }).setZone('America/Vancouver')`.

### Highlights:
- **`strr-examiner-web/app/components/Host/Expansion/FilingHistory.vue`**:
  - Replaced verbose native `Intl.DateTimeFormat` parsing with a concise Luxon helper `toPacificDate`.
  - Treats incoming backend timestamps as UTC (`{ zone: 'utc' }`) and explicitly converts them to Pacific Time (`'America/Vancouver'`).
  - Guarantees consistent Pacific Time (PST/PDT) display across all browsers, client devices, and SSR hydration renders.

### Tests:
- Executed unit test suite: `pnpm --filter strr-examiner-web test:unit tests/unit/components.spec.ts tests/unit/use-filing-history.spec.ts` (15 passed).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
