### PR TITLE
fix(strr-api): map secondary contact mailing address correctly in registration creation

### DIFF
--- a/strr-api/src/strr_api/services/registration_service.py
+++ b/strr-api/src/strr_api/services/registration_service.py
@@ -524,13 +524,15 @@ class RegistrationService:
                 social_insurance_number=registration_request.secondaryContact.socialInsuranceNumber,
                 business_number=registration_request.secondaryContact.businessNumber,
                 address=Address(
-                    country=registration_request.primaryContact.mailingAddress.country,
-                    street_address=registration_request.primaryContact.mailingAddress.address,
-                    street_address_additional=registration_request.primaryContact.mailingAddress.addressLineTwo,
-                    city=registration_request.primaryContact.mailingAddress.city,
-                    province=registration_request.primaryContact.mailingAddress.province,
-                    postal_code=registration_request.primaryContact.mailingAddress.postalCode,
-                ),
+                    country=registration_request.secondaryContact.mailingAddress.country,
+                    street_address=registration_request.secondaryContact.mailingAddress.address,
+                    street_address_additional=registration_request.secondaryContact.mailingAddress.addressLineTwo,
+                    city=registration_request.secondaryContact.mailingAddress.city,
+                    province=registration_request.secondaryContact.mailingAddress.province,
+                    postal_code=registration_request.secondaryContact.mailingAddress.postalCode,
+                )
+                if registration_request.secondaryContact.mailingAddress
+                else None,
             )
             rental_property.contacts.append(secondary_property_contact)
 

--- a/strr-api/tests/unit/services/test_registration_service.py
+++ b/strr-api/tests/unit/services/test_registration_service.py
@@ -193,3 +193,75 @@ def test_update_registration_empty_registration_json(session):
     change = details["changes"][0]
     assert change["oldValue"] is None
     assert change["newValue"] == "new@example.com"
+
+
+def test_create_host_registration_with_cohost_address(session):
+    """Test creating host registration with co-host (secondaryContact) having a unique mailing address."""
+    payload = {
+        "registration": {
+            "registrationType": "HOST",
+            "primaryContact": {
+                "contactType": "INDIVIDUAL",
+                "firstName": "Primary",
+                "lastName": "Host",
+                "emailAddress": "primary@example.com",
+                "mailingAddress": {
+                    "country": "CA",
+                    "address": "100 Primary St",
+                    "addressLineTwo": "",
+                    "city": "Vancouver",
+                    "province": "BC",
+                    "postalCode": "V6B 1A1",
+                },
+            },
+            "secondaryContact": {
+                "contactType": "INDIVIDUAL",
+                "firstName": "Secondary",
+                "lastName": "Cohost",
+                "emailAddress": "cohost@example.com",
+                "mailingAddress": {
+                    "country": "CA",
+                    "address": "200 Cohost Ave",
+                    "addressLineTwo": "Suite 5",
+                    "city": "Victoria",
+                    "province": "BC",
+                    "postalCode": "V8V 2B2",
+                },
+            },
+            "unitAddress": {
+                "nickname": "Rental Property",
+                "country": "CA",
+                "unitNumber": "",
+                "streetNumber": "300",
+                "streetName": "Rental St",
+                "city": "Victoria",
+                "province": "BC",
+                "postalCode": "V8V 3C3",
+            },
+            "unitDetails": {
+                "parcelIdentifier": "000-111-222",
+                "businessLicense": "12345",
+                "propertyType": "SINGLE_FAMILY_HOME",
+                "ownershipType": "OWN",
+                "rentalUnitSetupOption": "WHOLE_PRINCIPAL_RESIDENCE",
+                "hostResidence": "SAME_UNIT",
+                "isUnitOnPrincipalResidenceProperty": True,
+                "numberOfRoomsForRent": 1,
+            },
+            "listingDetails": [{"url": "https://www.airbnb.ca/rooms/12345"}],
+        }
+    }
+
+    rental_property = RegistrationService._create_host_registration(payload)
+    assert len(rental_property.contacts) == 2
+
+    primary_pc = next(c for c in rental_property.contacts if c.is_primary)
+    secondary_pc = next(c for c in rental_property.contacts if not c.is_primary)
+
+    assert primary_pc.contact.address.street_address == "100 Primary St"
+    assert primary_pc.contact.address.city == "Vancouver"
+
+    assert secondary_pc.contact.address.street_address == "200 Cohost Ave"
+    assert secondary_pc.contact.address.street_address_additional == "Suite 5"
+    assert secondary_pc.contact.address.city == "Victoria"
+    assert secondary_pc.contact.address.postal_code == "V8V 2B2"


### PR DESCRIPTION
*Issue:*

- JIRA: https://hous-hpb.atlassian.net/browse/REGBACKLOG-342

*Description of changes:*

- **Fixed bug:**
    - **Previous**: during application approval (initla or renewal), the registration was created/updated with the primary host mailing address as the address for co-host.
    - **Fix**: Map secondary contact mailing address correctly during registration creation

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BC Registry and Digital Services BSD 3-Clause License