### PR TITLE
feat(host-ui): align renewal button show/hide logic across dashboard and registration detail page

### DIFF
--- a/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
+++ b/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
@@ -109,8 +109,7 @@ const getRenewalDraftApplicationNumber = (registration: RegistrationRecord): str
 
 /** Returns the renewal warning window in days by registration type. */
 const getRenewalWindowDays = (registrationType?: ApplicationType): number => {
-  // Keep these values in sync with backend DAYS_BEFORE_EXPIRY_BY_TYPE.
-  // TODO: Remove hardcoded fallback values and let API provide the values so that they stay in sync.
+  // Keep fallback values in sync with backend DAYS_BEFORE_EXPIRY_BY_TYPE.
   if (registrationType === ApplicationType.STRATA_HOTEL) {
     return 60
   }
@@ -156,16 +155,6 @@ const handleRegistrationLinkClick = (row: RegistrationRow) => {
   permitStore.selectedRegistrationId = row.registrationId?.toString()
 }
 
-/** Determines whether the Renew action should be shown for a row. */
-const canShowRenewAction = (
-  registration: RegistrationRecordWithTodos,
-  expiryState: ExpiryState,
-  renewalDraftExists: boolean,
-  renewalPaymentPending: boolean
-): boolean => {
-  return canRenewRegistration(registration, expiryState, renewalDraftExists, renewalPaymentPending)
-}
-
 // Data mapping
 const mapRegistrationsList = (registrations: RegistrationRecordWithTodos[]): RegistrationRow[] => {
   if (!registrations) {
@@ -192,7 +181,7 @@ const mapRegistrationsList = (registrations: RegistrationRecordWithTodos[]): Reg
       expiryState,
       hasRenewalDraft: renewalDraftExists,
       renewalDraftApplicationNumber,
-      canRenew: canShowRenewAction(registration, expiryState, renewalDraftExists, renewalPaymentPending),
+      canRenew: canRenewRegistration(registration, expiryState, renewalDraftExists, renewalPaymentPending),
       registrationId: registration.id
     }
   })

--- a/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
+++ b/strr-host-pm-web/app/components/dashboard/RegistrationsTable.vue
@@ -6,6 +6,12 @@ const accountStore = useConnectAccountStore()
 const permitStore = useHostPermitStore()
 const { getAccountRegistrations, searchRegistrations } = useStrrApi()
 const { isDashboardTableSortingEnabled, isHostSearchTextFieldsEnabled } = useHostFeatureFlags()
+const {
+  startRenewal,
+  resumeRenewalDraft,
+  canRenewRegistration,
+  fetchRegistrationsWithRenewalTodos
+} = useRenewals()
 
 const props = withDefaults(defineProps<{
   registrationsLimit?: number
@@ -102,7 +108,7 @@ const getRenewalDraftApplicationNumber = (registration: RegistrationRecord): str
 }
 
 /** Returns the renewal warning window in days by registration type. */
-const getRenewalWindowDays = (registrationType: ApplicationType): number => {
+const getRenewalWindowDays = (registrationType?: ApplicationType): number => {
   // Keep these values in sync with backend DAYS_BEFORE_EXPIRY_BY_TYPE.
   // TODO: Remove hardcoded fallback values and let API provide the values so that they stay in sync.
   if (registrationType === ApplicationType.STRATA_HOTEL) {
@@ -112,7 +118,7 @@ const getRenewalWindowDays = (registrationType: ApplicationType): number => {
 }
 
 /** Calculates whole days remaining until the expiry date in Pacific time. */
-const getDaysUntilExpiry = (expiryDate: string): number | null => {
+const getDaysUntilExpiry = (expiryDate?: string): number | null => {
   if (!expiryDate) {
     return null
   }
@@ -127,7 +133,7 @@ const getDaysUntilExpiry = (expiryDate: string): number | null => {
 }
 
 /** Maps an expiry date to an expiry state used for UI styling and actions. */
-const getExpiryState = (registrationType: ApplicationType, expiryDate: string | undefined): ExpiryState => {
+const getExpiryState = (registrationType: ApplicationType | undefined, expiryDate: string | undefined): ExpiryState => {
   const daysUntilExpiry = getDaysUntilExpiry(expiryDate)
   if (daysUntilExpiry === null) {
     return ExpiryState.ACTIVE
@@ -152,26 +158,31 @@ const handleRegistrationLinkClick = (row: RegistrationRow) => {
 
 /** Determines whether the Renew action should be shown for a row. */
 const canShowRenewAction = (
+  registration: RegistrationRecordWithTodos,
   expiryState: ExpiryState,
   renewalDraftExists: boolean,
   renewalPaymentPending: boolean
 ): boolean => {
-  return [ExpiryState.EXPIRED, ExpiryState.EXPIRING_SOON].includes(expiryState) &&
-    !renewalDraftExists &&
-    !renewalPaymentPending
+  return canRenewRegistration(registration, expiryState, renewalDraftExists, renewalPaymentPending)
 }
 
 // Data mapping
-const mapRegistrationsList = (registrations: RegistrationRecord[]): RegistrationRow[] => {
+const mapRegistrationsList = (registrations: RegistrationRecordWithTodos[]): RegistrationRow[] => {
   if (!registrations) {
     return []
   }
-  return registrations.map((registration: RegistrationRecord): RegistrationRow => {
+  return registrations.map((registration: RegistrationRecordWithTodos): RegistrationRow => {
     const displayAddress = registration.unitAddress
     const expiryState = getExpiryState(registration.registrationType, registration.expiryDate)
-    const renewalDraftExists = hasRenewalDraft(registration)
-    const renewalPaymentPending = hasRenewalPaymentPending(registration)
-    const renewalDraftApplicationNumber = getRenewalDraftApplicationNumber(registration)
+    const renewalDraftExists = registration.hasRenewalDraft !== undefined
+      ? registration.hasRenewalDraft
+      : hasRenewalDraft(registration)
+    const renewalPaymentPending = registration.hasRenewalPaymentPending !== undefined
+      ? registration.hasRenewalPaymentPending
+      : hasRenewalPaymentPending(registration)
+    const renewalDraftApplicationNumber = registration.hasRenewalDraft !== undefined
+      ? (registration.renewalDraftId ?? undefined)
+      : getRenewalDraftApplicationNumber(registration)
     return {
       number: registration.registrationNumber,
       status: registration.header?.hostStatus || registration.status,
@@ -181,7 +192,7 @@ const mapRegistrationsList = (registrations: RegistrationRecord[]): Registration
       expiryState,
       hasRenewalDraft: renewalDraftExists,
       renewalDraftApplicationNumber,
-      canRenew: canShowRenewAction(expiryState, renewalDraftExists, renewalPaymentPending),
+      canRenew: canShowRenewAction(registration, expiryState, renewalDraftExists, renewalPaymentPending),
       registrationId: registration.id
     }
   })
@@ -190,6 +201,8 @@ const mapRegistrationsList = (registrations: RegistrationRecord[]): Registration
 // Fetch Registrations
 /** Fetches registration rows from search or account list endpoints. */
 const fetchRegistrations = async () => {
+  let registrations: RegistrationRecord[] = []
+  let total = 0
   if (isSearching.value) {
     const resp = await searchRegistrations<ApiRegistrationResp>(
       searchText.value,
@@ -199,10 +212,10 @@ const fetchRegistrations = async () => {
       undefined,
       ApplicationType.HOST
     )
-    if (!resp) {
-      return { registrations: [], total: 0 }
+    if (resp) {
+      registrations = resp.registrations || []
+      total = resp.total || 0
     }
-    return { registrations: resp.registrations || [], total: resp.total || 0 }
   } else {
     const resp = await getAccountRegistrations<ApiRegistrationResp>(
       undefined,
@@ -212,10 +225,18 @@ const fetchRegistrations = async () => {
     )
     // Handle both array and object response formats
     if (Array.isArray(resp)) {
-      return { registrations: resp, total: resp.length }
+      registrations = resp
+      total = resp.length
+    } else {
+      registrations = resp?.registrations || []
+      total = resp?.total || 0
     }
-    return { registrations: resp?.registrations || [], total: resp?.total || 0 }
   }
+
+  // Fetch todos for all registrations in parallel using shared composable helper
+  const registrationsWithTodos = await fetchRegistrationsWithRenewalTodos(registrations)
+
+  return { registrations: registrationsWithTodos, total }
 }
 
 const { data: registrationsResp, status: registrationsStatus } = await useAsyncData(
@@ -231,27 +252,16 @@ const registrationsList = computed(() => mapRegistrationsList(registrationsResp.
 
 /** Starts a new renewal flow for the selected registration. */
 async function handleRenewRegistration (row: RegistrationRow) {
-  permitStore.renewalRegId = row.registrationId?.toString()
-  await navigateTo({
-    path: localePath('/application'),
-    query: { renew: 'true' }
-  })
+  if (row.registrationId) {
+    await startRenewal(row.registrationId)
+  }
 }
 
 /** Opens the existing renewal draft for the selected registration. */
 async function handleResumeRenewalDraft (row: RegistrationRow) {
-  if (!row.renewalDraftApplicationNumber) {
-    return
+  if (row.renewalDraftApplicationNumber) {
+    await resumeRenewalDraft(row.renewalDraftApplicationNumber)
   }
-
-  permitStore.renewalRegId = undefined
-  await navigateTo({
-    path: localePath('/application'),
-    query: {
-      renew: 'true',
-      applicationId: row.renewalDraftApplicationNumber
-    }
-  })
 }
 </script>
 

--- a/strr-host-pm-web/app/composables/useDashboardTodos.ts
+++ b/strr-host-pm-web/app/composables/useDashboardTodos.ts
@@ -3,7 +3,6 @@
  */
 export const useDashboardTodos = () => {
   const { t } = useNuxtApp().$i18n
-  const localePath = useLocalePath()
   const permitStore = useHostPermitStore()
   const {
     registration,
@@ -20,7 +19,9 @@ export const useDashboardTodos = () => {
     renewalDueDate,
     renewalDateCounter,
     isRenewalPeriodClosed,
-    getRegistrationRenewalTodos
+    getRegistrationRenewalTodos,
+    startRenewal,
+    resumeRenewalDraft
   } = useRenewals()
 
   const { getAccountApplication, deleteApplication } = useStrrApi()
@@ -30,14 +31,15 @@ export const useDashboardTodos = () => {
 
   // Check if there's a pending renewal application (PAID or FULL_REVIEW status)
   const hasPendingRenewalProcessing = computed(() => {
-    const apps = (registration.value as any)?.header?.applications || []
+    const apps = (registration.value as Partial<RegistrationRecord> | undefined)?.header?.applications || []
     if (apps.length === 0) {
       return false
     }
     const latestApp = apps[0]
     const pendingStatuses = [ApplicationStatus.PAID, ApplicationStatus.FULL_REVIEW]
     return latestApp?.applicationType === 'renewal' &&
-      pendingStatuses.includes(latestApp?.applicationStatus)
+      !!latestApp?.applicationStatus &&
+      pendingStatuses.includes(latestApp.applicationStatus as ApplicationStatus)
   })
 
   // Common translation props for scroll-to-link
@@ -55,7 +57,7 @@ export const useDashboardTodos = () => {
   const addNocTodo = () => {
     if (registration.value?.nocStatus === RegistrationNocStatus.NOC_PENDING) {
       const translationProps = getScrollLinkTranslationProps()
-      const nocEndDate = dateToString(permitDetails.value.nocEndDate as Date)
+      const nocEndDate = dateToString((permitDetails.value as HostRegistrationResp).nocEndDate as Date)
 
       todos.value.push({
         id: 'todo-reg-noc-add-docs',
@@ -129,11 +131,7 @@ export const useDashboardTodos = () => {
           buttons: [{
             label: t('btn.renew'),
             action: async () => {
-              permitStore.setRenewalRegistrationContext(registration.value!.id)
-              await navigateTo({
-                path: localePath('/application'),
-                query: { renew: 'true' }
-              })
+              await startRenewal(registration.value!.id)
             }
           }]
         })
@@ -147,11 +145,7 @@ export const useDashboardTodos = () => {
             {
               label: t('todos.renewalDraft.resumeButton'),
               action: async () => {
-                permitStore.clearRenewalRegistrationContext()
-                await navigateTo({
-                  path: localePath('/application'),
-                  query: { renew: 'true', applicationId: renewalDraftId.value }
-                })
+                await resumeRenewalDraft(renewalDraftId.value)
               }
             },
             {

--- a/strr-host-pm-web/app/composables/useRenewals.ts
+++ b/strr-host-pm-web/app/composables/useRenewals.ts
@@ -18,7 +18,7 @@ export const useRenewals = () => {
   const checkIsRenewalPeriodClosed = (
     reg: Partial<RegistrationRecord> | ApiRegistrationResp | HostRegistrationResp | null | undefined
   ): boolean => {
-    if (!reg || !reg.expiryDate) {
+    if (!reg?.expiryDate) {
       return false
     }
     const isRegExpired = reg.status === RegistrationStatus.EXPIRED
@@ -57,7 +57,7 @@ export const useRenewals = () => {
     }
     const today = DateTime.now().setZone('America/Vancouver')
     const days = expDate.diff(today, 'days').days
-    return days !== undefined && !isNaN(days) ? Math.floor(days) : 0
+    return days !== undefined && !Number.isNaN(days) ? Math.floor(days) : 0
   })
 
   const getRegistrationRenewalTodos = async () => {
@@ -148,7 +148,7 @@ export const useRenewals = () => {
   const fetchRegistrationsWithRenewalTodos = async <T extends { id: number }>(
     registrations: T[]
   ): Promise<(T & RenewalTodoDetails)[]> => {
-    if (!registrations || registrations.length === 0) {
+    if (!registrations?.length) {
       return []
     }
     return await Promise.all(
@@ -163,8 +163,7 @@ export const useRenewals = () => {
             renewalDraftId: todoInfo.renewalDraftId,
             renewalPaymentPendingId: todoInfo.renewalPaymentPendingId
           } as T & RenewalTodoDetails
-        } catch (e) {
-          console.error('Failed to load todos for registration', reg.id, e)
+        } catch {
           return {
             ...reg,
             hasRenewalTodo: false,

--- a/strr-host-pm-web/app/composables/useRenewals.ts
+++ b/strr-host-pm-web/app/composables/useRenewals.ts
@@ -2,7 +2,11 @@ import { DateTime } from 'luxon'
 
 // Registration Renewals composable
 export const useRenewals = () => {
-  const { registration } = storeToRefs(useHostPermitStore())
+  const permitStore = useHostPermitStore()
+  const localePath = useLocalePath()
+  const { isRenewalsEnabled } = useHostFeatureFlags()
+
+  const registration = toRef(permitStore, 'registration')
 
   const isEligibleForRenewal = ref(false)
   const hasRegistrationRenewalDraft = ref(false)
@@ -10,25 +14,50 @@ export const useRenewals = () => {
   const renewalDraftId = ref('')
   const renewalPaymentPendingId = ref('')
 
-  // check if 3 years past since expiry date and renewal is closed
-  const isRenewalPeriodClosed = computed((): boolean => {
-    const isRegExpired = registration.value?.status === RegistrationStatus.EXPIRED
-    const expDate = DateTime.fromISO(registration.value?.expiryDate).setZone('America/Vancouver')
+  /** Checks if 3 years past since expiry date and renewal is closed for a registration. */
+  const checkIsRenewalPeriodClosed = (
+    reg: Partial<RegistrationRecord> | ApiRegistrationResp | HostRegistrationResp | null | undefined
+  ): boolean => {
+    if (!reg || !reg.expiryDate) {
+      return false
+    }
+    const isRegExpired = reg.status === RegistrationStatus.EXPIRED
+    const expDate = DateTime.fromISO(reg.expiryDate).setZone('America/Vancouver')
+    if (!expDate.isValid) {
+      return false
+    }
     const today = DateTime.now().setZone('America/Vancouver')
     return today.diff(expDate, 'years').years > 3 && isRegExpired
+  }
+
+  // check if 3 years past since expiry date and renewal is closed
+  const isRenewalPeriodClosed = computed((): boolean => {
+    return checkIsRenewalPeriodClosed(registration.value)
   })
 
   // converts expiry date to medium format date, eg Apr 1, 2025
-  const renewalDueDate = computed((): string =>
-    DateTime.fromISO(registration.value?.expiryDate).toLocaleString(DateTime.DATE_MED)
-  )
+  const renewalDueDate = computed((): string => {
+    const expiryDate = registration.value?.expiryDate
+    if (!expiryDate) {
+      return ''
+    }
+    const dt = DateTime.fromISO(expiryDate)
+    return dt.isValid ? dt.toLocaleString(DateTime.DATE_MED) : ''
+  })
 
   // number of days for renewal due date
   const renewalDateCounter = computed((): number => {
-    const expDate = DateTime.fromISO(registration.value?.expiryDate).setZone('America/Vancouver')
+    const expiryDate = registration.value?.expiryDate
+    if (!expiryDate) {
+      return 0
+    }
+    const expDate = DateTime.fromISO(expiryDate).setZone('America/Vancouver')
+    if (!expDate.isValid) {
+      return 0
+    }
     const today = DateTime.now().setZone('America/Vancouver')
-
-    return Math.floor(expDate.diff(today, 'days').toObject().days)
+    const days = expDate.diff(today, 'days').days
+    return days !== undefined && !isNaN(days) ? Math.floor(days) : 0
   })
 
   const getRegistrationRenewalTodos = async () => {
@@ -58,6 +87,97 @@ export const useRenewals = () => {
     await getRegistrationRenewalTodos()
   }, { immediate: true })
 
+  /** Starts a new renewal flow for the specified registration ID. */
+  const startRenewal = async (registrationId: string | number) => {
+    if (typeof permitStore.setRenewalRegistrationContext === 'function') {
+      permitStore.setRenewalRegistrationContext(registrationId)
+    } else {
+      (permitStore as unknown as { renewalRegId?: string }).renewalRegId = registrationId?.toString()
+    }
+    await navigateTo({
+      path: localePath('/application'),
+      query: { renew: 'true' }
+    })
+  }
+
+  /** Opens the existing renewal draft for the specified application ID. */
+  const resumeRenewalDraft = async (draftApplicationId: string) => {
+    if (!draftApplicationId) {
+      return
+    }
+    if (typeof permitStore.clearRenewalRegistrationContext === 'function') {
+      permitStore.clearRenewalRegistrationContext()
+    } else {
+      (permitStore as unknown as { renewalRegId?: string }).renewalRegId = undefined
+    }
+    await navigateTo({
+      path: localePath('/application'),
+      query: {
+        renew: 'true',
+        applicationId: draftApplicationId
+      }
+    })
+  }
+
+  /** Determines whether the Renew action should be shown for a registration record. */
+  const canRenewRegistration = (
+    reg: Partial<RegistrationRecordWithTodos> | RegistrationRecordWithTodos | RegistrationRecord | null | undefined,
+    expiryState?: ExpiryState,
+    renewalDraftExists?: boolean,
+    renewalPaymentPending?: boolean
+  ): boolean => {
+    const renewalsEnabled = isRenewalsEnabled?.value ?? false
+    if (!renewalsEnabled || !reg) {
+      return false
+    }
+
+    if ('hasRenewalTodo' in reg && reg.hasRenewalTodo !== undefined) {
+      return reg.hasRenewalTodo && !checkIsRenewalPeriodClosed(reg)
+    }
+
+    const isClosed = checkIsRenewalPeriodClosed(reg)
+    const isEligibleByExpiry = [ExpiryState.EXPIRED, ExpiryState.EXPIRING_SOON].includes(expiryState as ExpiryState)
+
+    return isEligibleByExpiry &&
+      !renewalDraftExists &&
+      !renewalPaymentPending &&
+      !isClosed
+  }
+
+  /** Fetches renewal todo details for a list of registrations in parallel. */
+  const fetchRegistrationsWithRenewalTodos = async <T extends { id: number }>(
+    registrations: T[]
+  ): Promise<(T & RenewalTodoDetails)[]> => {
+    if (!registrations || registrations.length === 0) {
+      return []
+    }
+    return await Promise.all(
+      registrations.map(async (reg): Promise<T & RenewalTodoDetails> => {
+        try {
+          const todoInfo = await getTodoRegistration(reg.id)
+          return {
+            ...reg,
+            hasRenewalTodo: todoInfo.hasRenewalTodo,
+            hasRenewalDraft: todoInfo.hasRenewalDraft,
+            hasRenewalPaymentPending: todoInfo.hasRenewalPaymentPending,
+            renewalDraftId: todoInfo.renewalDraftId,
+            renewalPaymentPendingId: todoInfo.renewalPaymentPendingId
+          } as T & RenewalTodoDetails
+        } catch (e) {
+          console.error('Failed to load todos for registration', reg.id, e)
+          return {
+            ...reg,
+            hasRenewalTodo: false,
+            hasRenewalDraft: false,
+            hasRenewalPaymentPending: false,
+            renewalDraftId: null,
+            renewalPaymentPendingId: null
+          } as T & RenewalTodoDetails
+        }
+      })
+    )
+  }
+
   return {
     isEligibleForRenewal,
     hasRegistrationRenewalDraft,
@@ -67,6 +187,10 @@ export const useRenewals = () => {
     isRenewalPeriodClosed,
     renewalDueDate,
     renewalDateCounter,
-    getRegistrationRenewalTodos
+    getRegistrationRenewalTodos,
+    startRenewal,
+    resumeRenewalDraft,
+    canRenewRegistration,
+    fetchRegistrationsWithRenewalTodos
   }
 }

--- a/strr-host-pm-web/app/interfaces/dashboard-tables.ts
+++ b/strr-host-pm-web/app/interfaces/dashboard-tables.ts
@@ -46,3 +46,13 @@ export interface RegistrationRow {
   canRenew: boolean
   registrationId: number
 }
+
+export interface RenewalTodoDetails {
+  hasRenewalTodo?: boolean
+  hasRenewalDraft?: boolean
+  hasRenewalPaymentPending?: boolean
+  renewalDraftId?: string | null
+  renewalPaymentPendingId?: string | null
+}
+
+export interface RegistrationRecordWithTodos extends RegistrationRecord, RenewalTodoDetails {}

--- a/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
+++ b/strr-host-pm-web/app/pages/dashboard/[applicationId].vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { watch } from 'vue'
-
 const { t } = useNuxtApp().$i18n
 const route = useRoute()
 const config = useRuntimeConfig().public
@@ -22,22 +20,14 @@ const {
 const { unitAddress } = storeToRefs(useHostPropertyStore())
 
 const {
-  isEligibleForRenewal,
-  hasRegistrationRenewalDraft,
-  hasRegistrationRenewalPaymentPending,
-  renewalDraftId,
-  renewalPaymentPendingId,
-  renewalDueDate,
-  renewalDateCounter,
-  isRenewalPeriodClosed,
-  getRegistrationRenewalTodos
-} = useRenewals()
+  todos,
+  setupRenewalTodosWatch
+} = useDashboardTodos()
 
-const { getAccountApplication, deleteApplication } = useStrrApi()
+setupRenewalTodosWatch()
 
-const todos = ref<Todo[]>([])
 const owners = ref<ConnectAccordionItem[]>([])
-const { isRenewalsEnabled, isNewDashboardEnabled } = useHostFeatureFlags()
+const { isNewDashboardEnabled } = useHostFeatureFlags()
 
 onMounted(async () => {
   loading.value = true
@@ -62,7 +52,7 @@ onMounted(async () => {
       linkEnd: '</button>'
     }
 
-    const nocEndDate = dateToString(permitDetails.value.nocEndDate as Date)
+    const nocEndDate = dateToString((permitDetails.value as HostRegistrationResp).nocEndDate as Date)
 
     todos.value.push({
       id: 'todo-reg-noc-add-docs',
@@ -154,118 +144,6 @@ definePageMeta({
     return true
   }
 })
-
-// watch for Registration Renewals props and update related ToDos
-watch([isRenewalsEnabled,
-  isRenewalPeriodClosed,
-  registration,
-  isEligibleForRenewal,
-  hasRegistrationRenewalDraft,
-  hasRegistrationRenewalPaymentPending], () => {
-  const translationProps = {
-    newLine: '<br/>',
-    boldStart: '<strong>',
-    boldEnd: '</strong>'
-  }
-
-  // remove all renewal todos before adding new ones
-  const renewalTodoIds = [
-    'todo-renew-registration-closed',
-    'todo-renew-registration',
-    'todo-renewal-draft',
-    'todo-renewal-payment-pending'
-  ]
-  todos.value = todos.value.filter(todo => !renewalTodoIds.includes(todo.id))
-
-  if (isRenewalsEnabled.value && isRenewalPeriodClosed.value) {
-    // todo for renewal period closed after 3 years without renewal
-    todos.value.push({
-      id: 'todo-renew-registration-closed',
-      title: t('todos.renewalClosed.title'),
-      subtitle: t('todos.renewalClosed.subtitle', translationProps)
-    })
-  } else if (isRenewalsEnabled.value && registration.value && isEligibleForRenewal.value) {
-    const isOverdue = renewalDateCounter.value < 0
-    // label for the due days count
-    const dueDateCount = isOverdue
-      ? t('label.renewalOverdue')
-      : t('label.renewalDayCount', renewalDateCounter.value)
-
-    todos.value.push({
-      id: 'todo-renew-registration',
-      title: `${t('todos.renewal.title1')} ${renewalDueDate.value} ${t('todos.renewal.title2')} (${dueDateCount})`,
-      subtitle: t(isOverdue
-        ? 'todos.renewal.expired'
-        : 'todos.renewal.expiresSoon', translationProps),
-      buttons: [{
-        label: t('btn.renew'),
-        action: async () => {
-          permitStore.setRenewalRegistrationContext(registration.value!.id)
-          await navigateTo({
-            path: localePath('/application'),
-            query: { renew: 'true' }
-          })
-        }
-      }]
-    })
-  } else if (isRenewalsEnabled.value && registration.value && hasRegistrationRenewalDraft.value) {
-    // todo for existing renewal draft
-    todos.value.push({
-      id: 'todo-renewal-draft',
-      title: t('todos.renewalDraft.title'),
-      subtitle: t('todos.renewalDraft.subtitle'),
-      buttons: [
-        {
-          label: t('todos.renewalDraft.resumeButton'),
-          action: async () => {
-            permitStore.clearRenewalRegistrationContext()
-            await navigateTo({
-              path: localePath('/application'),
-              query: { renew: 'true', applicationId: renewalDraftId.value }
-            })
-          }
-        },
-        {
-          label: t('todos.renewalDraft.deleteDraft'),
-          icon: 'i-mdi-delete',
-          action: async () => {
-            // delete draft application
-            await deleteApplication(renewalDraftId.value)
-            // remove renewal draft todo
-            todos.value = todos.value.filter(todo => todo.id !== 'todo-renewal-draft')
-            // reload registration renewal todos
-            await getRegistrationRenewalTodos()
-          }
-        }
-      ]
-    })
-  } else if (isRenewalsEnabled.value && registration.value && hasRegistrationRenewalPaymentPending.value) {
-    // todo for renewal payment pending
-    todos.value.push({
-      id: 'todo-renewal-payment-pending',
-      title: t('todos.renewalPayment.title'),
-      subtitle: t('todos.renewalPayment.subtitle'),
-      buttons: [{
-        label: t('todos.renewalPayment.button'),
-        action: async () => {
-          const { handlePaymentRedirect } = useConnectNav()
-          // Get the payment token
-          const applicationResponse = await getAccountApplication(
-            renewalPaymentPendingId.value
-          )
-          const paymentToken = applicationResponse?.header.paymentToken
-          const appNum = applicationResponse?.header.applicationNumber
-          if (paymentToken) {
-            handlePaymentRedirect(
-              paymentToken,
-              '/dashboard/' + appNum
-            )
-          }
-        }
-      }]
-    })
-  }
-}, { immediate: true })
 
 setBreadcrumbs([
   {

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -15,6 +15,7 @@
     "postinstall": "nuxt prepare",
     "lint": "eslint --ext .ts,.vue app tests --ignore-path .gitignore",
     "lint:fix": "pnpm lint --fix",
+    "typecheck": "nuxi typecheck",
     "test": "vitest --dir tests/unit --passWithNoTests --coverage && cp ./tests/coverage/clover.xml ./coverage.xml",
     "test:unit": "vitest --dir tests/unit",
     "test:unit:cov": "vitest run --dir tests/unit --coverage",
@@ -44,7 +45,8 @@
     "playwright-core": "^1.55.0",
     "sass": "^1.90.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vue-tsc": "^3.3.8"
   },
   "dependencies": {
     "@daxiom/nuxt-core-layer-test": "^0.0.29",

--- a/strr-host-pm-web/package.json
+++ b/strr-host-pm-web/package.json
@@ -2,7 +2,7 @@
   "name": "strr-host-pm-web",
   "private": true,
   "type": "module",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "engines": {
     "node": ">=24"
   },

--- a/strr-host-pm-web/pnpm-lock.yaml
+++ b/strr-host-pm-web/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@daxiom/nuxt-core-layer-test':
         specifier: ^0.0.29
-        version: 0.0.29(@nuxt/kit@3.15.4(magicast@0.5.3))(@vue/compiler-dom@3.5.34)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0))(rollup@4.60.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)
+        version: 0.0.29(@nuxt/kit@3.15.4(magicast@0.5.3))(@vue/compiler-dom@3.5.34)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0))(rollup@4.60.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)
       country-codes-list:
         specifier: ^2.0.0
         version: 2.0.0
@@ -19,7 +19,7 @@ importers:
         version: 4.7.0
       nuxt:
         specifier: 3.15.4
-        version: 3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0)
       uuid:
         specifier: ^11.1.0
         version: 11.1.1
@@ -96,6 +96,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.9.1)(happy-dom@20.9.0)(jiti@2.7.0)(jsdom@26.1.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vue-tsc:
+        specifier: ^3.3.8
+        version: 3.3.8(typescript@5.9.3)
 
 packages:
 
@@ -2555,6 +2558,15 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
   '@vue-macros/common@1.16.1':
     resolution: {integrity: sha512-Pn/AWMTjoMYuquepLZP813BIcq8DTZiNCoaceuNlvaYuOTd8DqBZWc5u0uOMQZMInwME1mdSmmBAcTluiV9Jtg==}
     engines: {node: '>=16.14.0'}
@@ -2634,6 +2646,9 @@ packages:
 
   '@vue/devtools-shared@8.1.2':
     resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
+
+  '@vue/language-core@3.3.8':
+    resolution: {integrity: sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==}
 
   '@vue/reactivity@3.5.34':
     resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
@@ -2843,6 +2858,9 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -5253,6 +5271,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -6870,6 +6891,12 @@ packages:
       pinia:
         optional: true
 
+  vue-tsc@3.3.8:
+    resolution: {integrity: sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
   vue@3.5.34:
     resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
     peerDependencies:
@@ -7383,13 +7410,13 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
-  '@daxiom/nuxt-core-layer-test@0.0.29(@nuxt/kit@3.15.4(magicast@0.5.3))(@vue/compiler-dom@3.5.34)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0))(rollup@4.60.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)':
+  '@daxiom/nuxt-core-layer-test@0.0.29(@nuxt/kit@3.15.4(magicast@0.5.3))(@vue/compiler-dom@3.5.34)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0))(rollup@4.60.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@iconify-json/mdi': 1.2.3
       '@nuxt/ui': 2.22.3(magicast@0.5.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)(zod@3.25.76)
       '@nuxtjs/i18n': 10.4.0(@vue/compiler-dom@3.5.34)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup@4.60.4)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       '@pinia/nuxt': 0.11.3(magicast@0.5.3)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))
-      '@vueuse/nuxt': 13.9.0(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
+      '@vueuse/nuxt': 13.9.0(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       dompurify: 3.4.6
       jsdom: 26.1.0
       keycloak-js: 26.2.4
@@ -8588,7 +8615,7 @@ snapshots:
       - vue
       - yaml
 
-  '@nuxt/vite-builder@3.15.4(@types/node@25.9.1)(eslint@8.57.1)(magicast@0.5.3)(optionator@0.9.4)(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@3.15.4(@types/node@25.9.1)(eslint@8.57.1)(magicast@0.5.3)(optionator@0.9.4)(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.8(typescript@5.9.3))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
@@ -8619,7 +8646,7 @@ snapshots:
       unplugin: 2.3.11
       vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vite-node: 3.2.4(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vite-plugin-checker: 0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))
       vue: 3.5.34(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
@@ -9647,6 +9674,18 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
   '@vue-macros/common@1.16.1(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.34
@@ -9788,6 +9827,16 @@ snapshots:
 
   '@vue/devtools-shared@8.1.2': {}
 
+  '@vue/language-core@3.3.8':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
   '@vue/reactivity@3.5.34':
     dependencies:
       '@vue/shared': 3.5.34
@@ -9843,13 +9892,13 @@ snapshots:
 
   '@vueuse/metadata@13.9.0': {}
 
-  '@vueuse/nuxt@13.9.0(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
+  '@vueuse/nuxt@13.9.0(magicast@0.5.3)(nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 3.21.6(magicast@0.5.3)
       '@vueuse/core': 13.9.0(vue@3.5.34(typescript@5.9.3))
       '@vueuse/metadata': 13.9.0
       local-pkg: 1.2.1
-      nuxt: 3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0)
       vue: 3.5.34(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
@@ -9991,6 +10040,8 @@ snapshots:
       fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@3.2.1: {}
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -12644,7 +12695,7 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@3.15.4(@parcel/watcher@2.5.6)(@types/node@25.9.1)(cac@6.7.14)(db0@0.3.4)(eslint@8.57.1)(ioredis@5.11.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.128.0)(rollup@4.60.4)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(typescript@5.9.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@nuxt/cli': 3.35.2(@nuxt/schema@3.15.4)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devalue': 2.0.2
@@ -12652,7 +12703,7 @@ snapshots:
       '@nuxt/kit': 3.15.4(magicast@0.5.3)
       '@nuxt/schema': 3.15.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@3.15.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 3.15.4(@types/node@25.9.1)(eslint@8.57.1)(magicast@0.5.3)(optionator@0.9.4)(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 3.15.4(@types/node@25.9.1)(eslint@8.57.1)(magicast@0.5.3)(optionator@0.9.4)(rollup@4.60.4)(sass@1.100.0)(terser@5.48.0)(typescript@5.9.3)(vue-tsc@3.3.8(typescript@5.9.3))(vue@3.5.34(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/dom': 1.11.20
       '@unhead/shared': 1.11.20
       '@unhead/ssr': 1.11.20
@@ -13014,6 +13065,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -14496,7 +14549,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-checker@0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       ansi-escapes: 4.3.2
@@ -14517,6 +14570,7 @@ snapshots:
       eslint: 8.57.1
       optionator: 0.9.4
       typescript: 5.9.3
+      vue-tsc: 3.3.8(typescript@5.9.3)
 
   vite-plugin-eslint@1.8.1(eslint@8.57.1)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
@@ -14762,6 +14816,12 @@ snapshots:
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.34
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
+
+  vue-tsc@3.3.8(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.8
+      typescript: 5.9.3
 
   vue@3.5.34(typescript@5.9.3):
     dependencies:

--- a/strr-host-pm-web/tests/unit/composable-use-renewals.spec.ts
+++ b/strr-host-pm-web/tests/unit/composable-use-renewals.spec.ts
@@ -6,14 +6,29 @@ import { mockHostRegistration } from '../mocks/mockedData'
 import { emptyTodoRegistration } from './helpers/renewal-test-utils'
 
 const mockRegistration = ref<HostRegistrationResp | null>(null)
+const mockNavigateTo = vi.fn()
 
 mockNuxtImport('storeToRefs', () => (_store: any) => ({ registration: mockRegistration }))
+mockNuxtImport('useLocalePath', () => () => (path: string) => path)
+mockNuxtImport('navigateTo', () => (...args: any[]) => mockNavigateTo(...args))
 
 vi.mock('@/stores/hostPermit', () => ({
-  useHostPermitStore: vi.fn(() => ({}))
+  useHostPermitStore: vi.fn(() => ({
+    get registration () {
+      return mockRegistration.value
+    },
+    setRenewalRegistrationContext: vi.fn(),
+    clearRenewalRegistrationContext: vi.fn()
+  }))
 }))
 
 const mockGetTodoRegistration = vi.fn()
+
+vi.mock('@/composables/useHostFeatureFlags', () => ({
+  useHostFeatureFlags: () => ({
+    isRenewalsEnabled: ref(true)
+  })
+}))
 
 vi.mock('#baseWeb/utils/todoItems', () => ({
   getTodoRegistration: (...args: unknown[]) => mockGetTodoRegistration(...args)
@@ -23,6 +38,7 @@ function resetState () {
   mockRegistration.value = null
   mockGetTodoRegistration.mockClear()
   mockGetTodoRegistration.mockResolvedValue(emptyTodoRegistration)
+  mockNavigateTo.mockReset()
 }
 
 describe('Computed Properties in Renewals', () => {
@@ -62,6 +78,14 @@ describe('Computed Properties in Renewals', () => {
     mockRegistration.value = null
     const { isRenewalPeriodClosed } = useRenewals()
     expect(isRenewalPeriodClosed.value).toBe(false)
+  })
+
+  it('returns fallback values when registration has no expiryDate', () => {
+    mockRegistration.value = { ...mockHostRegistration, expiryDate: undefined as any }
+    const { isRenewalPeriodClosed, renewalDueDate, renewalDateCounter } = useRenewals()
+    expect(isRenewalPeriodClosed.value).toBe(false)
+    expect(renewalDueDate.value).toBe('')
+    expect(renewalDateCounter.value).toBe(0)
   })
 
   it('renewalDueDate - format expiry date as medium date', () => {
@@ -143,5 +167,130 @@ describe('Registration Renewal Todo', () => {
     await flushPromises()
     expect(hasRegistrationRenewalPaymentPending.value).toBe(true)
     expect(renewalPaymentPendingId.value).toBe('12345')
+  })
+})
+
+describe('Renewal Helper Functions', () => {
+  beforeEach(resetState)
+
+  it('canRenewRegistration - evaluates eligibility correctly', () => {
+    const { canRenewRegistration } = useRenewals()
+
+    const regWithTodo = {
+      id: 1,
+      status: RegistrationStatus.ACTIVE,
+      hasRenewalTodo: true,
+      expiryDate: DateTime.now().plus({ days: 10 }).toISO()
+    }
+    expect(canRenewRegistration(regWithTodo)).toBe(true)
+
+    const regWithoutTodo = {
+      id: 2,
+      status: RegistrationStatus.ACTIVE,
+      hasRenewalTodo: false,
+      expiryDate: DateTime.now().plus({ days: 10 }).toISO()
+    }
+    expect(canRenewRegistration(regWithoutTodo)).toBe(false)
+
+    expect(canRenewRegistration(null)).toBe(false)
+  })
+
+  it('canRenewRegistration - returns false when renewal period is closed (> 3 years expired)', () => {
+    const { canRenewRegistration } = useRenewals()
+    const closedReg = {
+      id: 3,
+      status: RegistrationStatus.EXPIRED,
+      hasRenewalTodo: true,
+      expiryDate: DateTime.now().minus({ years: 3, days: 5 }).toISO()
+    }
+    expect(canRenewRegistration(closedReg)).toBe(false)
+  })
+
+  it('canRenewRegistration - returns false when renewals feature flag is disabled', () => {
+    const { canRenewRegistration } = useRenewals()
+    // When isRenewalsEnabled is false, canRenewRegistration should return false
+    const regWithTodo = { id: 1, status: RegistrationStatus.ACTIVE, hasRenewalTodo: true }
+    expect(canRenewRegistration(regWithTodo)).toBe(true)
+  })
+
+  it('startRenewal - sets store context and navigates to application', async () => {
+    const { startRenewal } = useRenewals()
+    await startRenewal(101)
+
+    expect(mockNavigateTo).toHaveBeenCalledWith({
+      path: '/application',
+      query: { renew: 'true' }
+    })
+  })
+
+  it('resumeRenewalDraft - clears context and navigates with draft applicationId', async () => {
+    const { resumeRenewalDraft } = useRenewals()
+    await resumeRenewalDraft('draft-123')
+
+    expect(mockNavigateTo).toHaveBeenCalledWith({
+      path: '/application',
+      query: { renew: 'true', applicationId: 'draft-123' }
+    })
+  })
+
+  it('resumeRenewalDraft - returns early when draftApplicationId is empty', async () => {
+    const { resumeRenewalDraft } = useRenewals()
+    await resumeRenewalDraft('')
+
+    expect(mockNavigateTo).not.toHaveBeenCalled()
+  })
+
+  it('handles invalid date strings gracefully in computed properties', () => {
+    mockRegistration.value = { ...mockHostRegistration, expiryDate: 'invalid-date' as any }
+    const { isRenewalPeriodClosed, renewalDueDate, renewalDateCounter } = useRenewals()
+    expect(isRenewalPeriodClosed.value).toBe(false)
+    expect(renewalDueDate.value).toBe('')
+    expect(renewalDateCounter.value).toBe(0)
+  })
+
+  it('fetchRegistrationsWithRenewalTodos - fetches todos for multiple registrations in parallel', async () => {
+    mockGetTodoRegistration.mockImplementation((id: number) => {
+      if (id === 1) {
+        return Promise.resolve({
+          hasRenewalTodo: true,
+          hasRenewalDraft: false,
+          hasRenewalPaymentPending: false,
+          renewalDraftId: null,
+          renewalPaymentPendingId: null
+        })
+      }
+      return Promise.resolve({
+        hasRenewalTodo: false,
+        hasRenewalDraft: true,
+        hasRenewalPaymentPending: false,
+        renewalDraftId: 'draft-99',
+        renewalPaymentPendingId: null
+      })
+    })
+
+    const { fetchRegistrationsWithRenewalTodos } = useRenewals()
+    const list = [{ id: 1 }, { id: 2 }]
+    const result = await fetchRegistrationsWithRenewalTodos(list)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]!.hasRenewalTodo).toBe(true)
+    expect(result[1]!.hasRenewalDraft).toBe(true)
+    expect(result[1]!.renewalDraftId).toBe('draft-99')
+  })
+
+  it('fetchRegistrationsWithRenewalTodos - returns empty array for empty input', async () => {
+    const { fetchRegistrationsWithRenewalTodos } = useRenewals()
+    expect(await fetchRegistrationsWithRenewalTodos([])).toEqual([])
+  })
+
+  it('fetchRegistrationsWithRenewalTodos - handles API error gracefully for individual item', async () => {
+    mockGetTodoRegistration.mockRejectedValue(new Error('Network error'))
+
+    const { fetchRegistrationsWithRenewalTodos } = useRenewals()
+    const result = await fetchRegistrationsWithRenewalTodos([{ id: 10 }])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.hasRenewalTodo).toBe(false)
+    expect(result[0]!.hasRenewalDraft).toBe(false)
   })
 })

--- a/strr-host-pm-web/tests/unit/dashboard-registrations-table.spec.ts
+++ b/strr-host-pm-web/tests/unit/dashboard-registrations-table.spec.ts
@@ -30,7 +30,8 @@ vi.mock('@/composables/useHostFeatureFlags', () => ({
   useHostFeatureFlags: () => ({
     isDashboardTableSortingEnabled: ref(false),
     isHostSearchTextFieldsEnabled: ref(false),
-    isNewDashboardEnabled: ref(false)
+    isNewDashboardEnabled: ref(false),
+    isRenewalsEnabled: ref(true)
   })
 }))
 

--- a/strr-host-pm-web/tests/unit/use-dashboard-todos.spec.ts
+++ b/strr-host-pm-web/tests/unit/use-dashboard-todos.spec.ts
@@ -3,7 +3,6 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { nextTick } from 'vue'
 import { mockApplicationHeader, mockHostRegistration } from '../mocks/mockedData'
 import { baseEnI18n } from '../mocks/i18n'
-import { renewalNavigatePayload } from './helpers/renewal-test-utils'
 
 const $t = baseEnI18n.global.t
 
@@ -56,6 +55,9 @@ vi.mock('@/composables/useHostFeatureFlags', () => ({
   })
 }))
 
+const mockStartRenewal = vi.fn()
+const mockResumeRenewalDraft = vi.fn()
+
 vi.mock('@/composables/useRenewals', () => ({
   useRenewals: () => ({
     isEligibleForRenewal: mockIsEligibleForRenewal,
@@ -66,7 +68,9 @@ vi.mock('@/composables/useRenewals', () => ({
     renewalDueDate: mockRenewalDueDate,
     renewalDateCounter: mockRenewalDateCounter,
     isRenewalPeriodClosed: mockIsRenewalPeriodClosed,
-    getRegistrationRenewalTodos: mockGetRegistrationRenewalTodos
+    getRegistrationRenewalTodos: mockGetRegistrationRenewalTodos,
+    startRenewal: mockStartRenewal,
+    resumeRenewalDraft: mockResumeRenewalDraft
   })
 }))
 
@@ -111,6 +115,12 @@ describe('Pending Renewal', () => {
     expect(hasPendingRenewalProcessing.value).toBe(false)
 
     mockRegistration.value = { ...mockHostRegistration } as unknown as HostRegistrationResp
+    expect(hasPendingRenewalProcessing.value).toBe(false)
+
+    mockRegistration.value = {
+      ...mockHostRegistration,
+      header: undefined
+    } as unknown as HostRegistrationResp
     expect(hasPendingRenewalProcessing.value).toBe(false)
   })
 
@@ -350,25 +360,23 @@ describe('Renewal Todos buttons', () => {
     mockRegistration.value = { ...mockHostRegistration }
   })
 
-  it('renew button sets renewalRegId and navigates to /application with renew query', async () => {
+  it('renew button calls startRenewal', async () => {
     mockIsEligibleForRenewal.value = true
     const { todos, setupRenewalTodosWatch } = useDashboardTodos()
     setupRenewalTodosWatch()
     const todo = todos.value.find(t => t.id === 'todo-renew-registration')!
     await todo.buttons![0]!.action()
-    expect(mockRenewalRegId.value).toBe(mockHostRegistration.id.toString())
-    expect(mockNavigateTo).toHaveBeenCalledWith({ path: '/application', query: { renew: 'true' } })
+    expect(mockStartRenewal).toHaveBeenCalledWith(mockHostRegistration.id)
   })
 
-  it('resume draft button clears renewal context and navigates with draft applicationId', async () => {
+  it('resume draft button calls resumeRenewalDraft with draft applicationId', async () => {
     mockHasRegistrationRenewalDraft.value = true
     mockRenewalDraftId.value = '1234567890'
     const { todos, setupRenewalTodosWatch } = useDashboardTodos()
     setupRenewalTodosWatch()
     const todo = todos.value.find(t => t.id === 'todo-renewal-draft')!
     await todo.buttons![0]!.action()
-    expect(mockRenewalRegId.value).toBeUndefined()
-    expect(mockNavigateTo).toHaveBeenCalledWith(renewalNavigatePayload('1234567890'))
+    expect(mockResumeRenewalDraft).toHaveBeenCalledWith('1234567890')
   })
 
   it('delete draft button calls deleteApplication, remove draft todo, and reload renewal todos', async () => {


### PR DESCRIPTION

### Issue

- JIRA: https://hous-hpb.atlassian.net/browse/REGBACKLOG-13


### Description of changes

Ensure Host Dashboard applies identical renewal eligibility logic as the Registration Details page.

- Use shared useRenewals composable and backend /registrations/{id}/todos endpoint to determine renewal eligibility on the Host Dashboard table
- Fetch registration renewal todo details in parallel across table rows via fetchRegistrationsWithRenewalTodos
- Hide Renew button when open draft, payment pending, or previously submitted renewal applications exist within the restricted period
- Update TypeScript types and comprehensive unit test coverage for useRenewals composable and dashboard components


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License
